### PR TITLE
Fix: Reset customer form when editing a new customer

### DIFF
--- a/apps/core-web/src/components/customers/CustomerDialog.tsx
+++ b/apps/core-web/src/components/customers/CustomerDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import {
@@ -66,6 +66,26 @@ export function CustomerDialog({ customer, trigger, open: controlledOpen, onOpen
             toast.error('Failed to save customer')
         }
     }
+
+    useEffect(() => {
+        if (customer) {
+            form.reset(customer)
+        } else {
+            form.reset({
+                type: 'PRIVATE',
+                first_name: '',
+                last_name: '',
+                company_name: '',
+                email: '',
+                phone: '',
+                vat_id: '',
+                address_street: '',
+                address_city: '',
+                address_zip: '',
+                address_country: 'AT',
+            })
+        }
+    }, [customer, form])
 
     const handleOpenChange = (newOpen: boolean) => {
         setOpen(newOpen)

--- a/apps/core-web/src/components/customers/CustomerDialog.tsx
+++ b/apps/core-web/src/components/customers/CustomerDialog.tsx
@@ -29,6 +29,20 @@ interface CustomerDialogProps {
     onOpenChange?: (open: boolean) => void
 }
 
+const DEFAULT_CUSTOMER: Partial<Customer> = {
+    type: 'PRIVATE',
+    first_name: '',
+    last_name: '',
+    company_name: '',
+    email: '',
+    phone: '',
+    vat_id: '',
+    address_street: '',
+    address_city: '',
+    address_zip: '',
+    address_country: 'AT',
+}
+
 export function CustomerDialog({ customer, trigger, open: controlledOpen, onOpenChange }: CustomerDialogProps) {
     const [open, setOpen] = useState(false)
     const isEdit = !!customer
@@ -36,19 +50,7 @@ export function CustomerDialog({ customer, trigger, open: controlledOpen, onOpen
     const updateMutation = useUpdateCustomer()
 
     const form = useForm<Partial<Customer>>({
-        defaultValues: customer || {
-            type: 'PRIVATE',
-            first_name: '',
-            last_name: '',
-            company_name: '',
-            email: '',
-            phone: '',
-            vat_id: '',
-            address_street: '',
-            address_city: '',
-            address_zip: '',
-            address_country: 'AT',
-        },
+        defaultValues: customer || DEFAULT_CUSTOMER,
     })
 
     const onSubmit = async (data: Partial<Customer>) => {
@@ -71,19 +73,7 @@ export function CustomerDialog({ customer, trigger, open: controlledOpen, onOpen
         if (customer) {
             form.reset(customer)
         } else {
-            form.reset({
-                type: 'PRIVATE',
-                first_name: '',
-                last_name: '',
-                company_name: '',
-                email: '',
-                phone: '',
-                vat_id: '',
-                address_street: '',
-                address_city: '',
-                address_zip: '',
-                address_country: 'AT',
-            })
+            form.reset(DEFAULT_CUSTOMER)
         }
     }, [customer, form])
 

--- a/core-api.log
+++ b/core-api.log
@@ -1,0 +1,5 @@
+
+> core-api@0.0.1 start
+> nest start
+
+sh: 1: nest: not found

--- a/core-web.log
+++ b/core-web.log
@@ -1,0 +1,5 @@
+
+> core-web@0.0.0 dev
+> vite
+
+sh: 1: vite: not found


### PR DESCRIPTION
The `CustomerDialog` form was not resetting its values when the `customer` prop changed, causing the form to remain empty or show stale data when opening the edit dialog for different customers.

This change adds a `useEffect` hook that watches for changes to the `customer` prop and resets the form with the new customer data (or default values if creating a new customer).

- Added `useEffect` to `CustomerDialog.tsx`
- Resets form values on `customer` prop change
- Ensures correct data is displayed when editing customers

---
*PR created automatically by Jules for task [14910482296813365507](https://jules.google.com/task/14910482296813365507) started by @vandean25*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed customer form to properly synchronize when switching between different customers or viewing customer details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->