### PR TITLE
Add workshop numbering and vendor detail workflows

### DIFF
--- a/apps/core-api/prisma/migrations/20260305212000_add_workshop_order_numbering/migration.sql
+++ b/apps/core-api/prisma/migrations/20260305212000_add_workshop_order_numbering/migration.sql
@@ -1,0 +1,35 @@
+-- AlterTable
+ALTER TABLE "finance_settings"
+ADD COLUMN "next_workshop_order_number" INTEGER NOT NULL DEFAULT 1001,
+ADD COLUMN "workshop_order_prefix" TEXT NOT NULL DEFAULT 'WO-2026-';
+
+-- AlterTable
+ALTER TABLE "workshop_orders" ADD COLUMN "order_number" TEXT;
+
+-- Backfill order numbers for existing rows using year-scoped sequence by createdAt
+WITH numbered AS (
+  SELECT
+    id,
+    'WO-' ||
+    EXTRACT(YEAR FROM "createdAt")::TEXT ||
+    '-' ||
+    LPAD(
+      ROW_NUMBER() OVER (
+        PARTITION BY EXTRACT(YEAR FROM "createdAt")
+        ORDER BY "createdAt", id
+      )::TEXT,
+      4,
+      '0'
+    ) AS order_number
+  FROM "workshop_orders"
+)
+UPDATE "workshop_orders" wo
+SET "order_number" = numbered.order_number
+FROM numbered
+WHERE wo.id = numbered.id;
+
+-- AlterTable
+ALTER TABLE "workshop_orders" ALTER COLUMN "order_number" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workshop_orders_order_number_key" ON "workshop_orders"("order_number");

--- a/apps/core-api/prisma/migrations/20260305212000_add_workshop_order_numbering/migration.sql
+++ b/apps/core-api/prisma/migrations/20260305212000_add_workshop_order_numbering/migration.sql
@@ -1,10 +1,7 @@
 -- AlterTable
 ALTER TABLE "finance_settings"
-ADD COLUMN "next_workshop_order_number" INTEGER NOT NULL DEFAULT 1001,
-ADD COLUMN "workshop_order_prefix" TEXT NOT NULL DEFAULT 'WO-2026-';
-
--- AlterTable
-ALTER TABLE "workshop_orders" ADD COLUMN "order_number" TEXT;
+ADD COLUMN "next_workshop_order_number" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN "workshop_order_prefix" TEXT NOT NULL DEFAULT '';
 
 -- Backfill order numbers for existing rows using year-scoped sequence by createdAt
 WITH numbered AS (

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -36,8 +36,8 @@ model FinanceSettings {
   invoice_prefix          String    @default("RE-2026-")
   next_sales_order_number Int       @default(1001)
   sales_order_prefix      String    @default("SO-2026-")
-  next_workshop_order_number Int    @default(1001)
-  workshop_order_prefix      String @default("WO-2026-")
+  next_workshop_order_number Int    @default(1)
+  workshop_order_prefix      String
   
   updatedAt               DateTime  @updatedAt
 

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -36,6 +36,8 @@ model FinanceSettings {
   invoice_prefix          String    @default("RE-2026-")
   next_sales_order_number Int       @default(1001)
   sales_order_prefix      String    @default("SO-2026-")
+  next_workshop_order_number Int    @default(1001)
+  workshop_order_prefix      String @default("WO-2026-")
   
   updatedAt               DateTime  @updatedAt
 
@@ -449,6 +451,7 @@ enum WorkshopOrderStatus {
 
 model WorkshopOrder {
   id           String              @id @default(uuid())
+  order_number String              @unique
   status       WorkshopOrderStatus @default(INTAKE)
 
   customer_id  String

--- a/apps/core-api/prisma/seed.ts
+++ b/apps/core-api/prisma/seed.ts
@@ -115,6 +115,7 @@ async function main() {
     ]);
 
     // Default Finance Settings
+    const currentYear = new Date().getFullYear();
     await prisma.financeSettings.upsert({
         where: { id: 1 },
         update: {},
@@ -123,7 +124,9 @@ async function main() {
             fiscal_year_start_month: 1,
             lock_date: null,
             next_invoice_number: 1001,
-            invoice_prefix: 'RE-2026-',
+            invoice_prefix: `RE-${currentYear}-`,
+            next_workshop_order_number: 1,
+            workshop_order_prefix: `WO-${currentYear}-`,
         },
     });
 

--- a/apps/core-api/src/finance/finance.service.ts
+++ b/apps/core-api/src/finance/finance.service.ts
@@ -9,6 +9,7 @@ export class FinanceService {
   constructor(private prisma: PrismaService) {}
 
   async getSettings() {
+    const currentYear = new Date().getFullYear();
     return this.prisma.financeSettings.upsert({
       where: { id: 1 },
       update: {},
@@ -17,7 +18,9 @@ export class FinanceService {
         fiscal_year_start_month: 1,
         lock_date: null,
         next_invoice_number: 1001,
-        invoice_prefix: 'RE-2026-',
+        invoice_prefix: `RE-${currentYear}-`,
+        next_workshop_order_number: 1,
+        workshop_order_prefix: `WO-${currentYear}-`,
       },
     });
   }

--- a/apps/core-api/src/vendor/vendor.service.ts
+++ b/apps/core-api/src/vendor/vendor.service.ts
@@ -59,11 +59,22 @@ export class VendorService {
     });
   }
 
-  async findOne(id: string): Promise<Vendor | null> {
+  async findOne(id: string): Promise<any | null> {
     return this.prisma.vendor.findUnique({
       where: { id },
       include: {
         supportedBrands: true,
+        purchase_orders: {
+          orderBy: { createdAt: 'desc' },
+          take: 20,
+          include: {
+            items: true,
+          },
+        },
+        purchase_invoices: {
+          orderBy: { createdAt: 'desc' },
+          take: 20,
+        },
       },
     });
   }

--- a/apps/core-api/src/vendor/vendor.service.ts
+++ b/apps/core-api/src/vendor/vendor.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { Vendor } from '@prisma/client';
+import { Vendor, Prisma } from '@prisma/client';
 
 @Injectable()
 export class VendorService {
@@ -59,7 +59,15 @@ export class VendorService {
     });
   }
 
-  async findOne(id: string): Promise<any | null> {
+  async findOne(id: string): Promise<Prisma.VendorGetPayload<{
+    include: {
+      supportedBrands: true
+      purchase_orders: {
+        include: { items: true }
+      }
+      purchase_invoices: true
+    }
+  }> | null> {
     return this.prisma.vendor.findUnique({
       where: { id },
       include: {

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -66,12 +66,11 @@ describe('WorkshopService', () => {
     mockPrisma.vehicle.findUnique.mockResolvedValue({ id: 'v-1' });
     mockPrisma.financeSettings.upsert.mockResolvedValue({ id: 1 });
     mockPrisma.financeSettings.update.mockResolvedValue({
-      workshop_order_prefix: 'WO-2026-',
-      next_workshop_order_number: 1002,
+      next_workshop_order_number: 2,
     });
     mockPrisma.workshopOrder.create.mockResolvedValue({
       id: 'wo-1',
-      order_number: 'WO-2026-1001',
+      order_number: 'WO-2026-0001',
       status: WorkshopOrderStatus.INTAKE,
       customer: { id: 'c-1' },
       vehicle: { id: 'v-1' },
@@ -86,14 +85,16 @@ describe('WorkshopService', () => {
       notes: 'Noise check',
     });
 
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
+    expect(mockPrisma.financeSettings.upsert).toHaveBeenCalled();
     expect(mockPrisma.workshopOrder.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          order_number: 'WO-2026-1001',
+          order_number: 'WO-2026-0001',
         }),
       }),
     );
-    expect(result.order_number).toBe('WO-2026-1001');
+    expect(result.order_number).toBe('WO-2026-0001');
   });
 
   it('derives workshop order status from task updates', async () => {

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -9,7 +9,18 @@ describe('WorkshopService', () => {
   let service: WorkshopService;
 
   const mockPrisma = {
+    financeSettings: {
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+    customer: {
+      findUnique: jest.fn(),
+    },
+    vehicle: {
+      findUnique: jest.fn(),
+    },
     workshopOrder: {
+      create: jest.fn(),
       findUnique: jest.fn(),
       update: jest.fn(),
       updateMany: jest.fn(),
@@ -48,6 +59,41 @@ describe('WorkshopService', () => {
     await service.createInvoiceFromOrder('wo-1');
 
     expect(mockInvoices.createDraftInvoice).toHaveBeenCalledWith('wo-1');
+  });
+
+  it('creates workshop order with generated order number', async () => {
+    mockPrisma.customer.findUnique.mockResolvedValue({ id: 'c-1' });
+    mockPrisma.vehicle.findUnique.mockResolvedValue({ id: 'v-1' });
+    mockPrisma.financeSettings.upsert.mockResolvedValue({ id: 1 });
+    mockPrisma.financeSettings.update.mockResolvedValue({
+      workshop_order_prefix: 'WO-2026-',
+      next_workshop_order_number: 1002,
+    });
+    mockPrisma.workshopOrder.create.mockResolvedValue({
+      id: 'wo-1',
+      order_number: 'WO-2026-1001',
+      status: WorkshopOrderStatus.INTAKE,
+      customer: { id: 'c-1' },
+      vehicle: { id: 'v-1' },
+      tasks: [],
+    });
+
+    const result = await service.create({
+      customerId: 'c-1',
+      vehicleId: 'v-1',
+      odometer: 10000,
+      fuelLevel: 50,
+      notes: 'Noise check',
+    });
+
+    expect(mockPrisma.workshopOrder.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          order_number: 'WO-2026-1001',
+        }),
+      }),
+    );
+    expect(result.order_number).toBe('WO-2026-1001');
   });
 
   it('derives workshop order status from task updates', async () => {

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -30,6 +30,35 @@ export class WorkshopService {
     @Inject(InvoicesService) private invoicesService: InvoicesService,
   ) {}
 
+  private async generateOrderNumber() {
+    await this.prisma.financeSettings.upsert({
+      where: { id: 1 },
+      update: {},
+      create: {
+        id: 1,
+        fiscal_year_start_month: 1,
+        lock_date: null,
+        next_invoice_number: 1001,
+        invoice_prefix: 'RE-2026-',
+        next_sales_order_number: 1001,
+        sales_order_prefix: 'SO-2026-',
+        next_workshop_order_number: 1001,
+        workshop_order_prefix: 'WO-2026-',
+      },
+    });
+
+    const settings = await this.prisma.financeSettings.update({
+      where: { id: 1 },
+      data: { next_workshop_order_number: { increment: 1 } },
+      select: {
+        workshop_order_prefix: true,
+        next_workshop_order_number: true,
+      },
+    });
+
+    return `${settings.workshop_order_prefix}${settings.next_workshop_order_number - 1}`;
+  }
+
   private deriveOrderStatus(taskStatuses: WorkshopTaskStatus[]) {
     if (taskStatuses.length === 0) return WorkshopOrderStatus.INTAKE;
     if (taskStatuses.every((status) => status === WorkshopTaskStatus.DONE)) {
@@ -133,8 +162,11 @@ export class WorkshopService {
     if (!vehicle)
       throw new NotFoundException(`Vehicle ${dto.vehicleId} not found`);
 
+    const orderNumber = await this.generateOrderNumber();
+
     const order = await this.prisma.workshopOrder.create({
       data: {
+        order_number: orderNumber,
         customer_id: dto.customerId,
         vehicle_id: dto.vehicleId,
         odometer: dto.odometer,
@@ -174,6 +206,9 @@ export class WorkshopService {
     const where: Prisma.WorkshopOrderWhereInput = params.search
       ? {
           OR: [
+            {
+              order_number: { contains: params.search, mode: 'insensitive' },
+            },
             { id: { contains: params.search, mode: 'insensitive' } },
             {
               customer: {
@@ -219,7 +254,9 @@ export class WorkshopService {
 
     if (sortField === 'status') {
       orderBy = { status: sortDirection };
-    } else if (sortField === 'orderNo' || sortField === 'id') {
+    } else if (sortField === 'orderNo' || sortField === 'order_number') {
+      orderBy = { order_number: sortDirection };
+    } else if (sortField === 'id') {
       orderBy = { id: sortDirection };
     } else if (sortField === 'customer') {
       orderBy = { customer: { last_name: sortDirection } };

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -31,32 +31,40 @@ export class WorkshopService {
   ) {}
 
   private async generateOrderNumber() {
-    await this.prisma.financeSettings.upsert({
-      where: { id: 1 },
-      update: {},
-      create: {
-        id: 1,
-        fiscal_year_start_month: 1,
-        lock_date: null,
-        next_invoice_number: 1001,
-        invoice_prefix: 'RE-2026-',
-        next_sales_order_number: 1001,
-        sales_order_prefix: 'SO-2026-',
-        next_workshop_order_number: 1001,
-        workshop_order_prefix: 'WO-2026-',
-      },
+    const currentYear = new Date().getFullYear();
+    const prefix = `WO-${currentYear}-`;
+
+    const settings = await this.prisma.$transaction(async (tx) => {
+      await tx.financeSettings.upsert({
+        where: { id: 1 },
+        update: {},
+        create: {
+          id: 1,
+          fiscal_year_start_month: 1,
+          lock_date: null,
+          next_invoice_number: 1001,
+          invoice_prefix: 'RE-2026-',
+          next_sales_order_number: 1001,
+          sales_order_prefix: 'SO-2026-',
+          next_workshop_order_number: 1,
+          workshop_order_prefix: prefix,
+        },
+      });
+
+      return tx.financeSettings.update({
+        where: { id: 1 },
+        data: { 
+          next_workshop_order_number: { increment: 1 },
+          workshop_order_prefix: prefix,
+        },
+        select: {
+          next_workshop_order_number: true,
+        },
+      });
     });
 
-    const settings = await this.prisma.financeSettings.update({
-      where: { id: 1 },
-      data: { next_workshop_order_number: { increment: 1 } },
-      select: {
-        workshop_order_prefix: true,
-        next_workshop_order_number: true,
-      },
-    });
-
-    return `${settings.workshop_order_prefix}${settings.next_workshop_order_number - 1}`;
+    const paddedSequence = String(settings.next_workshop_order_number - 1).padStart(4, '0');
+    return `${prefix}${paddedSequence}`;
   }
 
   private deriveOrderStatus(taskStatuses: WorkshopTaskStatus[]) {

--- a/apps/core-api/test/mocks/prisma.mock.ts
+++ b/apps/core-api/test/mocks/prisma.mock.ts
@@ -1,4 +1,15 @@
 export const mockPrismaService = {
+  financeSettings: {
+    upsert: jest.fn().mockResolvedValue({
+      id: 1,
+      workshop_order_prefix: 'WO-2026-',
+      next_workshop_order_number: 1001,
+    }),
+    update: jest.fn().mockResolvedValue({
+      workshop_order_prefix: 'WO-2026-',
+      next_workshop_order_number: 1002,
+    }),
+  },
   workshopOrder: {
     deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
     create: jest.fn().mockImplementation((args) =>
@@ -13,6 +24,7 @@ export const mockPrismaService = {
   },
   vehicle: {
     deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    count: jest.fn().mockResolvedValue(1),
     findMany: jest.fn().mockResolvedValue([
       {
         id: 'mock-vehicle-id',
@@ -28,6 +40,20 @@ export const mockPrismaService = {
         },
       },
     ]),
+    findUnique: jest.fn().mockImplementation((args) => {
+      if (args?.where?.id === 'mock-vehicle-id') {
+        return Promise.resolve({
+          id: 'mock-vehicle-id',
+          make: 'Toyota',
+          model: 'Corolla',
+          year: 2020,
+          vin: 'TESTVIN123456789',
+          plate: 'W-1234AB',
+          customer_id: 'mock-customer-id',
+        });
+      }
+      return Promise.resolve(null);
+    }),
     create: jest.fn().mockResolvedValue({
       id: 'mock-vehicle-id',
       make: 'Toyota',
@@ -50,8 +76,17 @@ export const mockPrismaService = {
   },
   customer: {
     deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    count: jest.fn().mockResolvedValue(1),
     findMany: jest.fn().mockResolvedValue([]),
     findUnique: jest.fn().mockImplementation((args) => {
+      if (args?.where?.id === 'mock-customer-id')
+        return Promise.resolve({
+          id: 'mock-customer-id',
+          first_name: 'Workshop',
+          last_name: 'Tester',
+          email: 'workshop@test.com',
+          type: 'PRIVATE',
+        });
       if (args?.where?.email === 'workshop@test.com')
         return Promise.resolve({
           id: 'mock-customer-id',

--- a/apps/core-api/test/workshop-intake.e2e-spec.ts
+++ b/apps/core-api/test/workshop-intake.e2e-spec.ts
@@ -55,6 +55,7 @@ describe('Workshop Intake Module (e2e)', () => {
       .expect(201);
 
     expect(res.body.id).toBeDefined();
+    expect(res.body.order_number).toMatch(/^WO-\d{4}-\d+$/);
     expect(res.body.status).toBe('INTAKE');
     expect(res.body.odometer).toBe(50000);
   });

--- a/apps/core-api/test/workshop-invoicing.e2e-spec.ts
+++ b/apps/core-api/test/workshop-invoicing.e2e-spec.ts
@@ -88,6 +88,7 @@ describe('Workshop Invoicing (e2e)', () => {
       .expect(201);
 
     const orderId = orderRes.body.id;
+    expect(orderRes.body.order_number).toMatch(/^WO-\d{4}-\d+$/);
 
     const taskRes = await api
       .post(`/api/workshop/orders/${orderId}/tasks`)

--- a/apps/core-web/src/App.tsx
+++ b/apps/core-web/src/App.tsx
@@ -4,6 +4,7 @@ import { Settings, Search, LogOut } from 'lucide-react'
 import InventoryList from './pages/InventoryList'
 import InventoryLedgerPage from './pages/inventory/InventoryLedgerPage'
 import VendorList from './pages/vendors/VendorList'
+import VendorDetail from './pages/vendors/VendorDetail'
 import PurchaseOrderList from './pages/purchase-orders/PurchaseOrderList'
 import PurchaseOrderCreate from './pages/purchase-orders/PurchaseOrderCreate'
 import PurchaseOrderDetail from './pages/purchase-orders/PurchaseOrderDetail'
@@ -63,6 +64,7 @@ function AppRoutes() {
             <Route path="/sales-orders/new" element={<SalesOrderCreate />} />
             <Route path="/sales-orders/:id" element={<SalesOrderDetail />} />
             <Route path="/vendors" element={<VendorList />} />
+            <Route path="/vendors/:id" element={<VendorDetail />} />
             <Route path="/purchase-orders" element={<PurchaseOrderList />} />
             <Route path="/purchase-orders/new" element={<PurchaseOrderCreate />} />
             <Route path="/purchase-orders/:id" element={<PurchaseOrderDetail />} />

--- a/apps/core-web/src/api/types.ts
+++ b/apps/core-web/src/api/types.ts
@@ -299,6 +299,7 @@ export interface WorkshopTask {
 
 export interface WorkshopOrder {
     id: string
+    order_number?: string
     status: WorkshopOrderStatus
     customer_id: string
     customer: Customer

--- a/apps/core-web/src/api/types.ts
+++ b/apps/core-web/src/api/types.ts
@@ -299,7 +299,7 @@ export interface WorkshopTask {
 
 export interface WorkshopOrder {
     id: string
-    order_number?: string
+    order_number: string
     status: WorkshopOrderStatus
     customer_id: string
     customer: Customer

--- a/apps/core-web/src/api/vendors.ts
+++ b/apps/core-web/src/api/vendors.ts
@@ -2,12 +2,19 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { fetchWithAuth } from './client'
 import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
 import { buildDataTableUrl } from './data-table-query'
+import type { Vendor } from './types'
 
 const VENDORS_API = '/api/vendors'
 
+export const vendorKeys = {
+    all: ['vendors'] as const,
+    list: (queryParams?: DataTableQueryParams) => [...vendorKeys.all, 'list', queryParams] as const,
+    detail: (id: string) => [...vendorKeys.all, 'detail', id] as const,
+}
+
 export function useVendors(queryParams?: DataTableQueryParams) {
     return useQuery<any>({
-        queryKey: ['vendors', queryParams],
+        queryKey: vendorKeys.list(queryParams),
         queryFn: async () => {
             const url = buildDataTableUrl(VENDORS_API, queryParams, {
                 searchFallbackFilterFields: ['name'],
@@ -16,6 +23,18 @@ export function useVendors(queryParams?: DataTableQueryParams) {
             if (!res.ok) throw new Error('Failed to fetch vendors')
             return res.json()
         },
+    })
+}
+
+export function useVendor<TVendor = Vendor>(id: string) {
+    return useQuery<TVendor>({
+        queryKey: vendorKeys.detail(id),
+        queryFn: async () => {
+            const res = await fetchWithAuth(`${VENDORS_API}/${id}`)
+            if (!res.ok) throw new Error('Failed to fetch vendor')
+            return res.json()
+        },
+        enabled: !!id,
     })
 }
 
@@ -42,7 +61,34 @@ export function useCreateVendor() {
             return res.json()
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['vendors'] })
+            queryClient.invalidateQueries({ queryKey: vendorKeys.all })
+        },
+    })
+}
+
+export function useUpdateVendor() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({ id, data }: {
+            id: string
+            data: Partial<Vendor> & { brandIds?: number[] }
+        }) => {
+            const res = await fetchWithAuth(`${VENDORS_API}/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: data.name,
+                    email: data.email,
+                    accountNumber: data.account_number,
+                    brandIds: data.brandIds,
+                }),
+            })
+            if (!res.ok) throw new Error('Failed to update vendor')
+            return res.json()
+        },
+        onSuccess: (updatedVendor) => {
+            queryClient.invalidateQueries({ queryKey: vendorKeys.all })
+            queryClient.invalidateQueries({ queryKey: vendorKeys.detail(updatedVendor.id) })
         },
     })
 }
@@ -61,7 +107,7 @@ export function useDeleteVendor() {
             return id
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['vendors'] })
+            queryClient.invalidateQueries({ queryKey: vendorKeys.all })
         },
     })
 }

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -38,6 +38,7 @@ function normalizeTask(task: any) {
 function normalizeOrder(order: any): WorkshopOrder {
   return {
     ...order,
+    order_number: order.order_number ?? order.orderNumber ?? order.id,
     reportedIssue: order.reportedIssue ?? order.reported_issue ?? '',
     tasks: (order.tasks ?? []).map(normalizeTask),
   }
@@ -48,7 +49,7 @@ export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
     queryKey: ['workshop', 'orders', queryParams],
     queryFn: async () => {
       const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, queryParams, {
-        searchFallbackFilterFields: ['id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
+        searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
       })
       const response = await fetchWithAuth(url)
       if (!response.ok) throw new Error('Failed to fetch workshop orders')

--- a/apps/core-web/src/pages/customers/CustomerDetail.tsx
+++ b/apps/core-web/src/pages/customers/CustomerDetail.tsx
@@ -50,6 +50,7 @@ type WorkshopTaskSummary = {
 
 type WorkshopOrderSummary = {
   id: string
+  order_number?: string
   status: WorkshopOrderStatus
   createdAt: string
   vehicle_id?: string
@@ -133,7 +134,7 @@ export default function CustomerDetail() {
     .map((order) => ({
       id: order.id,
       type: 'Service',
-      number: `#${order.id}`,
+      number: order.order_number ?? `#${order.id}`,
       createdAt: order.createdAt,
       status: order.status,
       total: getWorkshopOrderTotal(order),

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
@@ -52,7 +52,20 @@ export default function PurchaseOrderCreate() {
     const { data: vendorsResponse } = useVendors()
     const vendors = (Array.isArray(vendorsResponse) ? vendorsResponse : (vendorsResponse as any)?.data || []) as Vendor[]
 
-    const [selectedVendorId, setSelectedVendorId] = useState<string>(searchParams.get('vendorId') ?? '')
+    // Compute valid vendor ID based on params, brand, and available vendors
+    const computeValidVendorId = () => {
+        const vendorIdFromParams = searchParams.get('vendorId') ?? ''
+        if (!vendorIdFromParams) return ''
+
+        const filteredVendors = selectedBrand
+            ? vendors.filter((v: Vendor) => v.supportedBrands.some((b: Brand) => b.id === selectedBrand.id))
+            : vendors
+
+        const vendorExists = filteredVendors.some((v: Vendor) => v.id === vendorIdFromParams)
+        return vendorExists ? vendorIdFromParams : ''
+    }
+
+    const [selectedVendorId, setSelectedVendorId] = useState<string>(computeValidVendorId())
 
     // Step 3: Items
     const [items, setItems] = useState<POItem[]>([])

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useVendors } from '@/api/vendors'
 import { useInventory } from '@/api/inventory'
 import { useCreatePO } from '@/api/purchase-orders'
@@ -41,6 +41,7 @@ interface InventoryItem {
 
 export default function PurchaseOrderCreate() {
     const navigate = useNavigate()
+    const [searchParams] = useSearchParams()
     const [step, setStep] = useState(1)
 
     // Step 1: Brand
@@ -51,7 +52,7 @@ export default function PurchaseOrderCreate() {
     const { data: vendorsResponse } = useVendors()
     const vendors = (Array.isArray(vendorsResponse) ? vendorsResponse : (vendorsResponse as any)?.data || []) as Vendor[]
 
-    const [selectedVendorId, setSelectedVendorId] = useState<string>('')
+    const [selectedVendorId, setSelectedVendorId] = useState<string>(searchParams.get('vendorId') ?? '')
 
     // Step 3: Items
     const [items, setItems] = useState<POItem[]>([])

--- a/apps/core-web/src/pages/vehicles/VehicleDetail.tsx
+++ b/apps/core-web/src/pages/vehicles/VehicleDetail.tsx
@@ -56,6 +56,7 @@ type VehicleWorkshopTask = {
 
 type VehicleWorkshopOrderSummary = {
   id: string
+  order_number?: string
   status: WorkshopOrderStatus
   createdAt: string
   tasks?: VehicleWorkshopTask[]
@@ -145,7 +146,7 @@ export default function VehicleDetail() {
     .map((order) => ({
       id: order.id,
       type: 'Service',
-      number: `#${order.id}`,
+      number: order.order_number ?? `#${order.id}`,
       createdAt: order.createdAt,
       status: order.status,
       total: getWorkshopOrderTotal(order),
@@ -463,7 +464,7 @@ export default function VehicleDetail() {
                           onClick={() => navigate(`/workshop/orders/${order.id}`)}
                           tabIndex={0}
                           role='button'
-                          aria-label={`Open service order ${order.id}`}
+                          aria-label={`Open service order ${order.order_number ?? order.id}`}
                           onKeyDown={(event) => {
                             if (event.key === 'Enter' || event.key === ' ') {
                               event.preventDefault()
@@ -471,7 +472,7 @@ export default function VehicleDetail() {
                             }
                           }}
                         >
-                          <TableCell className='font-medium'>#{order.id}</TableCell>
+                          <TableCell className='font-medium'>{order.order_number ?? `#${order.id}`}</TableCell>
                           <TableCell>{new Date(order.createdAt).toLocaleDateString()}</TableCell>
                           <TableCell><StatusBadge status={order.status} /></TableCell>
                           <TableCell className='text-right'>{formatCurrency(getWorkshopOrderTotal(order))}</TableCell>

--- a/apps/core-web/src/pages/vehicles/VehicleDetail.tsx
+++ b/apps/core-web/src/pages/vehicles/VehicleDetail.tsx
@@ -146,7 +146,7 @@ export default function VehicleDetail() {
     .map((order) => ({
       id: order.id,
       type: 'Service',
-      number: order.order_number ?? `#${order.id}`,
+      number: order.order_number ?? `#${order.id.slice(0, 8)}`,
       createdAt: order.createdAt,
       status: order.status,
       total: getWorkshopOrderTotal(order),

--- a/apps/core-web/src/pages/vendors/VendorDetail.tsx
+++ b/apps/core-web/src/pages/vendors/VendorDetail.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Mail, Package, ReceiptText, Tags } from 'lucide-react'
+import { toast } from 'sonner'
+import { useVendor, useUpdateVendor } from '@/api/vendors'
+import { BrandMultiSelect } from '@/components/BrandMultiSelect'
+import { InlineEdit } from '@/components/inline-edit/InlineEdit'
+import { StatusBadge } from '@/components/status/StatusBadge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { formatCurrency } from '@/lib/utils'
+import type {
+  Brand,
+  PurchaseInvoiceStatus,
+  PurchaseOrderStatus,
+  Vendor,
+} from '@/api/types'
+
+type VendorPurchaseOrderItemSummary = {
+  quantity: string | number
+  unit_cost: string | number
+}
+
+type VendorPurchaseOrderSummary = {
+  id: string
+  order_number: string
+  status: PurchaseOrderStatus
+  createdAt: string
+  items?: VendorPurchaseOrderItemSummary[]
+}
+
+type VendorPurchaseInvoiceSummary = {
+  id: string
+  invoice_number?: string | null
+  vendor_invoice_number: string
+  status: PurchaseInvoiceStatus
+  invoice_date: string
+  total_amount: string | number
+}
+
+type VendorDetailResponse = Vendor & {
+  purchase_orders?: VendorPurchaseOrderSummary[]
+  purchase_invoices?: VendorPurchaseInvoiceSummary[]
+}
+
+function toNumber(value: string | number | null | undefined) {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function getPurchaseOrderTotal(order: VendorPurchaseOrderSummary) {
+  return (order.items ?? []).reduce(
+    (sum, item) => sum + toNumber(item.quantity) * toNumber(item.unit_cost),
+    0,
+  )
+}
+
+export default function VendorDetail() {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
+  const { data: vendor, isLoading, error } = useVendor<VendorDetailResponse>(id ?? '')
+  const updateVendor = useUpdateVendor()
+  const [selectedBrandIds, setSelectedBrandIds] = useState<number[]>([])
+
+  useEffect(() => {
+    setSelectedBrandIds((vendor?.supportedBrands ?? []).map((brand) => brand.id))
+  }, [vendor])
+
+  if (isLoading) {
+    return <div className='p-8 text-center'>Loading vendor details...</div>
+  }
+
+  if (error) {
+    return <div className='p-8 text-center'>Failed to load vendor: {(error as Error).message}</div>
+  }
+
+  if (!vendor) {
+    return <div className='p-8 text-center'>Vendor not found.</div>
+  }
+
+  const activeOrders = (vendor.purchase_orders ?? [])
+    .filter((order) => order.status !== 'COMPLETED')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+  type EditableVendorField = 'name' | 'email' | 'account_number'
+
+  const handleSaveVendorField = async (
+    field: EditableVendorField,
+    nextValue: string,
+  ) => {
+    try {
+      await updateVendor.mutateAsync({
+        id: vendor.id,
+        data: {
+          [field]: nextValue,
+        },
+      })
+      toast.success('Vendor updated')
+    } catch (updateError: unknown) {
+      if (updateError instanceof Error) {
+        toast.error(updateError.message)
+      } else {
+        toast.error('Failed to update vendor')
+      }
+      throw updateError
+    }
+  }
+
+  const handleSaveBrands = async () => {
+    try {
+      await updateVendor.mutateAsync({
+        id: vendor.id,
+        data: {
+          brandIds: selectedBrandIds,
+        },
+      })
+      toast.success('Supported brands updated')
+    } catch (updateError: unknown) {
+      if (updateError instanceof Error) {
+        toast.error(updateError.message)
+      } else {
+        toast.error('Failed to update brands')
+      }
+    }
+  }
+
+  return (
+    <div className='w-full max-w-7xl mx-auto p-6 space-y-6'>
+      <div className='flex items-center justify-between mb-8'>
+        <div className='flex items-center gap-4'>
+          <Button variant='ghost' size='icon' asChild>
+            <Link to='/vendors' aria-label='Back to vendors'>
+              <ArrowLeft className='h-4 w-4' />
+            </Link>
+          </Button>
+          <div>
+            <h1 className='text-2xl font-semibold tracking-tight'>{vendor.name}</h1>
+            <div className='flex items-center gap-2 text-slate-500 text-sm'>
+              <span>ID: {vendor.id.substring(0, 8)}</span>
+            </div>
+          </div>
+        </div>
+        <div className='flex gap-2'>
+          <Button asChild>
+            <Link to={`/purchase-orders/new?vendorId=${vendor.id}`}>
+              <Package className='mr-2 h-4 w-4' /> Purchase Order
+            </Link>
+          </Button>
+          <Button variant='outline' asChild>
+            <Link to={`/purchase-invoices/new?vendorId=${vendor.id}`}>
+              <ReceiptText className='mr-2 h-4 w-4' /> Purchase Invoice
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 items-start'>
+        <Card className='lg:col-span-1'>
+          <CardHeader>
+            <CardTitle className='text-base font-semibold'>Contact Information</CardTitle>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div>
+              <div className='text-xs text-muted-foreground mb-1'>Vendor Name</div>
+              <InlineEdit
+                value={vendor.name}
+                onSave={(nextValue) => handleSaveVendorField('name', nextValue)}
+                placeholder='Vendor name'
+                emptyText='Add vendor name'
+                ariaLabel='Vendor name'
+              />
+            </div>
+            <div className='flex items-center gap-2'>
+              <Mail className='h-4 w-4 text-muted-foreground' />
+              <InlineEdit
+                value={vendor.email}
+                onSave={(nextValue) => handleSaveVendorField('email', nextValue)}
+                placeholder='vendor@example.com'
+                emptyText='Add email'
+                ariaLabel='Vendor email'
+              />
+            </div>
+            <div className='pt-2 border-t'>
+              <span className='text-sm font-medium'>Account #:</span>
+              <div className='mt-1'>
+                <InlineEdit
+                  value={vendor.account_number}
+                  onSave={(nextValue) => handleSaveVendorField('account_number', nextValue)}
+                  placeholder='Account number'
+                  emptyText='Add account number'
+                  ariaLabel='Vendor account number'
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className='lg:col-span-2'>
+          <Tabs defaultValue='orders'>
+            <TabsList>
+              <TabsTrigger value='orders'>Active Orders</TabsTrigger>
+              <TabsTrigger value='invoices'>Invoice History</TabsTrigger>
+              <TabsTrigger value='brands'>Supported Brands</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value='orders' className='mt-4'>
+              <Card>
+                <CardContent className='p-0'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Order #</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className='text-right'>Total</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {activeOrders.map((order) => (
+                        <TableRow
+                          key={order.id}
+                          className='cursor-pointer hover:bg-accent/50'
+                          onClick={() => navigate(`/purchase-orders/${order.id}`)}
+                          tabIndex={0}
+                          role='button'
+                          aria-label={`Open purchase order ${order.order_number}`}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                              event.preventDefault()
+                              navigate(`/purchase-orders/${order.id}`)
+                            }
+                          }}
+                        >
+                          <TableCell className='font-medium'>{order.order_number}</TableCell>
+                          <TableCell>{new Date(order.createdAt).toLocaleDateString()}</TableCell>
+                          <TableCell><StatusBadge status={order.status} /></TableCell>
+                          <TableCell className='text-right'>{formatCurrency(getPurchaseOrderTotal(order))}</TableCell>
+                        </TableRow>
+                      ))}
+                      {activeOrders.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={4} className='text-center py-4 text-muted-foreground'>No active purchase orders</TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value='invoices' className='mt-4'>
+              <Card>
+                <CardContent className='p-0'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Invoice #</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className='text-right'>Total</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {(vendor.purchase_invoices ?? []).map((invoice) => (
+                        <TableRow key={invoice.id}>
+                          <TableCell className='font-medium'>
+                            {invoice.invoice_number || invoice.vendor_invoice_number || 'Draft'}
+                          </TableCell>
+                          <TableCell>{new Date(invoice.invoice_date).toLocaleDateString()}</TableCell>
+                          <TableCell><StatusBadge status={invoice.status} /></TableCell>
+                          <TableCell className='text-right'>{formatCurrency(toNumber(invoice.total_amount))}</TableCell>
+                        </TableRow>
+                      ))}
+                      {(vendor.purchase_invoices ?? []).length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={4} className='text-center py-4 text-muted-foreground'>No recent purchase invoices</TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value='brands' className='mt-4'>
+              <Card>
+                <CardHeader className='pb-3'>
+                  <CardTitle className='text-base font-semibold flex items-center gap-2'>
+                    <Tags className='h-4 w-4' />
+                    Brand Mapping
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className='space-y-4'>
+                  <BrandMultiSelect value={selectedBrandIds} onChange={setSelectedBrandIds} />
+                  <div className='flex justify-end'>
+                    <Button
+                      onClick={() => void handleSaveBrands()}
+                      disabled={updateVendor.isPending}
+                    >
+                      Save Brands
+                    </Button>
+                  </div>
+                  <div className='text-xs text-muted-foreground'>
+                    Current: {(vendor.supportedBrands ?? []).map((brand: Brand) => brand.name).join(', ') || 'No brands selected'}
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/core-web/src/pages/vendors/VendorDetail.tsx
+++ b/apps/core-web/src/pages/vendors/VendorDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, Mail, Package, ReceiptText, Tags } from 'lucide-react'
 import { toast } from 'sonner'
@@ -69,11 +69,9 @@ export default function VendorDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: vendor, isLoading, error } = useVendor<VendorDetailResponse>(id ?? '')
   const updateVendor = useUpdateVendor()
-  const [selectedBrandIds, setSelectedBrandIds] = useState<number[]>([])
-
-  useEffect(() => {
-    setSelectedBrandIds((vendor?.supportedBrands ?? []).map((brand) => brand.id))
-  }, [vendor])
+  const [selectedBrandIds, setSelectedBrandIds] = useState<number[]>(() => 
+    (vendor?.supportedBrands ?? []).map((brand) => brand.id)
+  )
 
   if (isLoading) {
     return <div className='p-8 text-center'>Loading vendor details...</div>

--- a/apps/core-web/src/pages/vendors/VendorList.tsx
+++ b/apps/core-web/src/pages/vendors/VendorList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { type ColumnDef } from '@tanstack/react-table'
+import { useNavigate } from 'react-router-dom'
 import { useDeleteVendor, useVendors } from '@/api/vendors'
 import { Button } from '@/components/ui/button'
 import { VendorDialog } from './VendorDialog'
@@ -12,6 +13,7 @@ import type { Vendor } from '@/api/types'
 import { toast } from 'sonner'
 
 export default function VendorList() {
+    const navigate = useNavigate()
     const { queryParams, ...tableState } = useDataTableQuery({ defaultPageSize: 10 })
     const { data: responseData, isLoading } = useVendors(queryParams)
     const deleteMutation = useDeleteVendor()
@@ -79,6 +81,7 @@ export default function VendorList() {
                 isLoading={isLoading}
                 searchColumn="name"
                 searchPlaceholder="Search vendors..."
+                onRowClick={(row) => navigate(`/vendors/${row.id}`)}
                 getRowContextActions={(row) => [
                     {
                         label: 'Delete',

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
@@ -818,13 +818,15 @@ export function WorkshopOrderDetails() {
                       <div
                         key={task.id}
                         data-workshop-task-row='true'
-                        className='w-full border rounded-lg px-3 py-2.5 hover:bg-accent transition-colors'
+                        onClick={() => setActiveTaskId(task.id)}
+                        className='w-full border rounded-lg px-3 py-2.5 hover:bg-accent transition-colors cursor-pointer'
                       >
                         <div className='flex items-center gap-3 text-left'>
                           <Checkbox
                             checked={task.done}
                             onCheckedChange={(checked) => void handleToggleTask(task.id, checked === true)}
                             disabled={isLocked}
+                            onClick={(e) => e.stopPropagation()}
                           />
                           <span className={`text-sm ${task.done ? 'line-through text-muted-foreground' : ''}`}>
                             {task.title}
@@ -834,7 +836,10 @@ export function WorkshopOrderDetails() {
                               variant='ghost'
                               size='sm'
                               className='h-7 px-2'
-                              onClick={() => setActiveTaskId(task.id)}
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                setActiveTaskId(task.id)
+                              }}
                             >
                               Open
                             </Button>

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
@@ -337,9 +337,12 @@ export function WorkshopOrderDetails() {
     !isLocked &&
     !issueInvoice.isPending &&
     !updateInvoiceDiscount.isPending
+  const isInvoicedWithLinkedInvoice = order.status === 'INVOICED' && !!activeInvoiceId
   const invoiceActionLabel = isCheckoutView
     ? 'Close Checkout'
-    : activeInvoiceId
+    : isInvoicedWithLinkedInvoice
+      ? 'Open Invoice'
+      : activeInvoiceId
       ? 'Open Checkout'
       : 'Generate Invoice'
   const isInvoiceActionDisabled = !isCheckoutView && !canEnterCheckout
@@ -466,6 +469,11 @@ export function WorkshopOrderDetails() {
       return
     }
 
+    if (isInvoicedWithLinkedInvoice) {
+      navigate(`/sales/invoices/${activeInvoiceId}`)
+      return
+    }
+
     if (canEnterCheckout) {
       openCheckoutView()
       return
@@ -523,7 +531,7 @@ export function WorkshopOrderDetails() {
 
   const handlePrint = () => {
     const previousTitle = document.title
-    document.title = `Job Card ${order.id}`
+    document.title = `Job Card ${order.order_number ?? order.id}`
     window.print()
     document.title = previousTitle
   }
@@ -706,7 +714,7 @@ export function WorkshopOrderDetails() {
               <div className='flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between'>
                 <div className='space-y-3'>
                   <div className='flex items-center gap-3'>
-                    <h1 className='text-2xl font-semibold tracking-tight'>#{order.id}</h1>
+                    <h1 className='text-2xl font-semibold tracking-tight'>{order.order_number ?? `#${order.id}`}</h1>
                     <StatusBadge status={order.status} />
                   </div>
 
@@ -715,10 +723,12 @@ export function WorkshopOrderDetails() {
                       <Printer className='h-4 w-4 mr-2' />
                       Print Job Card
                     </Button>
-                    <Button onClick={handleCheckoutAction} disabled={isInvoiceActionDisabled}>
-                      <FileText className='h-4 w-4 mr-2' />
-                      {invoiceActionLabel}
-                    </Button>
+                    {!isInvoiceActionDisabled && (
+                      <Button onClick={handleCheckoutAction}>
+                        <FileText className='h-4 w-4 mr-2' />
+                        {invoiceActionLabel}
+                      </Button>
+                    )}
                   </div>
                 </div>
 

--- a/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
@@ -38,7 +38,7 @@ export default function WorkshopOrderList() {
     const source = responseData?.data ?? []
     return source.map((order) => ({
       id: order.id,
-      orderNo: order.id,
+      orderNo: order.order_number ?? order.id,
       customer: getCustomerName(order),
       vehicle: `${order.vehicle.year} ${order.vehicle.make} ${order.vehicle.model}`,
       openedAt: format(new Date(order.createdAt), 'PPP'),


### PR DESCRIPTION
- add workshop order_number generation, migration, and UI usage\n- navigate invoiced workshop orders to linked invoice and hide disabled invoice action\n- add vendor detail page with customer-like layout and editing/history tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workshop orders now auto-generate unique, year-scoped order numbers (e.g., WO-YYYY-####).
  * Vendor Details page with vendor info, active orders, invoices, and inline editing.

* **Improvements**
  * Order numbers displayed across the app (lists, details, customer/vehicle views) and are searchable/sortable.
  * Vendor list rows navigate to vendor details; purchase order creation can pre-select vendor from URL.

* **Tests**
  * Added tests and assertions to validate generated order number format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->