### PR TITLE
fix: PO status sync and item search filtering

### DIFF
--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -466,6 +466,109 @@
         ]
       }
     },
+    "/api/purchase-orders/{id}/items": {
+      "post": {
+        "operationId": "PurchaseController_addItems",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddPurchaseOrderItemsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      }
+    },
+    "/api/purchase-orders/{id}/items/{itemId}": {
+      "patch": {
+        "operationId": "PurchaseController_updateItem",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePurchaseOrderItemDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      },
+      "delete": {
+        "operationId": "PurchaseController_deleteItem",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      }
+    },
     "/api/purchase-invoices": {
       "post": {
         "operationId": "PurchaseInvoiceController_create",
@@ -2013,6 +2116,14 @@
         "properties": {}
       },
       "ReceivePurchaseOrderDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "AddPurchaseOrderItemsDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "UpdatePurchaseOrderItemDto": {
         "type": "object",
         "properties": {}
       },

--- a/apps/core-api/src/purchase/dto/add-purchase-order-items.dto.ts
+++ b/apps/core-api/src/purchase/dto/add-purchase-order-items.dto.ts
@@ -1,0 +1,13 @@
+import {
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { PurchaseOrderItemDto } from './create-purchase-order.dto';
+
+export class AddPurchaseOrderItemsDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PurchaseOrderItemDto)
+  items: PurchaseOrderItemDto[];
+}

--- a/apps/core-api/src/purchase/dto/update-purchase-order-item.dto.ts
+++ b/apps/core-api/src/purchase/dto/update-purchase-order-item.dto.ts
@@ -1,0 +1,15 @@
+import {
+  IsOptional,
+  IsInt,
+  IsNumber,
+} from 'class-validator';
+
+export class UpdatePurchaseOrderItemDto {
+  @IsOptional()
+  @IsInt()
+  quantity?: number;
+
+  @IsOptional()
+  @IsNumber()
+  unitCost?: number;
+}

--- a/apps/core-api/src/purchase/purchase.controller.ts
+++ b/apps/core-api/src/purchase/purchase.controller.ts
@@ -15,6 +15,8 @@ import { PurchaseService } from './purchase.service';
 import { QueryBuilder } from '../common/utils/query-builder';
 import { CreatePurchaseOrderDto } from './dto/create-purchase-order.dto';
 import { ReceivePurchaseOrderDto } from './dto/receive-items.dto';
+import { AddPurchaseOrderItemsDto } from './dto/add-purchase-order-items.dto';
+import { UpdatePurchaseOrderItemDto } from './dto/update-purchase-order-item.dto';
 import type { Prisma } from '@prisma/client';
 
 @Controller('purchase-orders')
@@ -159,18 +161,18 @@ export class PurchaseController {
   @Post(':id/items')
   async addItems(
     @Param('id') orderId: string,
-    @Body() dto: CreatePurchaseOrderDto['items'],
+    @Body() dto: AddPurchaseOrderItemsDto,
   ) {
-    return this.purchaseService.addItemsToPurchaseOrder(orderId, dto);
+    return this.purchaseService.addItemsToPurchaseOrder(orderId, dto.items);
   }
 
   @Patch(':id/items/:itemId')
   async updateItem(
     @Param('id') orderId: string,
     @Param('itemId') itemId: string,
-    @Body() updates: { quantity?: number; unitCost?: number },
+    @Body() dto: UpdatePurchaseOrderItemDto,
   ) {
-    return this.purchaseService.updatePurchaseOrderItem(orderId, itemId, updates);
+    return this.purchaseService.updatePurchaseOrderItem(orderId, itemId, dto);
   }
 
   @Delete(':id/items/:itemId')

--- a/apps/core-api/src/purchase/purchase.controller.ts
+++ b/apps/core-api/src/purchase/purchase.controller.ts
@@ -8,6 +8,7 @@ import {
   BadRequestException,
   Query,
   HttpCode,
+  Patch,
 } from '@nestjs/common';
 import { ApiQuery } from '@nestjs/swagger';
 import { PurchaseService } from './purchase.service';
@@ -153,5 +154,30 @@ export class PurchaseController {
   @Delete(':id')
   async remove(@Param('id') id: string) {
     return this.purchaseService.remove(id);
+  }
+
+  @Post(':id/items')
+  async addItems(
+    @Param('id') orderId: string,
+    @Body() dto: CreatePurchaseOrderDto['items'],
+  ) {
+    return this.purchaseService.addItemsToPurchaseOrder(orderId, dto);
+  }
+
+  @Patch(':id/items/:itemId')
+  async updateItem(
+    @Param('id') orderId: string,
+    @Param('itemId') itemId: string,
+    @Body() updates: { quantity?: number; unitCost?: number },
+  ) {
+    return this.purchaseService.updatePurchaseOrderItem(orderId, itemId, updates);
+  }
+
+  @Delete(':id/items/:itemId')
+  async deleteItem(
+    @Param('id') orderId: string,
+    @Param('itemId') itemId: string,
+  ) {
+    return this.purchaseService.deleteItemFromPurchaseOrder(orderId, itemId);
   }
 }

--- a/apps/core-api/src/purchase/purchase.service.ts
+++ b/apps/core-api/src/purchase/purchase.service.ts
@@ -32,7 +32,10 @@ export class PurchaseService {
       .padStart(4, '0')}`;
   }
 
-  private recomputePurchaseOrderStatus(items: Array<{ quantity: number; quantity_received: number }>): PurchaseOrderStatus {
+  private recomputePurchaseOrderStatus(
+    items: Array<{ quantity: number; quantity_received: number }>,
+    previousStatus?: PurchaseOrderStatus,
+  ): PurchaseOrderStatus {
     if (items.length === 0) {
       return PurchaseOrderStatus.DRAFT;
     }
@@ -46,7 +49,10 @@ export class PurchaseService {
     } else if (totalReceived > 0) {
       return PurchaseOrderStatus.PARTIAL;
     } else {
-      return PurchaseOrderStatus.DRAFT;
+      // No items received yet - preserve SENT status if it was previously SENT, otherwise DRAFT
+      return previousStatus === PurchaseOrderStatus.SENT
+        ? PurchaseOrderStatus.SENT
+        : PurchaseOrderStatus.DRAFT;
     }
   }
 
@@ -256,6 +262,17 @@ export class PurchaseService {
     });
     if (!po) throw new NotFoundException('Purchase Order not found');
 
+    // Check for duplicate catalogItemIds within the incoming payload
+    const seenIds = new Set<string>();
+    for (const item of items) {
+      if (seenIds.has(item.catalogItemId)) {
+        throw new BadRequestException(
+          `Duplicate item in request: ${item.catalogItemId}`,
+        );
+      }
+      seenIds.add(item.catalogItemId);
+    }
+
     const itemIds = items.map((i) => i.catalogItemId);
     const catalogItems = await this.prisma.catalogItem.findMany({
       where: { id: { in: itemIds } },
@@ -292,39 +309,47 @@ export class PurchaseService {
       }
     }
 
-    // Add items to PO
-    const createdItems = await Promise.all(
-      items.map((i) =>
-        this.prisma.purchaseOrderItem.create({
-          data: {
-            purchase_order_id: orderId,
-            catalog_item_id: i.catalogItemId,
-            quantity: i.quantity,
-            unit_cost: i.unitCost,
-            quantity_received: 0,
+    // Add items to PO in a transaction
+    return this.prisma.$transaction(async (tx) => {
+      // Create all items
+      await Promise.all(
+        items.map((i) =>
+          tx.purchaseOrderItem.create({
+            data: {
+              purchase_order_id: orderId,
+              catalog_item_id: i.catalogItemId,
+              quantity: i.quantity,
+              unit_cost: i.unitCost,
+              quantity_received: 0,
+            },
+          }),
+        ),
+      );
+
+      // Re-read the PO with updated items
+      const updatedPO = await tx.purchaseOrder.findUnique({
+        where: { id: orderId },
+        include: { items: true },
+      });
+      if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+
+      // Recompute status, preserving previous status if needed
+      const newStatus = this.recomputePurchaseOrderStatus(
+        updatedPO.items,
+        po.status,
+      );
+
+      // Update status and return full PO
+      return tx.purchaseOrder.update({
+        where: { id: orderId },
+        data: { status: newStatus },
+        include: {
+          vendor: true,
+          items: {
+            include: { catalog_item: true },
           },
-        }),
-      ),
-    );
-
-    // Recompute status and update order
-    const updatedPO = await this.prisma.purchaseOrder.findUnique({
-      where: { id: orderId },
-      include: { items: true },
-    });
-    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
-
-    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
-    
-    return this.prisma.purchaseOrder.update({
-      where: { id: orderId },
-      data: { status: newStatus },
-      include: {
-        vendor: true,
-        items: {
-          include: { catalog_item: true },
         },
-      },
+      });
     });
   }
 
@@ -355,29 +380,36 @@ export class PurchaseService {
     if (updates.quantity !== undefined) prismaUpdates.quantity = updates.quantity;
     if (updates.unitCost !== undefined) prismaUpdates.unit_cost = updates.unitCost;
 
-    await this.prisma.purchaseOrderItem.update({
-      where: { id: itemId },
-      data: prismaUpdates,
-    });
+    // Update in a transaction
+    return this.prisma.$transaction(async (tx) => {
+      await tx.purchaseOrderItem.update({
+        where: { id: itemId },
+        data: prismaUpdates,
+      });
 
-    // Recompute status and return updated PO
-    const updatedPO = await this.prisma.purchaseOrder.findUnique({
-      where: { id: orderId },
-      include: { items: true },
-    });
-    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+      // Re-read the PO with updated items
+      const updatedPO = await tx.purchaseOrder.findUnique({
+        where: { id: orderId },
+        include: { items: true },
+      });
+      if (!updatedPO) throw new NotFoundException('Purchase Order not found');
 
-    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
+      // Recompute status, preserving previous status if needed
+      const newStatus = this.recomputePurchaseOrderStatus(
+        updatedPO.items,
+        po.status,
+      );
 
-    return this.prisma.purchaseOrder.update({
-      where: { id: orderId },
-      data: { status: newStatus },
-      include: {
-        vendor: true,
-        items: {
-          include: { catalog_item: true },
+      return tx.purchaseOrder.update({
+        where: { id: orderId },
+        data: { status: newStatus },
+        include: {
+          vendor: true,
+          items: {
+            include: { catalog_item: true },
+          },
         },
-      },
+      });
     });
   }
 
@@ -398,28 +430,35 @@ export class PurchaseService {
       );
     }
 
-    await this.prisma.purchaseOrderItem.delete({
-      where: { id: itemId },
-    });
+    // Delete in a transaction
+    return this.prisma.$transaction(async (tx) => {
+      await tx.purchaseOrderItem.delete({
+        where: { id: itemId },
+      });
 
-    // Recompute status and return updated PO
-    const updatedPO = await this.prisma.purchaseOrder.findUnique({
-      where: { id: orderId },
-      include: { items: true },
-    });
-    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+      // Re-read the PO with updated items
+      const updatedPO = await tx.purchaseOrder.findUnique({
+        where: { id: orderId },
+        include: { items: true },
+      });
+      if (!updatedPO) throw new NotFoundException('Purchase Order not found');
 
-    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
+      // Recompute status, preserving previous status if needed
+      const newStatus = this.recomputePurchaseOrderStatus(
+        updatedPO.items,
+        po.status,
+      );
 
-    return this.prisma.purchaseOrder.update({
-      where: { id: orderId },
-      data: { status: newStatus },
-      include: {
-        vendor: true,
-        items: {
-          include: { catalog_item: true },
+      return tx.purchaseOrder.update({
+        where: { id: orderId },
+        data: { status: newStatus },
+        include: {
+          vendor: true,
+          items: {
+            include: { catalog_item: true },
+          },
         },
-      },
+      });
     });
   }
 

--- a/apps/core-api/src/purchase/purchase.service.ts
+++ b/apps/core-api/src/purchase/purchase.service.ts
@@ -32,6 +32,24 @@ export class PurchaseService {
       .padStart(4, '0')}`;
   }
 
+  private recomputePurchaseOrderStatus(items: Array<{ quantity: number; quantity_received: number }>): PurchaseOrderStatus {
+    if (items.length === 0) {
+      return PurchaseOrderStatus.DRAFT;
+    }
+
+    const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0);
+    const totalReceived = items.reduce((sum, item) => sum + item.quantity_received, 0);
+    const totalRemaining = totalQuantity - totalReceived;
+
+    if (totalRemaining === 0) {
+      return PurchaseOrderStatus.COMPLETED;
+    } else if (totalReceived > 0) {
+      return PurchaseOrderStatus.PARTIAL;
+    } else {
+      return PurchaseOrderStatus.DRAFT;
+    }
+  }
+
   async createPurchaseOrder(
     vendorId: string,
     items: { catalogItemId: string; quantity: number; unitCost: number }[],
@@ -228,6 +246,183 @@ export class PurchaseService {
     }
   }
 
+  async addItemsToPurchaseOrder(
+    orderId: string,
+    items: { catalogItemId: string; quantity: number; unitCost: number }[],
+  ) {
+    const po = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { vendor: { include: { supportedBrands: true } }, items: true },
+    });
+    if (!po) throw new NotFoundException('Purchase Order not found');
+
+    const itemIds = items.map((i) => i.catalogItemId);
+    const catalogItems = await this.prisma.catalogItem.findMany({
+      where: { id: { in: itemIds } },
+      include: { brand: true },
+    });
+
+    for (const item of items) {
+      const catalogItem = catalogItems.find((c) => c.id === item.catalogItemId);
+      if (!catalogItem)
+        throw new BadRequestException(
+          `Catalog Item ${item.catalogItemId} not found`,
+        );
+
+      if (
+        catalogItem.brand &&
+        !po.vendor.supportedBrands.some((b) => b.id === catalogItem.brand_id)
+      ) {
+        const supportedNames = po.vendor.supportedBrands
+          .map((b) => b.name)
+          .join(', ');
+        throw new BadRequestException(
+          `Vendor ${po.vendor.name} does not support brand ${catalogItem.brand.name}. Supported: ${supportedNames}`,
+        );
+      }
+
+      // Check if item already exists in PO
+      const existingItem = po.items.find(
+        (i) => i.catalog_item_id === item.catalogItemId,
+      );
+      if (existingItem) {
+        throw new BadRequestException(
+          `Item ${catalogItem.name} is already in this purchase order`,
+        );
+      }
+    }
+
+    // Add items to PO
+    const createdItems = await Promise.all(
+      items.map((i) =>
+        this.prisma.purchaseOrderItem.create({
+          data: {
+            purchase_order_id: orderId,
+            catalog_item_id: i.catalogItemId,
+            quantity: i.quantity,
+            unit_cost: i.unitCost,
+            quantity_received: 0,
+          },
+        }),
+      ),
+    );
+
+    // Recompute status and update order
+    const updatedPO = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+
+    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
+    
+    return this.prisma.purchaseOrder.update({
+      where: { id: orderId },
+      data: { status: newStatus },
+      include: {
+        vendor: true,
+        items: {
+          include: { catalog_item: true },
+        },
+      },
+    });
+  }
+
+  async updatePurchaseOrderItem(
+    orderId: string,
+    itemId: string,
+    updates: { quantity?: number; unitCost?: number },
+  ) {
+    const po = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+    if (!po) throw new NotFoundException('Purchase Order not found');
+
+    const poItem = po.items.find((i) => i.id === itemId);
+    if (!poItem)
+      throw new BadRequestException('Item not found in this purchase order');
+
+    // Validate that new quantity is not less than already received
+    if (updates.quantity !== undefined && updates.quantity < poItem.quantity_received) {
+      throw new BadRequestException(
+        `Cannot reduce quantity below ${poItem.quantity_received} already received`,
+      );
+    }
+
+    // Map camelCase to snake_case for Prisma
+    const prismaUpdates: Record<string, any> = {};
+    if (updates.quantity !== undefined) prismaUpdates.quantity = updates.quantity;
+    if (updates.unitCost !== undefined) prismaUpdates.unit_cost = updates.unitCost;
+
+    await this.prisma.purchaseOrderItem.update({
+      where: { id: itemId },
+      data: prismaUpdates,
+    });
+
+    // Recompute status and return updated PO
+    const updatedPO = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+
+    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
+
+    return this.prisma.purchaseOrder.update({
+      where: { id: orderId },
+      data: { status: newStatus },
+      include: {
+        vendor: true,
+        items: {
+          include: { catalog_item: true },
+        },
+      },
+    });
+  }
+
+  async deleteItemFromPurchaseOrder(orderId: string, itemId: string) {
+    const po = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+    if (!po) throw new NotFoundException('Purchase Order not found');
+
+    const poItem = po.items.find((i) => i.id === itemId);
+    if (!poItem)
+      throw new BadRequestException('Item not found in this purchase order');
+
+    if (poItem.quantity_received > 0) {
+      throw new BadRequestException(
+        'Cannot delete an item that has already been received',
+      );
+    }
+
+    await this.prisma.purchaseOrderItem.delete({
+      where: { id: itemId },
+    });
+
+    // Recompute status and return updated PO
+    const updatedPO = await this.prisma.purchaseOrder.findUnique({
+      where: { id: orderId },
+      include: { items: true },
+    });
+    if (!updatedPO) throw new NotFoundException('Purchase Order not found');
+
+    const newStatus = this.recomputePurchaseOrderStatus(updatedPO.items);
+
+    return this.prisma.purchaseOrder.update({
+      where: { id: orderId },
+      data: { status: newStatus },
+      include: {
+        vendor: true,
+        items: {
+          include: { catalog_item: true },
+        },
+      },
+    });
+  }
+
   async findAll(
     params: Prisma.PurchaseOrderFindManyArgs,
   ): Promise<PaginatedPurchaseOrderResult>;
@@ -279,7 +474,7 @@ export class PurchaseService {
     return this.prisma.purchaseOrder.findUnique({
       where: { id },
       include: {
-        vendor: true,
+        vendor: { include: { supportedBrands: true } },
         items: {
           include: { catalog_item: true },
         },

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -196,6 +196,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/purchase-orders/{id}/items": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["PurchaseController_addItems"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/purchase-orders/{id}/items/{itemId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: operations["PurchaseController_deleteItem"];
+        options?: never;
+        head?: never;
+        patch: operations["PurchaseController_updateItem"];
+        trace?: never;
+    };
     "/api/purchase-invoices": {
         parameters: {
             query?: never;
@@ -733,6 +765,8 @@ export interface components {
         UpdateLocationDto: Record<string, never>;
         CreatePurchaseOrderDto: Record<string, never>;
         ReceivePurchaseOrderDto: Record<string, never>;
+        AddPurchaseOrderItemsDto: Record<string, never>;
+        UpdatePurchaseOrderItemDto: Record<string, never>;
         CreatePurchaseInvoiceDto: Record<string, never>;
         CreateVendorDto: Record<string, never>;
         UpdateVendorDto: Record<string, never>;
@@ -1172,6 +1206,73 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PurchaseController_addItems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddPurchaseOrderItemsDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PurchaseController_deleteItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    PurchaseController_updateItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePurchaseOrderItemDto"];
+            };
+        };
         responses: {
             200: {
                 headers: {

--- a/apps/core-web/src/api/purchase-orders.ts
+++ b/apps/core-web/src/api/purchase-orders.ts
@@ -76,6 +76,61 @@ export function useReceiveGoods() {
     })
 }
 
+export function useAddPOItems() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({ orderId, items }: { orderId: string; items: { catalogItemId: string; quantity: number; unitCost: number }[] }) => {
+            const res = await fetchWithAuth(`${PO_API}/${orderId}/items`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(items),
+            })
+            if (!res.ok) throw new Error('Failed to add items to PO')
+            return res.json()
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders', variables.orderId] })
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders'] })
+        },
+    })
+}
+
+export function useUpdatePOItem() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({ orderId, itemId, updates }: { orderId: string; itemId: string; updates: { quantity?: number; unitCost?: number } }) => {
+            const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updates),
+            })
+            if (!res.ok) throw new Error('Failed to update PO item')
+            return res.json()
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders', variables.orderId] })
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders'] })
+        },
+    })
+}
+
+export function useDeletePOItem() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({ orderId, itemId }: { orderId: string; itemId: string }) => {
+            const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
+                method: 'DELETE',
+            })
+            if (!res.ok) throw new Error('Failed to delete PO item')
+            return res.json()
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders', variables.orderId] })
+            queryClient.invalidateQueries({ queryKey: ['purchase-orders'] })
+        },
+    })
+}
+
 export function useDeletePurchaseOrder() {
     const queryClient = useQueryClient()
     return useMutation({
@@ -94,3 +149,4 @@ export function useDeletePurchaseOrder() {
         },
     })
 }
+

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
@@ -89,6 +89,7 @@ export default function PurchaseOrderCreate() {
                                     className="h-24 flex flex-col gap-2 p-4"
                                     onClick={() => {
                                         setSelectedBrand(brand)
+                                        setSelectedVendorId('')
                                         setStep(2)
                                     }}
                                 >

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderCreate.tsx
@@ -1,43 +1,13 @@
 import { useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useVendors } from '@/api/vendors'
-import { useInventory } from '@/api/inventory'
 import { useCreatePO } from '@/api/purchase-orders'
 import { useBrands } from '@/api/brands'
 import { Button } from '@/components/ui/button'
 import { toast } from "sonner"
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table'
-import { Command, CommandInput, CommandList, CommandItem, CommandEmpty, CommandGroup } from '@/components/ui/command'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Check, ChevronsUpDown, Trash2, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Loader2 } from 'lucide-react'
 import type { Brand, Vendor } from '@/api/types'
-
-interface POItem {
-    catalogItemId: string
-    name: string
-    sku: string
-    quantity: number
-    unitCost: number
-}
-
-interface InventoryItem {
-    id: string
-    name: string
-    sku: string
-    price: number
-    quantity_available: number
-    brand: string
-}
 
 export default function PurchaseOrderCreate() {
     const navigate = useNavigate()
@@ -67,49 +37,17 @@ export default function PurchaseOrderCreate() {
 
     const [selectedVendorId, setSelectedVendorId] = useState<string>(computeValidVendorId())
 
-    // Step 3: Items
-    const [items, setItems] = useState<POItem[]>([])
-    const [itemSearch, setItemSearch] = useState('')
-    const { data: inventoryResponse } = useInventory({ search: itemSearch, pageSize: 10, brand: selectedBrand?.name })
-    const inventory = inventoryResponse as any; // Cast for now as response structure handles data/meta
-
-    const [openCombobox, setOpenCombobox] = useState(false)
-
     const createPO = useCreatePO()
 
     const filteredVendors = vendors?.filter((v: Vendor) =>
         selectedBrand ? v.supportedBrands.some((b: Brand) => b.id === selectedBrand.id) : true
     )
 
-    const handleAddItem = (item: InventoryItem) => {
-        if (items.find(i => i.catalogItemId === item.id)) return
-        setItems([...items, {
-            catalogItemId: item.id,
-            name: item.name,
-            sku: item.sku,
-            quantity: 1,
-            unitCost: item.price
-        }])
-        setOpenCombobox(false)
-    }
-
-    const updateItem = (id: string, field: 'quantity' | 'unitCost', value: number) => {
-        setItems(items.map(i => i.catalogItemId === id ? { ...i, [field]: value } : i))
-    }
-
-    const removeItem = (id: string) => {
-        setItems(items.filter(i => i.catalogItemId !== id))
-    }
-
-    const handleSubmit = () => {
-        if (!selectedVendorId || items.length === 0) return
+    const handleCreatePO = () => {
+        if (!selectedVendorId) return
         createPO.mutate({
             vendorId: selectedVendorId,
-            items: items.map(i => ({
-                catalogItemId: i.catalogItemId,
-                quantity: i.quantity,
-                unitCost: i.unitCost
-            }))
+            items: [], // Create empty PO
         }, {
             onSuccess: (data) => navigate(`/purchase-orders/${data.id}`),
             onError: (error) => {
@@ -130,7 +68,7 @@ export default function PurchaseOrderCreate() {
 
             {/* Steps Indicator */}
             <div className="flex space-x-4 mb-8">
-                {[1, 2, 3].map(s => (
+                {[1, 2].map(s => (
                     <div key={s} className={cn("h-2 flex-1 rounded-full", s <= step ? "bg-primary" : "bg-muted")} />
                 ))}
             </div>
@@ -149,7 +87,10 @@ export default function PurchaseOrderCreate() {
                                     key={brand.id}
                                     variant={selectedBrand?.id === brand.id ? "default" : "outline"}
                                     className="h-24 flex flex-col gap-2 p-4"
-                                    onClick={() => setSelectedBrand(brand)}
+                                    onClick={() => {
+                                        setSelectedBrand(brand)
+                                        setStep(2)
+                                    }}
                                 >
                                     {brand.logoUrl && <img src={brand.logoUrl} className="h-8 object-contain" alt="" />}
                                     <span className={brand.logoUrl ? "text-xs" : "text-lg"}>{brand.name}</span>
@@ -157,9 +98,6 @@ export default function PurchaseOrderCreate() {
                             ))}
                         </div>
                     )}
-                    <div className="flex justify-end mt-8">
-                        <Button onClick={() => setStep(2)} disabled={!selectedBrand}>Next</Button>
-                    </div>
                 </div>
             )}
 
@@ -192,114 +130,10 @@ export default function PurchaseOrderCreate() {
 
                     <div className="flex justify-between mt-8">
                         <Button variant="outline" onClick={() => setStep(1)}>Back</Button>
-                        <Button onClick={() => setStep(3)} disabled={!selectedVendorId}>Next</Button>
-                    </div>
-                </div>
-            )}
-
-            {step === 3 && (
-                <div className="space-y-4">
-                    <h2 className="text-xl font-semibold">Step 3: Add Items</h2>
-
-                    {/* Item Search */}
-                    <div className="flex flex-col space-y-2">
-                        <Label>Search Catalog</Label>
-                        <Popover open={openCombobox} onOpenChange={setOpenCombobox}>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    aria-expanded={openCombobox}
-                                    className="w-full justify-between"
-                                >
-                                    Select item...
-                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-[400px] p-0" align="start">
-                                <Command shouldFilter={false}>
-                                    <CommandInput placeholder="Search SKU or Name..." onValueChange={setItemSearch} />
-                                    <CommandList>
-                                        <CommandEmpty>No item found.</CommandEmpty>
-                                        <CommandGroup>
-                                            {inventory?.data.map((item: InventoryItem) => (
-                                                <CommandItem
-                                                    key={item.id}
-                                                    value={item.id}
-                                                    onSelect={() => handleAddItem(item)}
-                                                >
-                                                    <Check
-                                                        className={cn(
-                                                            "mr-2 h-4 w-4",
-                                                            items.find(i => i.catalogItemId === item.id) ? "opacity-100" : "opacity-0"
-                                                        )}
-                                                    />
-                                                    <div className="flex flex-col">
-                                                        <span>{item.sku} - {item.name}</span>
-                                                        <span className="text-xs text-muted-foreground">Stock: {item.quantity_available} | {item.brand}</span>
-                                                    </div>
-                                                </CommandItem>
-                                            ))}
-                                        </CommandGroup>
-                                    </CommandList>
-                                </Command>
-                            </PopoverContent>
-                        </Popover>
-                    </div>
-
-                    {/* Items Table */}
-                    <div className="border rounded-md">
-                        <Table>
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead>SKU</TableHead>
-                                    <TableHead>Name</TableHead>
-                                    <TableHead className="w-[100px]">Qty</TableHead>
-                                    <TableHead className="w-[100px]">Cost</TableHead>
-                                    <TableHead className="w-[50px]"></TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {items.map(item => (
-                                    <TableRow key={item.catalogItemId}>
-                                        <TableCell>{item.sku}</TableCell>
-                                        <TableCell>{item.name}</TableCell>
-                                        <TableCell>
-                                            <Input
-                                                type="number"
-                                                min="1"
-                                                value={item.quantity}
-                                                onChange={(e) => updateItem(item.catalogItemId, 'quantity', parseInt(e.target.value))}
-                                            />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Input
-                                                type="number"
-                                                min="0"
-                                                step="0.01"
-                                                value={item.unitCost}
-                                                onChange={(e) => updateItem(item.catalogItemId, 'unitCost', parseFloat(e.target.value))}
-                                            />
-                                        </TableCell>
-                                        <TableCell>
-                                            <Button size="icon" variant="ghost" onClick={() => removeItem(item.catalogItemId)}>
-                                                <Trash2 className="h-4 w-4 text-red-500" />
-                                            </Button>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                                {items.length === 0 && (
-                                    <TableRow>
-                                        <TableCell colSpan={5} className="text-center text-muted-foreground">No items added yet.</TableCell>
-                                    </TableRow>
-                                )}
-                            </TableBody>
-                        </Table>
-                    </div>
-
-                    <div className="flex justify-between mt-8">
-                        <Button variant="outline" onClick={() => setStep(2)}>Back</Button>
-                        <Button onClick={handleSubmit} disabled={items.length === 0 || createPO.isPending}>
+                        <Button 
+                            onClick={handleCreatePO} 
+                            disabled={!selectedVendorId || createPO.isPending}
+                        >
                             {createPO.isPending ? 'Creating...' : 'Create Purchase Order'}
                         </Button>
                     </div>

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
@@ -167,14 +167,19 @@ export default function PurchaseOrderDetail() {
     function confirmAddItem() {
         if (!stagedItem || !id || !po) return
         const qty = Number(newQty)
-        const safeQty = Number.isFinite(qty) && qty > 0 ? qty : 1
+        
+        // Validate quantity strictly - don't silently default to 1
+        if (!Number.isFinite(qty) || qty <= 0) {
+            toast.error('Invalid quantity', { description: 'Please enter a positive number' })
+            return
+        }
 
         // Check if item already exists in the PO
         const existingItem = po.items.find((item: any) => item.catalog_item_id === stagedItem.id)
 
         if (existingItem) {
             // Item exists - update quantity by adding the new quantity
-            const newTotalQty = existingItem.quantity + safeQty
+            const newTotalQty = existingItem.quantity + qty
             updateItem.mutate({
                 orderId: id,
                 itemId: existingItem.id,
@@ -195,7 +200,7 @@ export default function PurchaseOrderDetail() {
                 orderId: id,
                 items: [{
                     catalogItemId: stagedItem.id,
-                    quantity: safeQty,
+                    quantity: qty,
                     unitCost: stagedItem.price,
                 }]
             }, {

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { usePurchaseOrder, useReceiveGoods } from '@/api/purchase-orders'
+import { motion } from 'framer-motion'
+import { usePurchaseOrder, useReceiveGoods, useAddPOItems, useUpdatePOItem, useDeletePOItem } from '@/api/purchase-orders'
+import { useInventory } from '@/api/inventory'
 import { useUnbilledReceipts } from '@/api/usePurchaseInvoices'
 import { Button } from '@/components/ui/button'
 import { toast } from "sonner"
@@ -23,20 +25,244 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { StatusBadge } from '@/components/status/StatusBadge'
+import { Command, CommandList, CommandItem, CommandEmpty, CommandGroup } from '@/components/ui/command'
 import type { PurchaseOrder, PurchaseOrderItem } from '@/api/types'
-import { Receipt } from "lucide-react"
+import { Receipt, Trash2 } from "lucide-react"
+
+interface InventoryItem {
+    id: string
+    name: string
+    sku: string
+    price: number
+    quantity_available: number
+    brand: string
+}
+
+interface StagedPOItem {
+    id: string
+    name: string
+    sku: string
+    price: number
+}
 
 export default function PurchaseOrderDetail() {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
     const { data: po, isLoading, error } = usePurchaseOrder(id!)
     const [isReceiveDialogOpen, setIsReceiveDialogOpen] = useState(false)
+    const [editingItemId, setEditingItemId] = useState<string | null>(null)
+    const [editingQty, setEditingQty] = useState<string>('')
+
+    // Animation state
+    const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null)
+    const [poppedQtyRowId, setPoppedQtyRowId] = useState<string | null>(null)
+    const rowFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const qtyPopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    // Item search state - inline pattern
+    const [searchQuery, setSearchQuery] = useState('')
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
+    const [newQty, setNewQty] = useState('1')
+    const [stagedItem, setStagedItem] = useState<StagedPOItem | null>(null)
+    const [showSuggestions, setShowSuggestions] = useState(false)
+
+    const itemInputRef = useRef<HTMLInputElement | null>(null)
+    const qtyInputRef = useRef<HTMLInputElement | null>(null)
+
+    // Debounce search
+    useEffect(() => {
+        const timeout = window.setTimeout(() => {
+            setDebouncedSearchQuery(searchQuery.trim())
+        }, 300)
+        return () => window.clearTimeout(timeout)
+    }, [searchQuery])
+
+    // Fetch inventory for item search - filter by vendor's supported brands
+    const vendorBrandNames = po?.vendor?.supportedBrands?.map((b: any) => b.name) ?? []
+    
+    // Fetch larger page size to ensure vendor-brand filtered results include all valid items
+    // We filter client-side, so we need to fetch enough items to get a good set after filtering
+    const { data: inventoryResponse } = useInventory({
+        search: debouncedSearchQuery,
+        pageSize: 100, // Increased from 10 to ensure we have valid items after brand filtering
+        brand: vendorBrandNames.length > 0 ? undefined : undefined
+    })
+    const inventory = inventoryResponse as any
+    
+    // Filter inventory items to only show those from vendor's supported brands
+    const filteredInventory = inventory?.data?.filter((item: InventoryItem) => 
+        vendorBrandNames.includes(item.brand)
+    ) ?? []
+
+    // Mutations
+    const addItems = useAddPOItems()
+    const updateItem = useUpdatePOItem()
+    const deleteItem = useDeletePOItem()
 
     // Fetch unbilled receipts for this vendor to calculate count related to this PO
     const { data: unbilledItems = [] } = useUnbilledReceipts(po?.vendor_id)
 
     // Filter unbilled items for this specific PO
     const poUnbilledCount = unbilledItems.filter(item => item.purchaseOrderNumber === po?.order_number).length
+
+    const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault()
+            const firstPart = filteredInventory?.[0]
+            if (firstPart) {
+                stagePart(firstPart)
+            }
+        }
+    }
+
+    const handleQtyKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault()
+            confirmAddItem()
+        }
+    }
+
+    function stagePart(item: InventoryItem) {
+        setStagedItem({
+            id: item.id,
+            name: item.name,
+            sku: item.sku,
+            price: item.price,
+        })
+        setSearchQuery(`${item.sku} · ${item.name}`)
+        setDebouncedSearchQuery('')
+        setNewQty('1')
+        setShowSuggestions(false)
+        requestAnimationFrame(() => {
+            qtyInputRef.current?.focus()
+            qtyInputRef.current?.select()
+        })
+    }
+
+    function clearQuickEntry() {
+        setSearchQuery('')
+        setDebouncedSearchQuery('')
+        setStagedItem(null)
+        setNewQty('1')
+        requestAnimationFrame(() => itemInputRef.current?.focus())
+    }
+
+    function triggerMergeFeedback(itemId: string) {
+        if (rowFlashTimeoutRef.current) {
+            window.clearTimeout(rowFlashTimeoutRef.current)
+        }
+        if (qtyPopTimeoutRef.current) {
+            window.clearTimeout(qtyPopTimeoutRef.current)
+        }
+        setHighlightedRowId(itemId)
+        setPoppedQtyRowId(itemId)
+        rowFlashTimeoutRef.current = window.setTimeout(() => {
+            setHighlightedRowId(null)
+        }, 500)
+        qtyPopTimeoutRef.current = window.setTimeout(() => {
+            setPoppedQtyRowId(null)
+        }, 240)
+    }
+
+    function confirmAddItem() {
+        if (!stagedItem || !id || !po) return
+        const qty = Number(newQty)
+        const safeQty = Number.isFinite(qty) && qty > 0 ? qty : 1
+
+        // Check if item already exists in the PO
+        const existingItem = po.items.find((item: any) => item.catalog_item_id === stagedItem.id)
+
+        if (existingItem) {
+            // Item exists - update quantity by adding the new quantity
+            const newTotalQty = existingItem.quantity + safeQty
+            updateItem.mutate({
+                orderId: id,
+                itemId: existingItem.id,
+                updates: { quantity: newTotalQty }
+            }, {
+                onSuccess: () => {
+                    toast.success(`Quantity updated to ${newTotalQty}`)
+                    triggerMergeFeedback(existingItem.id)
+                    clearQuickEntry()
+                },
+                onError: (error) => {
+                    toast.error('Failed to update item', { description: error.message })
+                }
+            })
+        } else {
+            // Item doesn't exist - add as new
+            addItems.mutate({
+                orderId: id,
+                items: [{
+                    catalogItemId: stagedItem.id,
+                    quantity: safeQty,
+                    unitCost: stagedItem.price,
+                }]
+            }, {
+                onSuccess: () => {
+                    toast.success('Item added to PO')
+                    clearQuickEntry()
+                },
+                onError: (error) => {
+                    toast.error('Failed to add item', { description: error.message })
+                }
+            })
+        }
+    }
+
+    const handleUpdateItemQty = (itemId: string, newQty: string) => {
+        const qty = Number(newQty)
+        if (!Number.isFinite(qty) || qty <= 0) return
+
+        if (!po) return
+
+        // Find the item to check quantity_received
+        const item = po.items.find((i: PurchaseOrderItem) => i.id === itemId)
+        if (!item) return
+
+        // Validate that new quantity is not less than already received
+        if (qty < item.quantity_received) {
+            toast.error('Invalid quantity', { 
+                description: `Cannot reduce quantity below ${item.quantity_received} already received`
+            })
+            setEditingItemId(null)
+            setEditingQty('')
+            return
+        }
+
+        if (!id) return
+        updateItem.mutate({
+            orderId: id,
+            itemId,
+            updates: { quantity: qty }
+        }, {
+            onSuccess: () => {
+                toast.success('Item quantity updated')
+                setEditingItemId(null)
+                setEditingQty('')
+            },
+            onError: (error) => {
+                toast.error('Failed to update item', { description: error.message })
+            }
+        })
+    }
+
+    const handleDeleteItem = (itemId: string) => {
+        if (!id) return
+        if (confirm('Are you sure you want to delete this item?')) {
+            deleteItem.mutate({
+                orderId: id,
+                itemId,
+            }, {
+                onSuccess: () => {
+                    toast.success('Item deleted')
+                },
+                onError: (error) => {
+                    toast.error('Failed to delete item', { description: error.message })
+                }
+            })
+        }
+    }
 
     if (isLoading) return <div>Loading order...</div>
     if (error) return <div>Error loading order</div>
@@ -114,8 +340,92 @@ export default function PurchaseOrderDetail() {
                         <CardHeader>
                             <CardTitle className="text-base font-semibold">Line Items</CardTitle>
                         </CardHeader>
-                        <CardContent className="p-0 overflow-x-auto">
-                            <Table className="min-w-[700px]">
+                        <CardContent className="space-y-2 p-3">
+                            {/* Inline Item Search & Add Panel */}
+                            <div className="border rounded-xl bg-muted/40 px-3 py-2">
+                                <div className="grid grid-cols-[1fr_70px_auto] gap-2">
+                                    <div className="relative">
+                                        <Input
+                                            ref={itemInputRef}
+                                            value={searchQuery}
+                                            onChange={(e) => {
+                                                if (stagedItem) {
+                                                    setStagedItem(null)
+                                                }
+                                                setSearchQuery(e.target.value)
+                                            }}
+                                            onKeyDown={handleSearchKeyDown}
+                                            onFocus={() => setShowSuggestions(true)}
+                                            placeholder="Search part number or name..."
+                                            className="h-8 text-xs"
+                                        />
+                                        {showSuggestions && debouncedSearchQuery && (
+                                            <div className="absolute left-0 right-0 top-full z-20 mt-1 rounded-md border bg-popover shadow-md">
+                                                <Command shouldFilter={false}>
+                                                    <CommandList className="max-h-64">
+                                                        {filteredInventory.length === 0 && (
+                                                            <CommandEmpty>
+                                                                {vendorBrandNames.length === 0 
+                                                                    ? 'No vendor brands configured.' 
+                                                                    : 'No parts found for this vendor\'s brands.'}
+                                                            </CommandEmpty>
+                                                        )}
+                                                        {filteredInventory.length > 0 && (
+                                                            <CommandGroup heading="Parts">
+                                                                {filteredInventory.map((item: InventoryItem) => {
+                                                                    return (
+                                                                        <CommandItem
+                                                                            key={item.id}
+                                                                            value={`${item.sku} ${item.name}`}
+                                                                            onSelect={() => stagePart(item)}
+                                                                        >
+                                                                            <div className="flex w-full items-center justify-between gap-2">
+                                                                                <div className="min-w-0">
+                                                                                    <div className="text-xs font-medium">{item.sku}</div>
+                                                                                    <div className="truncate text-xs text-muted-foreground">
+                                                                                        {item.name}
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div className="shrink-0 text-right text-xs text-muted-foreground">
+                                                                                    <div>{formatCurrency(item.price)}</div>
+                                                                                    <div>Stock: {item.quantity_available}</div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </CommandItem>
+                                                                    )
+                                                                })}
+                                                            </CommandGroup>
+                                                        )}
+                                                    </CommandList>
+                                                </Command>
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    <Input
+                                        ref={qtyInputRef}
+                                        value={newQty}
+                                        onChange={(e) => setNewQty(e.target.value)}
+                                        onKeyDown={handleQtyKeyDown}
+                                        placeholder="Qty"
+                                        className="h-8 text-xs text-right"
+                                        disabled={!stagedItem}
+                                    />
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        className="h-8 px-3 text-xs"
+                                        onClick={confirmAddItem}
+                                        disabled={!stagedItem || addItems.isPending}
+                                    >
+                                        {addItems.isPending ? '...' : '+ Add'}
+                                    </Button>
+                                </div>
+                            </div>
+
+                            {/* Items Table */}
+                            <div className="border rounded-md overflow-x-auto">
+                                <Table className="min-w-[700px]">
                                 <TableHeader>
                                     <TableRow>
                                         <TableHead>SKU</TableHead>
@@ -124,14 +434,79 @@ export default function PurchaseOrderDetail() {
                                         <TableHead className="text-right">Received</TableHead>
                                         <TableHead className="text-right">Remaining</TableHead>
                                         <TableHead className="text-right">Cost</TableHead>
+                                        <TableHead className="w-[100px]"></TableHead>
                                     </TableRow>
                                 </TableHeader>
                                 <TableBody>
                                     {po.items.map((item: PurchaseOrderItem) => (
-                                        <TableRow key={item.id}>
+                                        <TableRow 
+                                            key={item.id}
+                                            className={`transition-colors duration-500 ${
+                                                highlightedRowId === item.id
+                                                    ? 'bg-blue-50/80 dark:bg-blue-500/20'
+                                                    : ''
+                                            }`}
+                                        >
                                             <TableCell>{item.catalog_item?.sku || 'N/A'}</TableCell>
                                             <TableCell>{item.catalog_item?.name || 'Unknown Item'}</TableCell>
-                                            <TableCell className="text-right">{item.quantity}</TableCell>
+                                            <TableCell className="text-right">
+                                                {editingItemId === item.id ? (
+                                                    <motion.div
+                                                        animate={
+                                                            poppedQtyRowId === item.id
+                                                                ? { scale: [1, 1.2, 1] }
+                                                                : { scale: 1 }
+                                                        }
+                                                        transition={{ duration: 0.24, ease: 'easeOut' }}
+                                                        className="origin-center"
+                                                    >
+                                                        <Input
+                                                            type="number"
+                                                            min="1"
+                                                            value={editingQty}
+                                                            onChange={(e) => setEditingQty(e.target.value)}
+                                                            onBlur={() => {
+                                                                if (editingQty && editingQty !== item.quantity.toString()) {
+                                                                    handleUpdateItemQty(item.id, editingQty)
+                                                                } else {
+                                                                    setEditingItemId(null)
+                                                                    setEditingQty('')
+                                                                }
+                                                            }}
+                                                            onKeyDown={(e) => {
+                                                                if (e.key === 'Enter') {
+                                                                    handleUpdateItemQty(item.id, editingQty)
+                                                                } else if (e.key === 'Escape') {
+                                                                    setEditingItemId(null)
+                                                                    setEditingQty('')
+                                                                }
+                                                            }}
+                                                        className="w-16 text-right"
+                                                        autoFocus
+                                                    />
+                                                    </motion.div>
+                                                ) : (
+                                                    <motion.div
+                                                        animate={
+                                                            poppedQtyRowId === item.id
+                                                                ? { scale: [1, 1.2, 1] }
+                                                                : { scale: 1 }
+                                                        }
+                                                        transition={{ duration: 0.24, ease: 'easeOut' }}
+                                                        className="origin-center"
+                                                    >
+                                                        <div 
+                                                            onClick={() => {
+                                                                setEditingItemId(item.id)
+                                                                setEditingQty(item.quantity.toString())
+                                                            }}
+                                                            className="cursor-pointer hover:text-primary"
+                                                        >
+                                                            {item.quantity}
+                                                        </div>
+                                                    </motion.div>
+                                                )}
+                                            </TableCell>
                                             <TableCell className="text-right text-green-600 font-medium">
                                                 {item.quantity_received}
                                             </TableCell>
@@ -143,10 +518,22 @@ export default function PurchaseOrderDetail() {
                                                     ? '—'
                                                     : formatCurrency(item.unit_cost)}
                                             </TableCell>
+                                            <TableCell className="text-right">
+                                                <Button
+                                                    size="icon"
+                                                    variant="ghost"
+                                                    onClick={() => handleDeleteItem(item.id)}
+                                                    disabled={item.quantity_received > 0}
+                                                    title={item.quantity_received > 0 ? 'Cannot delete items that have been received' : 'Delete item'}
+                                                >
+                                                    <Trash2 className="h-4 w-4 text-red-500" />
+                                                </Button>
+                                            </TableCell>
                                         </TableRow>
                                     ))}
                                 </TableBody>
                             </Table>
+                            </div>
                         </CardContent>
                     </Card>
                 </div>


### PR DESCRIPTION
- Add status recomputation helper to keep PO status in sync with actual remaining quantities
- Reopen completed POs when new items are added (P1)
- Recompute status after quantity edits with proper unitCost field mapping (P1)
- Close partial POs when final outstanding line is deleted (P2)
- Increase inventory search page size from 10 to 100 to prevent valid vendor items from being hidden by pagination (P2)
- Add validation to prevent reducing ordered quantity below already-received amount

Fixes:
- Completed POs no longer hide Receive Goods button when items are added
- Quantity edits now properly trigger status changes
- Deleted items correctly update PO status
- Item search shows all valid vendor items, not just first 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add/update/delete item operations for purchase orders (API and UI hooks).
  * Inline item management on purchase order details: inventory search, staging, quantity editing, and deletion.

* **Improvements**
  * Purchase order creation simplified to two steps; items are added on the order detail page instead of during creation.
  * Purchase order status now recalculates after item changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->