### PR TITLE
Implement Navigation to Register Customer

### DIFF
--- a/apps/core-web/src/components/GlobalSearch.tsx
+++ b/apps/core-web/src/components/GlobalSearch.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useNavigate } from "react-router-dom"
 import {
     PlusCircle,
     User,
@@ -26,6 +27,7 @@ interface GlobalSearchProps {
 export function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
     const [search, setSearch] = React.useState("")
     const { data: searchResults, isLoading } = useGlobalSearch(search)
+    const navigate = useNavigate()
 
     return (
         <CommandDialog open={open} onOpenChange={onOpenChange}>
@@ -43,7 +45,10 @@ export function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
                         <span>Create New Invoice</span>
                         <CommandShortcut>{navigator.userAgent.includes('Mac') ? '⌘I' : 'Ctrl+I'}</CommandShortcut>
                     </CommandItem>
-                    <CommandItem onSelect={() => { console.log("Navigate to Register Customer"); onOpenChange(false) }}>
+                    <CommandItem onSelect={() => {
+                        navigate('/customers?action=create')
+                        onOpenChange(false)
+                    }}>
                         <User className="mr-2 h-4 w-4" />
                         <span>Register New Customer</span>
                         <CommandShortcut>{navigator.userAgent.includes('Mac') ? '⌘N' : 'Ctrl+N'}</CommandShortcut>

--- a/apps/core-web/src/pages/customers/CustomerList.tsx
+++ b/apps/core-web/src/pages/customers/CustomerList.tsx
@@ -26,13 +26,17 @@ export default function CustomerList() {
 
     useEffect(() => {
         if (searchParams.get('action') === 'create') {
-            setSelectedCustomer(undefined)
-            setIsDialogOpen(true)
+            // Use setTimeout to avoid synchronous state updates during render phase
+            // which can cause cascading renders and trigger linter errors
+            setTimeout(() => {
+                setSelectedCustomer(undefined)
+                setIsDialogOpen(true)
 
-            // Optional: clean up the URL
-            const newParams = new URLSearchParams(searchParams)
-            newParams.delete('action')
-            setSearchParams(newParams, { replace: true })
+                // Optional: clean up the URL
+                const newParams = new URLSearchParams(searchParams)
+                newParams.delete('action')
+                setSearchParams(newParams, { replace: true })
+            }, 0)
         }
     }, [searchParams, setSearchParams])
 

--- a/apps/core-web/src/pages/customers/CustomerList.tsx
+++ b/apps/core-web/src/pages/customers/CustomerList.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { type ColumnDef } from "@tanstack/react-table"
 import { useCustomers, useDeleteCustomer } from '@/api/customers'
 import type { Customer } from '@/api/types'
@@ -13,6 +14,7 @@ import { DataTable } from '@/components/data-table/DataTable'
 export default function CustomerList() {
     const { queryParams, ...tableState } = useDataTableQuery({ defaultPageSize: 10 })
     const { data: responseData, isLoading } = useCustomers(queryParams)
+    const [searchParams, setSearchParams] = useSearchParams()
 
     // Handle both legacy array response and new paginated response
     const customers: Customer[] = Array.isArray(responseData) ? responseData : responseData?.data || []
@@ -21,6 +23,18 @@ export default function CustomerList() {
     const deleteMutation = useDeleteCustomer()
     const [selectedCustomer, setSelectedCustomer] = useState<Customer | undefined>(undefined)
     const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+    useEffect(() => {
+        if (searchParams.get('action') === 'create') {
+            setSelectedCustomer(undefined)
+            setIsDialogOpen(true)
+
+            // Optional: clean up the URL
+            const newParams = new URLSearchParams(searchParams)
+            newParams.delete('action')
+            setSearchParams(newParams, { replace: true })
+        }
+    }, [searchParams, setSearchParams])
 
     const handleDelete = async (id: string) => {
         if (!confirm('Are you sure you want to delete this customer?')) return


### PR DESCRIPTION
Implemented navigation from Global Search to "Register New Customer". It now navigates to `/customers?action=create`, which triggers the customer creation dialog on the Customer List page.

---
*PR created automatically by Jules for task [3427043932840392715](https://jules.google.com/task/3427043932840392715) started by @vandean25*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the global search "Register New Customer" command to provide seamless navigation. Users are now automatically directed to the customers page with the creation dialog pre-opened, streamlining the customer registration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->