### PR TITLE
Add workshop task deletion flow with invoice guards

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -145,10 +145,12 @@ We use a **Context-Based Approach**, allowing both patterns strictly based on th
 ### API Contract Source of Truth
 - **OpenAPI is authoritative**: Backend contract is generated to `apps/core-api/openapi/openapi.json`.
 - **Frontend types are generated**: Use `apps/core-web/src/api/generated/openapi.ts` from OpenAPI instead of manually duplicating DTO contracts.
+- **Mandatory whenever backend API shape changes**: If you add or change any controller route, request/response DTO, Swagger decorator metadata, or anything else that can affect OpenAPI output, you must regenerate and commit both contract artifacts before finishing the task.
 - **Required update flow when backend DTO/controller contract changes**:
   1. `npm --prefix apps/core-api run openapi:generate`
   2. `npm --prefix apps/core-web run api:types:generate`
   3. Commit both generated files.
+- **PR check reminder**: Forgetting to commit either regenerated file will fail the PR build on contract drift, even if local builds/tests pass.
 - **CI enforcement**: PR workflow regenerates OpenAPI + frontend generated types and fails on drift.
 
 ### Testing Standards

--- a/agents.md
+++ b/agents.md
@@ -104,6 +104,10 @@ auto-core-platform/
 - **Typography/Colors**: Use `text-2xl font-semibold tracking-tight` for main page headers, and `text-slate-500` for subtitles instead of `text-muted-foreground`.
 - **Lists / Tables**: Prefer using the shared `DataTable` component abstraction (`@/components/data-table/DataTable`) over constructing raw tables in `src/pages/` components for listing data.
 
+### UX/UI Standards
+- **DO**: Place all page-level action buttons (`Create`, `Save`, `Print`, `Delete`, `Export`) aligned to the top-right corner of the page header.
+- **DON'T**: Do not place page-level action buttons on the left side under the page title. The top-left is strictly reserved for context (`breadcrumbs`, `titles`, `badges`).
+
 ### List Page UI Standard (Required for New Lists)
 - **Header**: Use the standard title/subtitle block with `text-2xl font-semibold tracking-tight` and `text-slate-500`.
 - **Top-right create action**: Use a plus icon with entity-only label format: `+ <Entity>` (examples: `+ Customer`, `+ Vendor`, `+ Order`, `+ Purchase Order`). Do not use `Add`, `New`, or `Create` in the button label.

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -1944,7 +1944,51 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Workshop task deleted successfully."
+          },
+          "400": {
+            "description": "Task cannot be deleted because the order is invoiced or already has a linked invoice.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number",
+                      "example": 400
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workshop task or order was not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number",
+                      "example": 404
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tags": [

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -1921,6 +1921,35 @@
         "tags": [
           "Workshop"
         ]
+      },
+      "delete": {
+        "operationId": "WorkshopController_deleteTask",
+        "parameters": [
+          {
+            "name": "orderId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Workshop"
+        ]
       }
     },
     "/api/workshop/orders/{orderId}/tasks/{taskId}/line-items": {

--- a/apps/core-api/src/workshop/workshop.controller.ts
+++ b/apps/core-api/src/workshop/workshop.controller.ts
@@ -9,7 +9,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import { ApiQuery } from '@nestjs/swagger';
+import { ApiQuery, ApiResponse } from '@nestjs/swagger';
 import { WorkshopService } from './workshop.service';
 import { CreateWorkshopOrderDto } from './dto/create-workshop-order.dto';
 import { RegisterIntakeDto } from './dto/register-intake.dto';
@@ -105,6 +105,35 @@ export class WorkshopController {
   }
 
   @Delete('orders/:orderId/tasks/:taskId')
+  @ApiResponse({
+    status: 200,
+    description: 'Workshop task deleted successfully.',
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Task cannot be deleted because the order is invoiced or already has a linked invoice.',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        code: { type: 'string' },
+        statusCode: { type: 'number', example: 400 },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Workshop task or order was not found.',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+        code: { type: 'string' },
+        statusCode: { type: 'number', example: 404 },
+      },
+    },
+  })
   deleteTask(
     @Param('orderId') orderId: string,
     @Param('taskId') taskId: string,

--- a/apps/core-api/src/workshop/workshop.controller.ts
+++ b/apps/core-api/src/workshop/workshop.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -101,6 +102,14 @@ export class WorkshopController {
     @Body() dto: UpdateWorkshopTaskDto,
   ) {
     return this.workshopService.updateTask(orderId, taskId, dto);
+  }
+
+  @Delete('orders/:orderId/tasks/:taskId')
+  deleteTask(
+    @Param('orderId') orderId: string,
+    @Param('taskId') taskId: string,
+  ) {
+    return this.workshopService.deleteTask(orderId, taskId);
   }
 
   @Patch('orders/:orderId/tasks/:taskId/line-items')

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -28,6 +28,7 @@ describe('WorkshopService', () => {
     workshopTask: {
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      delete: jest.fn(),
       update: jest.fn(),
     },
     $transaction: jest.fn(),
@@ -167,5 +168,57 @@ describe('WorkshopService', () => {
     ).rejects.toThrow(BadRequestException);
 
     expect(mockPrisma.workshopTask.update).not.toHaveBeenCalled();
+  });
+
+  it('deletes a task and recalculates workshop order status', async () => {
+    mockPrisma.workshopTask.findFirst.mockResolvedValue({
+      id: 't-1',
+      workshop_order_id: 'wo-1',
+      workshop_order: {
+        status: WorkshopOrderStatus.IN_PROGRESS,
+        invoice: null,
+      },
+    });
+    mockPrisma.workshopTask.delete.mockResolvedValue({});
+    mockPrisma.workshopTask.findMany.mockResolvedValue([]);
+    mockPrisma.workshopOrder.updateMany.mockResolvedValue({ count: 1 });
+    jest.spyOn(service, 'findOne').mockResolvedValue({ id: 'wo-1' } as any);
+
+    await expect(service.deleteTask('wo-1', 't-1')).resolves.toEqual({
+      id: 'wo-1',
+    });
+
+    expect(mockPrisma.workshopTask.delete).toHaveBeenCalledWith({
+      where: { id: 't-1' },
+    });
+    expect(mockPrisma.workshopOrder.updateMany).toHaveBeenCalledWith({
+      where: { id: 'wo-1', status: { not: WorkshopOrderStatus.INVOICED } },
+      data: { status: WorkshopOrderStatus.INTAKE },
+    });
+  });
+
+  it('throws not found when deleting a missing task', async () => {
+    mockPrisma.workshopTask.findFirst.mockResolvedValue(null);
+
+    await expect(service.deleteTask('wo-x', 'task-x')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('blocks task deletion when a linked draft invoice exists', async () => {
+    mockPrisma.workshopTask.findFirst.mockResolvedValue({
+      id: 't-1',
+      workshop_order_id: 'wo-1',
+      workshop_order: {
+        status: WorkshopOrderStatus.COMPLETED,
+        invoice: { id: 'inv-draft-1', invoice_number: null },
+      },
+    });
+
+    await expect(service.deleteTask('wo-1', 't-1')).rejects.toThrow(
+      BadRequestException,
+    );
+
+    expect(mockPrisma.workshopTask.delete).not.toHaveBeenCalled();
   });
 });

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -467,6 +467,58 @@ export class WorkshopService {
     return this.findOne(orderId);
   }
 
+  async deleteTask(orderId: string, taskId: string) {
+    await this.prisma.$transaction(async (tx) => {
+      const task = await tx.workshopTask.findFirst({
+        where: {
+          id: taskId,
+          workshop_order_id: orderId,
+        },
+        include: {
+          workshop_order: {
+            select: {
+              status: true,
+              invoice: { select: { id: true, invoice_number: true } },
+            },
+          },
+        },
+      });
+
+      if (!task) {
+        throw new NotFoundException(`Task ${taskId} not found for this order`);
+      }
+      this.assertOrderEditable(task.workshop_order.status);
+
+      if (task.workshop_order.invoice) {
+        throw new BadRequestException(
+          'Workshop order already has an invoice; tasks cannot be deleted',
+        );
+      }
+
+      await tx.workshopTask.delete({
+        where: { id: taskId },
+      });
+
+      const tasks = await tx.workshopTask.findMany({
+        where: { workshop_order_id: orderId },
+        select: { status: true },
+      });
+
+      const nextOrderStatus = this.deriveOrderStatus(
+        tasks.map((existingTask) => existingTask.status),
+      );
+      await tx.workshopOrder.updateMany({
+        where: {
+          id: orderId,
+          status: { not: WorkshopOrderStatus.INVOICED },
+        },
+        data: { status: nextOrderStatus },
+      });
+    });
+
+    return this.findOne(orderId);
+  }
+
   async replaceTaskLineItems(
     orderId: string,
     taskId: string,

--- a/apps/core-api/test/workshop-invoicing.e2e-spec.ts
+++ b/apps/core-api/test/workshop-invoicing.e2e-spec.ts
@@ -172,4 +172,128 @@ describe('Workshop Invoicing (e2e)', () => {
       .send({ notes: 'Attempt to edit after invoicing' })
       .expect(400);
   });
+
+  it('deletes a task, removes its line items, and recalculates the order status', async () => {
+    const api = request(app.getHttpServer());
+
+    const orderRes = await api
+      .post('/api/workshop/orders')
+      .set('x-api-key', 'test-api-key')
+      .send({
+        customerId,
+        vehicleId,
+        odometer: 90000,
+        fuelLevel: 55,
+        notes: 'Service inspection',
+      })
+      .expect(201);
+
+    const orderId = orderRes.body.id;
+
+    const taskRes = await api
+      .post(`/api/workshop/orders/${orderId}/tasks`)
+      .set('x-api-key', 'test-api-key')
+      .send({ title: 'Inspection task' })
+      .expect(201);
+
+    const taskId = taskRes.body.id;
+
+    await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}/line-items`)
+      .set('x-api-key', 'test-api-key')
+      .send({
+        items: [
+          {
+            type: 'LABOR',
+            itemNo: 'LAB-INSPECT',
+            description: 'Inspection labor',
+            qty: 1,
+            unitPrice: 65,
+          },
+        ],
+      })
+      .expect(200);
+
+    const deleteRes = await api
+      .delete(`/api/workshop/orders/${orderId}/tasks/${taskId}`)
+      .set('x-api-key', 'test-api-key')
+      .expect(200);
+
+    expect(deleteRes.body.id).toBe(orderId);
+    expect(deleteRes.body.status).toBe('INTAKE');
+    expect(deleteRes.body.tasks).toHaveLength(0);
+
+    const persistedTask = await prisma.workshopTask.findUnique({
+      where: { id: taskId },
+    });
+    expect(persistedTask).toBeNull();
+
+    const persistedLineItems = await prisma.workshopTaskLineItem.findMany({
+      where: { workshop_task_id: taskId },
+    });
+    expect(persistedLineItems).toHaveLength(0);
+  });
+
+  it('blocks deleting a task after a draft invoice exists', async () => {
+    const api = request(app.getHttpServer());
+
+    const orderRes = await api
+      .post('/api/workshop/orders')
+      .set('x-api-key', 'test-api-key')
+      .send({
+        customerId,
+        vehicleId,
+        odometer: 91000,
+        fuelLevel: 50,
+        notes: 'Draft invoice protection',
+      })
+      .expect(201);
+
+    const orderId = orderRes.body.id;
+
+    const taskRes = await api
+      .post(`/api/workshop/orders/${orderId}/tasks`)
+      .set('x-api-key', 'test-api-key')
+      .send({ title: 'Invoice protected task' })
+      .expect(201);
+
+    const taskId = taskRes.body.id;
+
+    await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}/line-items`)
+      .set('x-api-key', 'test-api-key')
+      .send({
+        items: [
+          {
+            type: 'PART',
+            itemNo: 'PART-PROTECT',
+            description: 'Protected part',
+            qty: 1,
+            unitPrice: 25,
+          },
+        ],
+      })
+      .expect(200);
+
+    await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}`)
+      .set('x-api-key', 'test-api-key')
+      .send({ status: 'DONE' })
+      .expect(200);
+
+    await api
+      .post('/api/invoices/drafts')
+      .set('x-api-key', 'test-api-key')
+      .send({ workshopOrderId: orderId })
+      .expect(201);
+
+    const deleteRes = await api
+      .delete(`/api/workshop/orders/${orderId}/tasks/${taskId}`)
+      .set('x-api-key', 'test-api-key')
+      .expect(400);
+
+    expect(deleteRes.body.message).toBe(
+      'Workshop order already has an invoice; tasks cannot be deleted',
+    );
+  });
 });

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -2268,11 +2268,40 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
+            /** @description Workshop task deleted successfully. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Task cannot be deleted because the order is invoiced or already has a linked invoice. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message?: string;
+                        code?: string;
+                        /** @example 400 */
+                        statusCode?: number;
+                    };
+                };
+            };
+            /** @description Workshop task or order was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message?: string;
+                        code?: string;
+                        /** @example 404 */
+                        statusCode?: number;
+                    };
+                };
             };
         };
     };

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -638,7 +638,7 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["WorkshopController_deleteTask"];
         options?: never;
         head?: never;
         patch: operations["WorkshopController_updateTask"];
@@ -2249,6 +2249,26 @@ export interface operations {
         };
         responses: {
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WorkshopController_deleteTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orderId: string;
+                taskId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -257,6 +257,10 @@ export const useDeleteWorkshopTask = () => {
       queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
       queryClient.setQueryData(workshopKeys.order(order.id), order)
     },
+    onSettled: (_order, _error, { orderId }) => {
+      queryClient.invalidateQueries({ queryKey: workshopKeys.order(orderId) })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+    },
   })
 }
 

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -17,6 +17,13 @@ const WORKSHOP_API = '/api/workshop'
 const LABOR_API = '/api/labor'
 const CATALOG_API = '/api/catalog'
 
+export const workshopKeys = {
+  all: ['workshop'] as const,
+  orders: () => [...workshopKeys.all, 'orders'] as const,
+  order: (id: string) => [...workshopKeys.all, 'order', id] as const,
+  search: (query: string) => [...workshopKeys.all, 'search', query] as const,
+}
+
 type WorkshopOrderResponse = {
   data: WorkshopOrder[]
   meta: {
@@ -46,7 +53,7 @@ function normalizeOrder(order: any): WorkshopOrder {
 
 export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
   return useQuery<WorkshopOrderResponse>({
-    queryKey: ['workshop', 'orders', queryParams],
+    queryKey: [...workshopKeys.orders(), queryParams],
     queryFn: async () => {
       const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, queryParams, {
         searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
@@ -64,7 +71,7 @@ export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
 
 export function useWorkshopOrder(id: string) {
   return useQuery<WorkshopOrder>({
-    queryKey: ['workshop', 'order', id],
+    queryKey: workshopKeys.order(id),
     queryFn: async () => {
       const response = await fetchWithAuth(`${WORKSHOP_API}/orders/${id}`)
       if (!response.ok) throw new Error('Failed to fetch workshop order')
@@ -77,7 +84,7 @@ export function useWorkshopOrder(id: string) {
 
 export const useWorkshopSearch = (query: string) => {
   return useQuery<WorkshopSearchResponse>({
-    queryKey: ['workshop', 'search', query],
+    queryKey: workshopKeys.search(query),
     queryFn: async () => {
       if (!query || query.length < 2) return { data: { vehicles: [], customers: [] }, meta: { total: 0, page: 1, limit: 0, totalPages: 0 } }
       const response = await fetchWithAuth(`${WORKSHOP_API}/search?q=${encodeURIComponent(query)}`)
@@ -148,7 +155,7 @@ export const useCreateWorkshopOrder = () => {
       return normalizeOrder(json)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
     },
   })
 }
@@ -175,8 +182,8 @@ export const useUpdateWorkshopOrder = () => {
       return normalizeOrder(json)
     },
     onSuccess: (order) => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
-      queryClient.setQueryData(['workshop', 'order', order.id], order)
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+      queryClient.setQueryData(workshopKeys.order(order.id), order)
     },
   })
 }
@@ -194,8 +201,8 @@ export const useCreateWorkshopTask = () => {
       return response.json()
     },
     onSuccess: (_task, { orderId }) => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'order', orderId] })
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.order(orderId) })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
     },
   })
 }
@@ -226,8 +233,29 @@ export const useUpdateWorkshopTask = () => {
       return normalizeOrder(json)
     },
     onSuccess: (order) => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
-      queryClient.setQueryData(['workshop', 'order', order.id], order)
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+      queryClient.setQueryData(workshopKeys.order(order.id), order)
+    },
+  })
+}
+
+export const useDeleteWorkshopTask = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ orderId, taskId }: { orderId: string; taskId: string }) => {
+      const response = await fetchWithAuth(`${WORKSHOP_API}/orders/${orderId}/tasks/${taskId}`, {
+        method: 'DELETE',
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ message: 'Failed to delete task' }))
+        throw new Error(error.message || 'Failed to delete task')
+      }
+      const json = await response.json()
+      return normalizeOrder(json)
+    },
+    onSuccess: (order) => {
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+      queryClient.setQueryData(workshopKeys.order(order.id), order)
     },
   })
 }
@@ -260,8 +288,8 @@ export const useReplaceWorkshopTaskLineItems = () => {
       return normalizeOrder(json)
     },
     onSuccess: (order) => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
-      queryClient.setQueryData(['workshop', 'order', order.id], order)
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+      queryClient.setQueryData(workshopKeys.order(order.id), order)
     },
   })
 }
@@ -280,8 +308,8 @@ export const useCreateInvoiceFromWorkshopOrder = () => {
       return response.json()
     },
     onSuccess: (_invoice, orderId) => {
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'orders'] })
-      queryClient.invalidateQueries({ queryKey: ['workshop', 'order', orderId] })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.order(orderId) })
     },
   })
 }
@@ -299,7 +327,7 @@ export const useRegisterIntake = () => {
       return response.json()
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['workshop'] })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.all })
     },
   })
 }

--- a/apps/core-web/src/components/ui/action-group.tsx
+++ b/apps/core-web/src/components/ui/action-group.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+
+export interface SecondaryAction {
+  label: string
+  icon?: ReactNode
+  onClick: () => void
+  variant?: 'default' | 'destructive'
+  disabled?: boolean
+  separator?: boolean // renders a separator BEFORE this item
+}
+
+export interface ActionGroupProps {
+  /** The primary action button. Its right-side border radius is overridden to produce the split effect. */
+  primaryAction: ReactNode
+  /** List of items to show in the secondary dropdown */
+  secondaryActions: SecondaryAction[]
+  /** Alignment of the dropdown (default: end) */
+  align?: 'start' | 'center' | 'end'
+  /** Extra class names on the outer wrapper */
+  className?: string
+}
+
+/**
+ * ActionGroup – a "split button" that pairs a primary CTA with a secondary
+ * dropdown of contextual actions, separated by a 1px vertical divider.
+ *
+ * Keyboard accessible: the chevron trigger participates in the normal tab
+ * sequence and the Radix DropdownMenu handles arrow-key navigation with
+ * loop enabled.
+ */
+export function ActionGroup({
+  primaryAction,
+  secondaryActions,
+  align = 'end',
+  className,
+}: ActionGroupProps) {
+  return (
+    <div className={cn('flex items-stretch', className)}>
+      {/* Primary action – override right border-radius to merge with trigger */}
+      <div className='[&>button]:rounded-r-none [&>button]:border-r-0'>{primaryAction}</div>
+
+      {/* 1px visual divider */}
+      <div className='w-px bg-primary/30 self-stretch' />
+
+      {/* Chevron trigger */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant='default'
+            size='default'
+            className='rounded-l-none px-2'
+            aria-label='More actions'
+          >
+            <ChevronDown className='h-4 w-4' aria-hidden='true' />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align={align} loop>
+          {secondaryActions.map((action, idx) => (
+            <div key={idx}>
+              {action.separator && <DropdownMenuSeparator />}
+              <DropdownMenuItem
+                onClick={action.onClick}
+                disabled={action.disabled}
+                className={
+                  action.variant === 'destructive'
+                    ? 'text-destructive focus:text-destructive'
+                    : undefined
+                }
+              >
+                {action.icon && (
+                  <span className='mr-2 flex h-4 w-4 items-center justify-center'>
+                    {action.icon}
+                  </span>
+                )}
+                {action.label}
+              </DropdownMenuItem>
+            </div>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
+++ b/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import { motion } from 'framer-motion'
-import { CircleDollarSign, Clock3, Package, X } from 'lucide-react'
+import { CircleDollarSign, Clock3, Package, Trash2, X } from 'lucide-react'
 import { useCatalogSearch } from '@/api/workshop'
 import type { CatalogPartSearchItem, LaborOperationSearchItem } from '@/api/types'
 import { formatCurrency } from '@/lib/utils'
@@ -66,6 +66,9 @@ interface TaskDetailDrawerProps {
   onTaskStatusChange: (taskId: string, status: TaskStatus) => void
   onTaskLineItemsChange: (taskId: string, items: TaskLineItem[]) => void
   onTaskMechanicNotesChange: (taskId: string, notes: string) => void
+  onTaskDelete?: (taskId: string) => void
+  canDeleteTask?: boolean
+  isDeletingTask?: boolean
   readOnly?: boolean
   variant?: 'drawer' | 'docked'
 }
@@ -90,6 +93,9 @@ export function TaskDetailDrawer({
   onTaskStatusChange,
   onTaskLineItemsChange,
   onTaskMechanicNotesChange,
+  onTaskDelete,
+  canDeleteTask = false,
+  isDeletingTask = false,
   readOnly = false,
   variant = 'drawer',
 }: TaskDetailDrawerProps) {
@@ -305,28 +311,43 @@ export function TaskDetailDrawer({
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-3 min-w-0">
             <h2 className="text-lg font-semibold tracking-tight">{taskTitle}</h2>
-            <div className="w-[220px]">
-              <Select
-                value={status}
-                disabled={readOnly}
-                onValueChange={(v) => {
-                  if (!task) return
-                  const nextStatus = v as TaskStatus
-                  if (nextStatus !== task.status) {
-                    onTaskStatusChange(task.id, nextStatus)
-                  }
-                }}
-              >
-                <SelectTrigger className="h-9 text-xs">
-                  <SelectValue placeholder="Select status" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="NOT_STARTED">Not Started</SelectItem>
-                  <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
-                  <SelectItem value="WAITING_PARTS">Waiting Parts</SelectItem>
-                  <SelectItem value="DONE">Done</SelectItem>
-                </SelectContent>
-              </Select>
+            <div className="flex items-center gap-2">
+              <div className="w-[220px]">
+                <Select
+                  value={status}
+                  disabled={readOnly}
+                  onValueChange={(v) => {
+                    if (!task) return
+                    const nextStatus = v as TaskStatus
+                    if (nextStatus !== task.status) {
+                      onTaskStatusChange(task.id, nextStatus)
+                    }
+                  }}
+                >
+                  <SelectTrigger className="h-9 text-xs">
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NOT_STARTED">Not Started</SelectItem>
+                    <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                    <SelectItem value="WAITING_PARTS">Waiting Parts</SelectItem>
+                    <SelectItem value="DONE">Done</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {task && onTaskDelete && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-9 px-2 text-destructive hover:text-destructive"
+                  onClick={() => onTaskDelete(task.id)}
+                  disabled={!canDeleteTask || isDeletingTask}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  <span className="sr-only">Delete task</span>
+                </Button>
+              )}
             </div>
             <p className="text-xs text-muted-foreground">
               Task details, labor lines, parts, and mechanic notes.

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
@@ -6,13 +6,27 @@ import {
   ChevronDown,
   ChevronRight,
   CircleDollarSign,
+  Clock,
   Clock3,
   FileText,
+  Key,
+  MapPin,
   Package,
   Phone,
   Plus,
   Printer,
+  User,
 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -21,6 +35,7 @@ import { Input } from '@/components/ui/input'
 import { TaskDetailDrawer } from '@/components/workshop/TaskDetailDrawer'
 import { StatusBadge } from '@/components/status/StatusBadge'
 import { Badge } from '@/components/ui/badge'
+import { ActionGroup } from '@/components/ui/action-group'
 import {
   Select,
   SelectContent,
@@ -42,6 +57,7 @@ import { calculateDiscountAmount, parseDiscountValue } from '@/lib/discount'
 import { formatCurrency } from '@/lib/utils'
 import {
   useCreateWorkshopTask,
+  useDeleteWorkshopTask,
   useReplaceWorkshopTaskLineItems,
   useUpdateWorkshopOrder,
   useUpdateWorkshopTask,
@@ -104,6 +120,7 @@ export function WorkshopOrderDetails() {
 
   const updateOrder = useUpdateWorkshopOrder()
   const createTask = useCreateWorkshopTask()
+  const deleteTask = useDeleteWorkshopTask()
   const updateTask = useUpdateWorkshopTask()
   const replaceTaskLineItems = useReplaceWorkshopTaskLineItems()
   const createDraftInvoice = useCreateDraftInvoice()
@@ -118,6 +135,7 @@ export function WorkshopOrderDetails() {
   const [lineDiscountOverrides, setLineDiscountOverrides] = useState<Record<string, DiscountState>>({})
   const [checkoutInvoiceIdOverride, setCheckoutInvoiceIdOverride] = useState<string | null>(null)
   const [taskLineItemOverrides, setTaskLineItemOverrides] = useState<Record<string, WorkshopTask['lineItems']>>({})
+  const [taskPendingDelete, setTaskPendingDelete] = useState<WorkshopTask | null>(null)
   const lineItemSaveSeq = useRef<Record<string, number>>({})
   const [isDockedLayout, setIsDockedLayout] = useState(
     typeof window !== 'undefined'
@@ -324,6 +342,8 @@ export function WorkshopOrderDetails() {
   const customerPhone = order.customer.phone ?? ''
   const canEnterCheckout = order.status === 'COMPLETED' || !!activeInvoiceId
   const isLocked = order.status === 'INVOICED'
+  const hasLinkedInvoice = !!activeInvoiceId
+  const canDeleteTasks = !isLocked && !hasLinkedInvoice
   const invoiceStatus = fetchedInvoice?.status ?? null
   const canCreateDraftInCheckout =
     isCheckoutView &&
@@ -455,6 +475,27 @@ export function WorkshopOrderDetails() {
 
   const handleToggleTask = async (taskId: string, checked: boolean) => {
     await handleTaskStatusChange(taskId, checked ? 'DONE' : 'IN_PROGRESS')
+  }
+
+  const handleDeleteTask = async () => {
+    if (!taskPendingDelete || !canDeleteTasks) return
+
+    try {
+      await deleteTask.mutateAsync({ orderId: order.id, taskId: taskPendingDelete.id })
+      if (activeTaskId === taskPendingDelete.id) {
+        setActiveTaskId(null)
+      }
+      setTaskLineItemOverrides((previous) => {
+        const next = { ...previous }
+        delete next[taskPendingDelete.id]
+        return next
+      })
+      delete lineItemSaveSeq.current[taskPendingDelete.id]
+      setTaskPendingDelete(null)
+      toast.success('Task deleted')
+    } catch (error: any) {
+      toast.error(error?.message || 'Failed to delete task')
+    }
   }
 
   const openCheckoutView = () => {
@@ -616,6 +657,46 @@ export function WorkshopOrderDetails() {
     </Card>
   )
 
+  const orderInfoCard = (
+    <Card>
+      <CardHeader className='pb-3'>
+        <CardTitle className='text-base font-semibold'>Order Info</CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-4 text-sm'>
+        <div className='grid grid-cols-1 sm:grid-cols-2 gap-4'>
+          <div>
+            <div className='text-muted-foreground mb-1'>Assigned Tech</div>
+            <div className='font-medium flex items-center'>
+              <User className='w-4 h-4 mr-1.5 text-slate-500' />
+              John Doe
+            </div>
+          </div>
+          <div>
+            <div className='text-muted-foreground mb-1'>Bay / Location</div>
+            <div className='font-medium flex items-center'>
+              <MapPin className='w-4 h-4 mr-1.5 text-slate-500' />
+              Bay 4
+            </div>
+          </div>
+          <div>
+            <div className='text-muted-foreground mb-1'>Promised Time</div>
+            <div className='font-medium flex items-center'>
+              <Clock className='w-4 h-4 mr-1.5 text-slate-500' />
+              04/17/2026, 17:00
+            </div>
+          </div>
+          <div>
+            <div className='text-muted-foreground mb-1'>Key Tag</div>
+            <div className='font-medium flex items-center'>
+              <Key className='w-4 h-4 mr-1.5 text-slate-500' />
+              #42
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+
   const customerInfoCard = (
     <Card>
       <CardHeader className='pb-3'>
@@ -716,23 +797,11 @@ export function WorkshopOrderDetails() {
                   <div className='flex items-center gap-3'>
                     <h1 className='text-2xl font-semibold tracking-tight'>{order.order_number ?? `#${order.id}`}</h1>
                     <StatusBadge status={order.status} />
-                  </div>
-
-                  <div className='flex flex-wrap gap-2'>
-                    <Button variant='outline' onClick={handlePrint}>
-                      <Printer className='h-4 w-4 mr-2' />
-                      Print Job Card
-                    </Button>
-                    {!isInvoiceActionDisabled && (
-                      <Button onClick={handleCheckoutAction}>
-                        <FileText className='h-4 w-4 mr-2' />
-                        {invoiceActionLabel}
-                      </Button>
-                    )}
+                    <Badge variant='secondary' className='bg-blue-100 text-blue-800 hover:bg-blue-100 dark:bg-blue-900 dark:text-blue-300'>Waiter</Badge>
                   </div>
                 </div>
 
-                <div className='w-full lg:w-auto lg:pl-4'>
+                <div className='flex w-full flex-col gap-3 lg:w-auto lg:items-end'>
                   <div className='grid grid-cols-1 sm:grid-cols-3 gap-2 lg:min-w-[460px]'>
                     <div className='rounded-xl border bg-muted/40 px-3 py-2'>
                       <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
@@ -756,6 +825,31 @@ export function WorkshopOrderDetails() {
                       <div className='mt-1 text-sm font-semibold text-primary'>{formatCurrency(orderGrandTotal)}</div>
                     </div>
                   </div>
+
+                  <div className='flex justify-end mt-1'>
+                    {!isInvoiceActionDisabled ? (
+                      <ActionGroup
+                        primaryAction={
+                          <Button onClick={handleCheckoutAction}>
+                            <FileText className='h-4 w-4 mr-2' />
+                            {invoiceActionLabel}
+                          </Button>
+                        }
+                        secondaryActions={[
+                          {
+                            label: 'Print Job Card',
+                            icon: <Printer className='h-4 w-4' />,
+                            onClick: handlePrint,
+                          },
+                        ]}
+                      />
+                    ) : (
+                      <Button variant='outline' onClick={handlePrint}>
+                        <Printer className='h-4 w-4 mr-2' />
+                        Print Job Card
+                      </Button>
+                    )}
+                  </div>
                 </div>
               </div>
             </CardContent>
@@ -768,6 +862,7 @@ export function WorkshopOrderDetails() {
                 initial={{ opacity: 0, x: -8 }}
                 animate={{ opacity: 1, x: 0, transition: { duration: 0.22, ease: 'easeOut' } }}
               >
+                {orderInfoCard}
                 {customerInfoCard}
                 {vehicleInfoCard}
               </motion.div>
@@ -1085,6 +1180,14 @@ export function WorkshopOrderDetails() {
                 onTaskStatusChange={(taskId, status) => void handleTaskStatusChange(taskId, status)}
                 onTaskLineItemsChange={(taskId, items) => void handleTaskLineItemsChange(taskId, items)}
                 onTaskMechanicNotesChange={(taskId, notes) => void handleTaskMechanicNotesChange(taskId, notes)}
+                onTaskDelete={(taskId) => {
+                  const task = tasks.find((existingTask) => existingTask.id === taskId)
+                  if (task) {
+                    setTaskPendingDelete(task)
+                  }
+                }}
+                canDeleteTask={canDeleteTasks}
+                isDeletingTask={deleteTask.isPending}
                 readOnly={isLocked}
               />
             </motion.div>
@@ -1104,9 +1207,50 @@ export function WorkshopOrderDetails() {
           onTaskStatusChange={(taskId, status) => void handleTaskStatusChange(taskId, status)}
           onTaskLineItemsChange={(taskId, items) => void handleTaskLineItemsChange(taskId, items)}
           onTaskMechanicNotesChange={(taskId, notes) => void handleTaskMechanicNotesChange(taskId, notes)}
+          onTaskDelete={(taskId) => {
+            const task = tasks.find((existingTask) => existingTask.id === taskId)
+            if (task) {
+              setTaskPendingDelete(task)
+            }
+          }}
+          canDeleteTask={canDeleteTasks}
+          isDeletingTask={deleteTask.isPending}
           readOnly={isLocked}
         />
       )}
+
+      <AlertDialog
+        open={taskPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setTaskPendingDelete(null)
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete task?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {taskPendingDelete
+                ? `Delete "${taskPendingDelete.title}" from this workshop order? This also removes its parts and labor lines.`
+                : 'Delete this task from the workshop order?'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteTask.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+              onClick={(event) => {
+                event.preventDefault()
+                void handleDeleteTask()
+              }}
+              disabled={!canDeleteTasks || deleteTask.isPending}
+            >
+              {deleteTask.isPending ? 'Deleting...' : 'Delete Task'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/docs/deletion-policy.md
+++ b/docs/deletion-policy.md
@@ -32,6 +32,7 @@ This document defines when deletion is allowed in Auto Core Platform.
 | PurchaseInvoice | No | Financial document; use status lifecycle (`DRAFT`, `POSTED`, `PAID`). |
 | PurchaseInvoiceLine | No direct delete | Managed by parent `PurchaseInvoice` lifecycle. |
 | WorkshopOrder | Conditional (future API) | Prefer cancel/archive flow; if delete is added, limit to pre-work intake states only. |
+| WorkshopTask | Conditional | Allow only when parent `WorkshopOrder` is not `INVOICED` and no linked invoice exists yet on the order. |
 | InvoiceSequence | No | Numbering integrity record; never deleted. |
 
 ## UI Contract


### PR DESCRIPTION
## Summary
- Add a `DELETE /api/workshop/orders/:orderId/tasks/:taskId` endpoint for workshop tasks
- Block task deletion when the parent order is invoiced or already has a linked invoice
- Recalculate workshop order status after task deletion and clean up task line items via cascade delete
- Add frontend support for deleting tasks from the workshop task detail view with React Query cache updates
- Regenerate OpenAPI and frontend generated API types for the new endpoint
- Document the workshop task deletion rule in the deletion policy

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to delete workshop tasks from the UI with confirmation and safeguards (blocked if the order has a linked invoice); updated task drawer, header actions, and success/error toasts.
  * New ActionGroup for organizing primary and secondary actions (used in order header).

* **Documentation**
  * Added UX/UI standards for action button placement.
  * Documented task deletion policy for WorkshopTask.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->