### PR TITLE
query/pagination cleanup across API + web

### DIFF
--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -75,7 +75,7 @@
             }
           },
           {
-            "name": "limit",
+            "name": "pageSize",
             "required": false,
             "in": "query",
             "schema": {
@@ -1222,15 +1222,6 @@
           },
           {
             "name": "pageSize",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          },
-          {
-            "name": "limit",
             "required": false,
             "in": "query",
             "schema": {

--- a/apps/core-api/src/customer/customer.controller.ts
+++ b/apps/core-api/src/customer/customer.controller.ts
@@ -39,9 +39,16 @@ export class CustomerController {
     @Query('sortDirection') sortDirection?: 'asc' | 'desc',
   ) {
     const queryParams: any = {};
+    const parsedPage = page ? parseInt(page, 10) : NaN;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : NaN;
+
     if (search) queryParams.search = search;
-    if (page) queryParams.page = parseInt(page, 10);
-    if (pageSize) queryParams.pageSize = parseInt(pageSize, 10);
+    if (Number.isFinite(parsedPage) && parsedPage > 0) {
+      queryParams.page = parsedPage;
+    }
+    if (Number.isFinite(parsedPageSize) && parsedPageSize > 0) {
+      queryParams.pageSize = parsedPageSize;
+    }
     if (sortField) {
       queryParams.sorting = [
         {

--- a/apps/core-api/src/inventory/inventory.controller.spec.ts
+++ b/apps/core-api/src/inventory/inventory.controller.spec.ts
@@ -45,20 +45,24 @@ describe('InventoryController', () => {
       expect(result).toBe(mockResult);
       expect(service.findAll).toHaveBeenCalledWith({
         page: 2,
-        limit: 20,
+        pageSize: 20,
         search: 'test',
         location: 'location',
+        brand: undefined,
+        brandId: undefined,
       });
     });
 
-    it('should use default values for page and limit', async () => {
+    it('should use default values for page and pageSize', async () => {
       await controller.findAll();
 
       expect(service.findAll).toHaveBeenCalledWith({
         page: 1,
-        limit: 10,
+        pageSize: 10,
         search: undefined,
         location: undefined,
+        brand: undefined,
+        brandId: undefined,
       });
     });
   });

--- a/apps/core-api/src/inventory/inventory.controller.ts
+++ b/apps/core-api/src/inventory/inventory.controller.ts
@@ -32,26 +32,36 @@ export class InventoryController {
 
   @Get()
   @ApiQuery({ name: 'page', required: false, schema: { type: 'integer', minimum: 1 } })
-  @ApiQuery({ name: 'limit', required: false, schema: { type: 'integer', minimum: 1 } })
+  @ApiQuery({ name: 'pageSize', required: false, schema: { type: 'integer', minimum: 1 } })
   @ApiQuery({ name: 'search', required: false, schema: { type: 'string' } })
   @ApiQuery({ name: 'location', required: false, schema: { type: 'string' } })
   @ApiQuery({ name: 'brand', required: false, schema: { type: 'string' } })
   @ApiQuery({ name: 'brandId', required: false, schema: { type: 'integer', minimum: 1 } })
   async findAll(
     @Query('page') page?: string,
-    @Query('limit') limit?: string,
+    @Query('pageSize') pageSize?: string,
     @Query('search') search?: string,
     @Query('location') location?: string,
     @Query('brand') brand?: string,
     @Query('brandId') brandId?: string,
   ) {
+    const parsedPage = page ? parseInt(page, 10) : NaN;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : NaN;
+    const parsedBrandId = brandId ? parseInt(brandId, 10) : NaN;
+
     return await this.inventoryService.findAll({
-      page: page ? parseInt(page, 10) : 1,
-      limit: limit ? parseInt(limit, 10) : 10,
+      page: Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
+      pageSize:
+        Number.isFinite(parsedPageSize) && parsedPageSize > 0
+          ? parsedPageSize
+          : 10,
       search,
       location,
       brand,
-      brandId: brandId ? parseInt(brandId, 10) : undefined,
+      brandId:
+        Number.isFinite(parsedBrandId) && parsedBrandId > 0
+          ? parsedBrandId
+          : undefined,
     });
   }
 

--- a/apps/core-api/src/inventory/inventory.service.ts
+++ b/apps/core-api/src/inventory/inventory.service.ts
@@ -97,8 +97,17 @@ export class InventoryService {
       ]);
     } else {
       // Legacy path
-      const { page = 1, limit = 10, search, location, brand, brandId } = params;
-      const skip = (page - 1) * limit;
+      const {
+        page = 1,
+        pageSize,
+        limit = 10,
+        search,
+        location,
+        brand,
+        brandId,
+      } = params;
+      const effectivePageSize = pageSize ?? limit;
+      const skip = (page - 1) * effectivePageSize;
       const where: any = {};
 
       if (search) {
@@ -136,14 +145,16 @@ export class InventoryService {
             },
           },
           skip,
-          take: limit,
+          take: effectivePageSize,
         }),
         this.prisma.catalogItem.count({ where }),
       ]);
     }
 
     // Common transformation logic
-    const last_page = Math.ceil(total / (params.take || params.limit || 10));
+    const last_page = Math.ceil(
+      total / (params.take || params.pageSize || params.limit || 10),
+    );
 
     // Transform items to match frontend expected shape
     const transformedItems = items.map((item) => {

--- a/apps/core-api/src/purchase/purchase.controller.ts
+++ b/apps/core-api/src/purchase/purchase.controller.ts
@@ -61,9 +61,16 @@ export class PurchaseController {
     @Query('sortDirection') sortDirection?: 'asc' | 'desc',
   ) {
     const queryParams: any = {};
+    const parsedPage = page ? parseInt(page, 10) : NaN;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : NaN;
+
     if (search) queryParams.search = search;
-    if (page) queryParams.page = parseInt(page, 10);
-    if (pageSize) queryParams.pageSize = parseInt(pageSize, 10);
+    if (Number.isFinite(parsedPage) && parsedPage > 0) {
+      queryParams.page = parsedPage;
+    }
+    if (Number.isFinite(parsedPageSize) && parsedPageSize > 0) {
+      queryParams.pageSize = parsedPageSize;
+    }
     if (sortField) {
       queryParams.sorting = [
         {

--- a/apps/core-api/src/sales/sales-order/sales-order.controller.ts
+++ b/apps/core-api/src/sales/sales-order/sales-order.controller.ts
@@ -29,22 +29,26 @@ export class SalesOrderController {
   @ApiQuery({ name: 'search', required: false, schema: { type: 'string' } })
   @ApiQuery({ name: 'page', required: false, schema: { type: 'integer', minimum: 1 } })
   @ApiQuery({ name: 'pageSize', required: false, schema: { type: 'integer', minimum: 1 } })
-  @ApiQuery({ name: 'limit', required: false, schema: { type: 'integer', minimum: 1 } })
   @ApiQuery({ name: 'sortField', required: false, schema: { type: 'string' } })
   @ApiQuery({ name: 'sortDirection', required: false, schema: { type: 'string', enum: ['asc', 'desc'] } })
   async findAll(
     @Query('status') status?: SalesOrderStatus,
     @Query('page') page?: string,
     @Query('pageSize') pageSize?: string,
-    @Query('limit') limit?: string,
     @Query('search') search?: string,
     @Query('sortField') sortField?: string,
     @Query('sortDirection') sortDirection?: 'asc' | 'desc',
   ) {
     const queryParams: any = {};
-    if (page) queryParams.page = parseInt(page, 10);
-    if (pageSize) queryParams.pageSize = parseInt(pageSize, 10);
-    else if (limit) queryParams.pageSize = parseInt(limit, 10);
+    const parsedPage = page ? parseInt(page, 10) : NaN;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : NaN;
+
+    if (Number.isFinite(parsedPage) && parsedPage > 0) {
+      queryParams.page = parsedPage;
+    }
+    if (Number.isFinite(parsedPageSize) && parsedPageSize > 0) {
+      queryParams.pageSize = parsedPageSize;
+    }
     if (search) queryParams.search = search;
     if (sortField) {
       queryParams.sorting = [

--- a/apps/core-api/src/vendor/vendor.controller.ts
+++ b/apps/core-api/src/vendor/vendor.controller.ts
@@ -36,9 +36,16 @@ export class VendorController {
     @Query('sortDirection') sortDirection?: 'asc' | 'desc',
   ) {
     const queryParams: any = {};
+    const parsedPage = page ? parseInt(page, 10) : NaN;
+    const parsedPageSize = pageSize ? parseInt(pageSize, 10) : NaN;
+
     if (search) queryParams.search = search;
-    if (page) queryParams.page = parseInt(page, 10);
-    if (pageSize) queryParams.pageSize = parseInt(pageSize, 10);
+    if (Number.isFinite(parsedPage) && parsedPage > 0) {
+      queryParams.page = parsedPage;
+    }
+    if (Number.isFinite(parsedPageSize) && parsedPageSize > 0) {
+      queryParams.pageSize = parsedPageSize;
+    }
     if (sortField) {
       queryParams.sorting = [
         {

--- a/apps/core-web/src/api/data-table-query.ts
+++ b/apps/core-web/src/api/data-table-query.ts
@@ -29,7 +29,10 @@ export function buildDataTableUrl(
   const searchFallback = options.searchFallbackFilterFields
     ?.map((field) => queryParams.filters.find((f) => f.field === field)?.value)
     .find(Boolean)
-  const search = queryParams.search ?? searchFallback
+  const search =
+    typeof queryParams.search === 'string' && queryParams.search.trim() !== ''
+      ? queryParams.search
+      : searchFallback
   if (search) {
     params.append('search', search)
   }

--- a/apps/core-web/src/api/data-table-query.ts
+++ b/apps/core-web/src/api/data-table-query.ts
@@ -1,0 +1,47 @@
+import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
+
+interface BuildDataTableUrlOptions {
+  sortFieldMap?: Record<string, string>
+  searchFallbackFilterFields?: string[]
+  exactFilterMap?: Record<string, string>
+}
+
+export function buildDataTableUrl(
+  baseUrl: string,
+  queryParams?: DataTableQueryParams,
+  options: BuildDataTableUrlOptions = {},
+) {
+  if (!queryParams) return baseUrl
+
+  const params = new URLSearchParams()
+  params.append('page', String(queryParams.page))
+  params.append('pageSize', String(queryParams.pageSize))
+
+  if (queryParams.sortDirection) {
+    params.append('sortDirection', queryParams.sortDirection)
+  }
+  if (queryParams.sortField) {
+    const mappedSortField =
+      options.sortFieldMap?.[queryParams.sortField] ?? queryParams.sortField
+    params.append('sortField', mappedSortField)
+  }
+
+  const searchFallback = options.searchFallbackFilterFields
+    ?.map((field) => queryParams.filters.find((f) => f.field === field)?.value)
+    .find(Boolean)
+  const search = queryParams.search ?? searchFallback
+  if (search) {
+    params.append('search', search)
+  }
+
+  if (options.exactFilterMap) {
+    for (const [field, queryName] of Object.entries(options.exactFilterMap)) {
+      const value = queryParams.filters.find((f) => f.field === field)?.value
+      if (value) {
+        params.append(queryName, value)
+      }
+    }
+  }
+
+  return `${baseUrl}?${params.toString()}`
+}

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -639,7 +639,7 @@ export interface operations {
         parameters: {
             query?: {
                 page?: number;
-                limit?: number;
+                pageSize?: number;
                 search?: string;
                 location?: string;
                 brand?: string;
@@ -1467,7 +1467,6 @@ export interface operations {
                 status?: "DRAFT" | "CONFIRMED" | "IN_PROGRESS" | "COMPLETED" | "INVOICED";
                 page?: number;
                 pageSize?: number;
-                limit?: number;
                 search?: string;
                 sortField?: string;
                 sortDirection?: "asc" | "desc";

--- a/apps/core-web/src/api/inventory.ts
+++ b/apps/core-web/src/api/inventory.ts
@@ -10,11 +10,11 @@ export const inventoryKeys = {
 
 export function useInventory(params: { page?: number; pageSize?: number; search?: string; brand?: string } = {}) {
     return useQuery<InventoryResponse>({
-        queryKey: [...inventoryKeys.list(params), params.brand],
+        queryKey: [...inventoryKeys.list(params)],
         queryFn: async () => {
             const searchParams = new URLSearchParams()
             if (params.page) searchParams.append('page', params.page.toString())
-            if (params.pageSize) searchParams.append('limit', params.pageSize.toString())
+            if (params.pageSize) searchParams.append('pageSize', params.pageSize.toString())
             if (params.search) searchParams.append('search', params.search)
             if (params.brand) searchParams.append('brand', params.brand)
 

--- a/apps/core-web/src/api/purchase-orders.ts
+++ b/apps/core-web/src/api/purchase-orders.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { PurchaseOrder } from './types'
 import { fetchWithAuth } from './client'
 import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
+import { buildDataTableUrl } from './data-table-query'
 
 const PO_API = '/api/purchase-orders'
 
@@ -9,26 +10,12 @@ export function usePurchaseOrders(queryParams?: DataTableQueryParams) {
     return useQuery<any>({
         queryKey: ['purchase-orders', queryParams],
         queryFn: async () => {
-            let url = PO_API
-            if (queryParams) {
-                const params = new URLSearchParams()
-                params.append('page', String(queryParams.page))
-                params.append('pageSize', String(queryParams.pageSize))
-                if (queryParams.sortDirection) params.append('sortDirection', queryParams.sortDirection)
-                if (queryParams.sortField) {
-                    const sortField = queryParams.sortField === 'vendor' ? 'vendor.name' : queryParams.sortField
-                    params.append('sortField', sortField)
-                }
+            const url = buildDataTableUrl(PO_API, queryParams, {
+                sortFieldMap: { vendor: 'vendor.name' },
+                searchFallbackFilterFields: ['order_number'],
+                exactFilterMap: { status: 'status' },
+            })
 
-                const orderNumberFilter = queryParams.filters.find((f) => f.field === 'order_number')?.value
-                const statusFilter = queryParams.filters.find((f) => f.field === 'status')?.value
-                const search = queryParams.search ?? orderNumberFilter
-                if (search) params.append('search', search)
-                if (statusFilter) params.append('status', statusFilter)
-
-                url += `?${params.toString()}`
-            }
-            
             const res = await fetchWithAuth(url)
             if (!res.ok) throw new Error('Failed to fetch purchase orders')
             return res.json()

--- a/apps/core-web/src/api/sales-orders.ts
+++ b/apps/core-web/src/api/sales-orders.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { SalesOrder } from './types'
 import { fetchWithAuth } from './client'
 import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
+import { buildDataTableUrl } from './data-table-query'
 
 export const salesOrderKeys = {
     all: ['sales-orders'] as const,
@@ -13,25 +14,11 @@ export function useSalesOrders(queryParams?: DataTableQueryParams) {
     return useQuery<any>({
         queryKey: salesOrderKeys.list(queryParams),
         queryFn: async () => {
-            let url = '/api/sales-orders'
-            if (queryParams) {
-                const params = new URLSearchParams()
-                params.append('page', String(queryParams.page))
-                params.append('pageSize', String(queryParams.pageSize))
-                if (queryParams.sortDirection) params.append('sortDirection', queryParams.sortDirection)
-                if (queryParams.sortField) {
-                    const sortField = queryParams.sortField === 'customer' ? 'customer.last_name' : queryParams.sortField
-                    params.append('sortField', sortField)
-                }
-
-                const orderNumberFilter = queryParams.filters.find((f) => f.field === 'order_number')?.value
-                const statusFilter = queryParams.filters.find((f) => f.field === 'status')?.value
-                const search = queryParams.search ?? orderNumberFilter
-                if (search) params.append('search', search)
-                if (statusFilter) params.append('status', statusFilter)
-
-                url += `?${params.toString()}`
-            }
+            const url = buildDataTableUrl('/api/sales-orders', queryParams, {
+                sortFieldMap: { customer: 'customer.last_name' },
+                searchFallbackFilterFields: ['order_number'],
+                exactFilterMap: { status: 'status' },
+            })
             
             const response = await fetchWithAuth(url)
             if (!response.ok) throw new Error('Failed to fetch sales orders')

--- a/apps/core-web/src/api/vendors.ts
+++ b/apps/core-web/src/api/vendors.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { fetchWithAuth } from './client'
 import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
+import { buildDataTableUrl } from './data-table-query'
 
 const VENDORS_API = '/api/vendors'
 
@@ -8,20 +9,9 @@ export function useVendors(queryParams?: DataTableQueryParams) {
     return useQuery<any>({
         queryKey: ['vendors', queryParams],
         queryFn: async () => {
-            let url = VENDORS_API
-            if (queryParams) {
-                const params = new URLSearchParams()
-                params.append('page', String(queryParams.page))
-                params.append('pageSize', String(queryParams.pageSize))
-                if (queryParams.sortField) params.append('sortField', queryParams.sortField)
-                if (queryParams.sortDirection) params.append('sortDirection', queryParams.sortDirection)
-
-                const nameFilter = queryParams.filters.find((f) => f.field === 'name')?.value
-                const search = queryParams.search ?? nameFilter
-                if (search) params.append('search', search)
-
-                url += `?${params.toString()}`
-            }
+            const url = buildDataTableUrl(VENDORS_API, queryParams, {
+                searchFallbackFilterFields: ['name'],
+            })
             const res = await fetchWithAuth(url)
             if (!res.ok) throw new Error('Failed to fetch vendors')
             return res.json()

--- a/apps/core-web/src/components/sales/CustomerSearch.tsx
+++ b/apps/core-web/src/components/sales/CustomerSearch.tsx
@@ -38,7 +38,11 @@ export function CustomerSearch({ value, onChange }: CustomerSearchProps) {
     search: search || undefined,
     filters: [],
   })
-  const customers: Customer[] = Array.isArray(customersResponse) ? customersResponse : customersResponse?.data || []
+  const customers: Customer[] = Array.isArray(customersResponse)
+    ? customersResponse
+    : Array.isArray(customersResponse?.data)
+      ? customersResponse.data
+      : []
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/apps/core-web/src/hooks/useGlobalSearch.ts
+++ b/apps/core-web/src/hooks/useGlobalSearch.ts
@@ -6,6 +6,7 @@ import { fetchWithAuth } from '@/api/client'
 
 export function useGlobalSearch(searchTerm: string) {
     const [debouncedSearch, setDebouncedSearch] = useState(searchTerm)
+    const pageSize = 3
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -16,13 +17,13 @@ export function useGlobalSearch(searchTerm: string) {
     }, [searchTerm])
 
     return useQuery<InventoryResponse>({
-        queryKey: inventoryKeys.list({ search: debouncedSearch, pageSize: 3 }),
+        queryKey: inventoryKeys.list({ search: debouncedSearch, pageSize }),
         queryFn: async () => {
-            if (!debouncedSearch) return { data: [], meta: { total: 0, page: 1, limit: 3, totalPages: 0 } }
+            if (!debouncedSearch) return { data: [], meta: { total: 0, page: 1, limit: pageSize, totalPages: 0 } }
 
             const searchParams = new URLSearchParams()
             searchParams.append('search', debouncedSearch)
-            searchParams.append('limit', '3')
+            searchParams.append('pageSize', String(pageSize))
 
             const response = await fetchWithAuth(`/api/inventory?${searchParams.toString()}`)
             if (!response.ok) {


### PR DESCRIPTION
- Added a new shared frontend helper buildDataTableUrl to centralize table query-string building (pagination, sorting,
    search fallback, exact filters).
  - Refactored purchase-orders, sales-orders, and vendors API hooks to use that helper, reducing duplicated URL param
    logic.
  - Standardized pagination param usage toward pageSize (instead of limit) in inventory-related frontend calls and
    backend inventory controller/service handling.
  - Hardened backend controllers (customer, vendor, purchase, sales-order, inventory) to parse/validate numeric query
    params before applying them (only positive finite values).
  - Updated inventory controller tests to match the new pageSize behavior.
  - Improved CustomerSearch response handling to safely accept only array-shaped data.

  Net effect: more consistent query contract, less duplicated frontend filtering logic, and safer backend query parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized data-table URL builder for consistent pagination, sorting, filtering.
  * Global-search now respects a configurable page size for results.

* **Bug Fixes**
  * Improved pagination validation to ignore invalid or non-positive values.
  * Fixed global search error handling for failed responses.

* **Refactor**
  * Renamed pagination parameter from "limit" to "pageSize" across endpoints and clients.
  * Simplified client cache keys to avoid unstable dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->