### PR TITLE
feat(workshop): implement labor data integration milestones

### DIFF
--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -296,6 +296,7 @@ describe('WorkshopService', () => {
       new Prisma.PrismaClientKnownRequestError('Foreign key failed', {
         code: 'P2003',
         clientVersion: 'test',
+        meta: { field_name: 'labor_operation_id' },
       }),
     );
 

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -285,6 +285,39 @@ describe('WorkshopService', () => {
     expect(secondLineItem.internal_cost_rate).toBeNull();
   });
 
+  it('returns a bad request error for invalid laborOperationId', async () => {
+    mockPrisma.workshopTask.findFirst.mockResolvedValue({
+      id: 't-1',
+      workshop_order_id: 'wo-1',
+      workshop_order: { status: WorkshopOrderStatus.IN_PROGRESS },
+    });
+    mockPrisma.workshopTaskLineItem.deleteMany.mockResolvedValue({ count: 1 });
+    mockPrisma.workshopTaskLineItem.createMany.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Foreign key failed', {
+        code: 'P2003',
+        clientVersion: 'test',
+      }),
+    );
+
+    await expect(
+      service.replaceTaskLineItems('wo-1', 't-1', {
+        items: [
+          {
+            type: WorkshopLineItemType.LABOR,
+            itemNo: 'LAB-INVALID',
+            description: 'Invalid labor reference',
+            qty: 1,
+            unitPrice: 100,
+            laborOperationId: '00000000-0000-0000-0000-000000000001',
+            standardAw: 1,
+            actualHours: 1,
+            internalCostRate: 50,
+          },
+        ],
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
   it('normalizes labor metadata fields in workshop order response', async () => {
     mockPrisma.workshopOrder.findUnique.mockResolvedValue({
       id: 'wo-1',

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -551,40 +551,52 @@ export class WorkshopService {
     }
     this.assertOrderEditable(task.workshop_order.status);
 
-    await this.prisma.$transaction(async (tx) => {
-      await tx.workshopTaskLineItem.deleteMany({
-        where: { workshop_task_id: taskId },
-      });
-
-      if (dto.items.length > 0) {
-        await tx.workshopTaskLineItem.createMany({
-          data: dto.items.map((item) => ({
-            workshop_task_id: taskId,
-            type:
-              item.type === WorkshopLineItemType.LABOR
-                ? WorkshopLineItemType.LABOR
-                : WorkshopLineItemType.PART,
-            item_no: item.itemNo,
-            description: item.description,
-            quantity: new Prisma.Decimal(item.qty),
-            unit_price: new Prisma.Decimal(item.unitPrice),
-            labor_operation_id: item.laborOperationId ?? null,
-            standard_aw:
-              item.standardAw != null
-                ? new Prisma.Decimal(item.standardAw)
-                : null,
-            actual_hours:
-              item.actualHours != null
-                ? new Prisma.Decimal(item.actualHours)
-                : null,
-            internal_cost_rate:
-              item.internalCostRate != null
-                ? new Prisma.Decimal(item.internalCostRate)
-                : null,
-          })),
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.workshopTaskLineItem.deleteMany({
+          where: { workshop_task_id: taskId },
         });
+
+        if (dto.items.length > 0) {
+          await tx.workshopTaskLineItem.createMany({
+            data: dto.items.map((item) => ({
+              workshop_task_id: taskId,
+              type:
+                item.type === WorkshopLineItemType.LABOR
+                  ? WorkshopLineItemType.LABOR
+                  : WorkshopLineItemType.PART,
+              item_no: item.itemNo,
+              description: item.description,
+              quantity: new Prisma.Decimal(item.qty),
+              unit_price: new Prisma.Decimal(item.unitPrice),
+              labor_operation_id: item.laborOperationId ?? null,
+              standard_aw:
+                item.standardAw != null
+                  ? new Prisma.Decimal(item.standardAw)
+                  : null,
+              actual_hours:
+                item.actualHours != null
+                  ? new Prisma.Decimal(item.actualHours)
+                  : null,
+              internal_cost_rate:
+                item.internalCostRate != null
+                  ? new Prisma.Decimal(item.internalCostRate)
+                  : null,
+            })),
+          });
+        }
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2003'
+      ) {
+        throw new BadRequestException(
+          'Invalid laborOperationId: referenced labor operation was not found',
+        );
       }
-    });
+      throw error;
+    }
 
     return this.findOne(orderId);
   }

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -589,7 +589,10 @@ export class WorkshopService {
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2003'
+        error.code === 'P2003' &&
+        String((error.meta as Record<string, unknown> | undefined)?.field_name ?? '').includes(
+          'labor_operation_id',
+        )
       ) {
         throw new BadRequestException(
           'Invalid laborOperationId: referenced labor operation was not found',

--- a/apps/core-api/test/workshop-labor.e2e-spec.ts
+++ b/apps/core-api/test/workshop-labor.e2e-spec.ts
@@ -26,18 +26,6 @@ describe('Workshop Labor Metadata (e2e)', () => {
 
     prisma = app.get<PrismaService>(PrismaService);
 
-    await prisma.invoiceItem.deleteMany();
-    await prisma.invoice.deleteMany();
-    await prisma.workshopTaskLineItem.deleteMany();
-    await prisma.workshopTask.deleteMany();
-    await prisma.workshopOrder.deleteMany();
-    await prisma.laborFitment.deleteMany();
-    await prisma.laborOperation.deleteMany();
-    await prisma.laborCategory.deleteMany();
-    await prisma.vehicle.deleteMany();
-    await prisma.customer.deleteMany();
-    await prisma.invoiceSequence.deleteMany();
-
     const customer = await prisma.customer.create({
       data: {
         first_name: 'Workshop',
@@ -73,17 +61,35 @@ describe('Workshop Labor Metadata (e2e)', () => {
   });
 
   afterAll(async () => {
-    await prisma.invoiceItem.deleteMany();
-    await prisma.invoice.deleteMany();
-    await prisma.workshopTaskLineItem.deleteMany();
-    await prisma.workshopTask.deleteMany();
-    await prisma.workshopOrder.deleteMany();
-    await prisma.laborFitment.deleteMany();
-    await prisma.laborOperation.deleteMany();
-    await prisma.laborCategory.deleteMany();
-    await prisma.vehicle.deleteMany();
-    await prisma.customer.deleteMany();
-    await prisma.invoiceSequence.deleteMany();
+    if (customerId) {
+      await prisma.invoiceItem.deleteMany({
+        where: { invoice: { workshop_order: { customer_id: customerId } } },
+      });
+      await prisma.invoice.deleteMany({
+        where: { workshop_order: { customer_id: customerId } },
+      });
+      await prisma.workshopTaskLineItem.deleteMany({
+        where: {
+          workshop_task: { workshop_order: { customer_id: customerId } },
+        },
+      });
+      await prisma.workshopTask.deleteMany({
+        where: { workshop_order: { customer_id: customerId } },
+      });
+      await prisma.workshopOrder.deleteMany({
+        where: { customer_id: customerId },
+      });
+      await prisma.vehicle.deleteMany({ where: { customer_id: customerId } });
+      await prisma.customer.deleteMany({ where: { id: customerId } });
+    }
+    if (laborOperationId) {
+      await prisma.laborFitment.deleteMany({
+        where: { labor_operation_id: laborOperationId },
+      });
+      await prisma.laborOperation.deleteMany({
+        where: { id: laborOperationId },
+      });
+    }
     await app.close();
   });
 

--- a/apps/core-api/test/workshop-labor.e2e-spec.ts
+++ b/apps/core-api/test/workshop-labor.e2e-spec.ts
@@ -1,0 +1,241 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Workshop Labor Metadata (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let customerId: string;
+  let vehicleId: string;
+  let laborOperationId: string;
+
+  beforeAll(async () => {
+    process.env.API_KEY = 'test-api-key';
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+    await app.init();
+
+    prisma = app.get<PrismaService>(PrismaService);
+
+    await prisma.invoiceItem.deleteMany();
+    await prisma.invoice.deleteMany();
+    await prisma.workshopTaskLineItem.deleteMany();
+    await prisma.workshopTask.deleteMany();
+    await prisma.workshopOrder.deleteMany();
+    await prisma.laborFitment.deleteMany();
+    await prisma.laborOperation.deleteMany();
+    await prisma.laborCategory.deleteMany();
+    await prisma.vehicle.deleteMany();
+    await prisma.customer.deleteMany();
+    await prisma.invoiceSequence.deleteMany();
+
+    const customer = await prisma.customer.create({
+      data: {
+        first_name: 'Workshop',
+        last_name: 'Labor Tester',
+        email: `workshop-labor-${Date.now()}@example.com`,
+        type: 'PRIVATE',
+      },
+    });
+    customerId = customer.id;
+
+    const vehicle = await prisma.vehicle.create({
+      data: {
+        make: 'BMW',
+        model: 'X5',
+        year: 2022,
+        vin: `VIN-WL-${Date.now()}`,
+        customer_id: customerId,
+      },
+    });
+    vehicleId = vehicle.id;
+
+    const laborOperation = await prisma.laborOperation.create({
+      data: {
+        code: `LAB-E2E-${Date.now()}`,
+        description: 'Workshop labor metadata operation',
+        standard_aw: 1.5,
+        hourly_rate: 120,
+        internal_cost: 65,
+        is_active: true,
+      },
+    });
+    laborOperationId = laborOperation.id;
+  });
+
+  afterAll(async () => {
+    await prisma.invoiceItem.deleteMany();
+    await prisma.invoice.deleteMany();
+    await prisma.workshopTaskLineItem.deleteMany();
+    await prisma.workshopTask.deleteMany();
+    await prisma.workshopOrder.deleteMany();
+    await prisma.laborFitment.deleteMany();
+    await prisma.laborOperation.deleteMany();
+    await prisma.laborCategory.deleteMany();
+    await prisma.vehicle.deleteMany();
+    await prisma.customer.deleteMany();
+    await prisma.invoiceSequence.deleteMany();
+    await app.close();
+  });
+
+  it('persists and updates labor metadata, then creates invoice from the completed order', async () => {
+    const api = request(app.getHttpServer());
+
+    const orderRes = await api
+      .post('/api/workshop/orders')
+      .set('x-api-key', 'test-api-key')
+      .send({
+        customerId,
+        vehicleId,
+        odometer: 100000,
+        fuelLevel: 50,
+        notes: 'Labor metadata happy path',
+      })
+      .expect(201);
+
+    const orderId = orderRes.body.id;
+
+    const taskRes = await api
+      .post(`/api/workshop/orders/${orderId}/tasks`)
+      .set('x-api-key', 'test-api-key')
+      .send({ title: 'Engine diagnostic labor' })
+      .expect(201);
+
+    const taskId = taskRes.body.id;
+
+    const firstSaveRes = await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}/line-items`)
+      .set('x-api-key', 'test-api-key')
+      .send({
+        items: [
+          {
+            type: 'LABOR',
+            itemNo: 'LAB-ENG-01',
+            description: 'Engine diagnostic labor',
+            qty: 1.5,
+            unitPrice: 120,
+            laborOperationId,
+            standardAw: 1.5,
+            actualHours: 1.75,
+            internalCostRate: 65,
+          },
+        ],
+      })
+      .expect(200);
+
+    const firstLineItem = firstSaveRes.body.tasks[0].lineItems[0];
+    expect(firstLineItem.laborOperationId).toBe(laborOperationId);
+    expect(firstLineItem.standardAw).toBe(1.5);
+    expect(firstLineItem.actualHours).toBe(1.75);
+    expect(firstLineItem.internalCostRate).toBe(65);
+
+    const secondSaveRes = await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}/line-items`)
+      .set('x-api-key', 'test-api-key')
+      .send({
+        items: [
+          {
+            type: 'LABOR',
+            itemNo: 'LAB-ENG-01',
+            description: 'Engine diagnostic labor',
+            qty: 1.5,
+            unitPrice: 120,
+            laborOperationId,
+            standardAw: 1.5,
+            actualHours: 2.25,
+            internalCostRate: 65,
+          },
+        ],
+      })
+      .expect(200);
+
+    const updatedLineItem = secondSaveRes.body.tasks[0].lineItems[0];
+    expect(updatedLineItem.actualHours).toBe(2.25);
+
+    const persistedLineItem = await prisma.workshopTaskLineItem.findFirst({
+      where: { workshop_task_id: taskId },
+    });
+    expect(persistedLineItem).toBeDefined();
+    expect(persistedLineItem?.labor_operation_id).toBe(laborOperationId);
+    expect(Number(persistedLineItem?.standard_aw)).toBe(1.5);
+    expect(Number(persistedLineItem?.actual_hours)).toBe(2.25);
+    expect(Number(persistedLineItem?.internal_cost_rate)).toBe(65);
+
+    await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}`)
+      .set('x-api-key', 'test-api-key')
+      .send({ status: 'DONE' })
+      .expect(200);
+
+    const draftInvoiceRes = await api
+      .post('/api/invoices/drafts')
+      .set('x-api-key', 'test-api-key')
+      .send({ workshopOrderId: orderId })
+      .expect(201);
+
+    const invoiceLaborLine = draftInvoiceRes.body.items.find(
+      (item: { description: string }) =>
+        item.description === 'Engine diagnostic labor',
+    );
+
+    expect(invoiceLaborLine).toBeDefined();
+    expect(Number(invoiceLaborLine.line_total)).toBeCloseTo(180);
+  });
+
+  it('rejects non-existent laborOperationId with a controlled validation error', async () => {
+    const api = request(app.getHttpServer());
+
+    const orderRes = await api
+      .post('/api/workshop/orders')
+      .set('x-api-key', 'test-api-key')
+      .send({
+        customerId,
+        vehicleId,
+        odometer: 101000,
+        fuelLevel: 48,
+        notes: 'Invalid labor operation test',
+      })
+      .expect(201);
+
+    const orderId = orderRes.body.id;
+
+    const taskRes = await api
+      .post(`/api/workshop/orders/${orderId}/tasks`)
+      .set('x-api-key', 'test-api-key')
+      .send({ title: 'Invalid labor operation reference' })
+      .expect(201);
+
+    const taskId = taskRes.body.id;
+
+    const invalidRes = await api
+      .patch(`/api/workshop/orders/${orderId}/tasks/${taskId}/line-items`)
+      .set('x-api-key', 'test-api-key')
+      .send({
+        items: [
+          {
+            type: 'LABOR',
+            itemNo: 'LAB-INVALID',
+            description: 'Invalid operation labor line',
+            qty: 1,
+            unitPrice: 100,
+            laborOperationId: '00000000-0000-0000-0000-000000000001',
+            standardAw: 1,
+            actualHours: 1,
+            internalCostRate: 50,
+          },
+        ],
+      })
+      .expect(400);
+
+    expect(invalidRes.body.message).toContain('laborOperationId');
+  });
+});

--- a/apps/core-web/src/api/types.ts
+++ b/apps/core-web/src/api/types.ts
@@ -288,7 +288,7 @@ export interface WorkshopTaskLineItem {
     description: string
     qty: number
     unitPrice: number
-    laborOperationId?: string
+    laborOperationId?: string | null
     standardAw?: number | null
     actualHours?: number | null
     internalCostRate?: number | null

--- a/apps/core-web/src/api/types.ts
+++ b/apps/core-web/src/api/types.ts
@@ -288,6 +288,10 @@ export interface WorkshopTaskLineItem {
     description: string
     qty: number
     unitPrice: number
+    laborOperationId?: string
+    standardAw?: number | null
+    actualHours?: number | null
+    internalCostRate?: number | null
 }
 
 export interface NormalizedWorkshopTaskLineItem {

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -280,6 +280,10 @@ export const useReplaceWorkshopTaskLineItems = () => {
         description: string
         qty: number
         unitPrice: number
+        laborOperationId?: string
+        standardAw?: number | null
+        actualHours?: number | null
+        internalCostRate?: number | null
       }>
     }) => {
       const response = await fetchWithAuth(`${WORKSHOP_API}/orders/${orderId}/tasks/${taskId}/line-items`, {

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -24,6 +24,18 @@ export const workshopKeys = {
   search: (query: string) => [...workshopKeys.all, 'search', query] as const,
 }
 
+export const laborKeys = {
+  all: ['labor'] as const,
+  search: (query: string, workshopOrderId: string) =>
+    [...laborKeys.all, 'search', query, workshopOrderId] as const,
+}
+
+export const catalogKeys = {
+  all: ['catalog'] as const,
+  search: (query: string, workshopOrderId: string) =>
+    [...catalogKeys.all, 'search', query, workshopOrderId] as const,
+}
+
 type WorkshopOrderResponse = {
   data: WorkshopOrder[]
   meta: {
@@ -103,7 +115,7 @@ export const useLaborSearch = (
   const normalizedQuery = query.trim().toLowerCase()
   const normalizedWorkshopOrderId = workshopOrderId.trim()
   return useQuery<LaborOperationSearchResponse>({
-    queryKey: ['labor', 'search', normalizedQuery, normalizedWorkshopOrderId],
+    queryKey: laborKeys.search(normalizedQuery, normalizedWorkshopOrderId),
     queryFn: async () => {
       if (!normalizedQuery || !normalizedWorkshopOrderId) {
         return { data: [], meta: { total: 0, limit: 20 } }
@@ -126,7 +138,7 @@ export const useCatalogSearch = (
   const normalizedQuery = query.trim().toLowerCase()
   const normalizedWorkshopOrderId = workshopOrderId.trim()
   return useQuery<CatalogSearchResponse>({
-    queryKey: ['catalog', 'search', normalizedQuery, normalizedWorkshopOrderId],
+    queryKey: catalogKeys.search(normalizedQuery, normalizedWorkshopOrderId),
     queryFn: async () => {
       if (!normalizedQuery || !normalizedWorkshopOrderId) {
         return { labor: [], parts: [], meta: { laborCount: 0, partCount: 0, limit: 20 } }
@@ -280,7 +292,7 @@ export const useReplaceWorkshopTaskLineItems = () => {
         description: string
         qty: number
         unitPrice: number
-        laborOperationId?: string
+        laborOperationId?: string | null
         standardAw?: number | null
         actualHours?: number | null
         internalCostRate?: number | null

--- a/apps/core-web/src/components/workshop/TaskDetailDrawer.test.tsx
+++ b/apps/core-web/src/components/workshop/TaskDetailDrawer.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TaskDetailDrawer } from './TaskDetailDrawer'
+import * as workshopApi from '@/api/workshop'
+import * as laborApi from '@/api/labor'
+
+vi.mock('@/api/workshop')
+vi.mock('@/api/labor')
+
+describe('TaskDetailDrawer labor metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(workshopApi.useCatalogSearch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { labor: [], parts: [] },
+      isFetching: false,
+    })
+    ;(laborApi.useLaborOperation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: null,
+      isFetching: false,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders Standard AW, Actual Hours, and Efficiency for labor lines', () => {
+    render(
+      <TaskDetailDrawer
+        variant='docked'
+        workshopOrderId='wo-1'
+        open
+        onOpenChange={vi.fn()}
+        task={{
+          id: 'task-1',
+          title: 'Oil Service',
+          done: false,
+          status: 'IN_PROGRESS',
+          mechanicNotes: '',
+          lineItems: [
+            {
+              id: 'li-1',
+              type: 'LABOR',
+              itemNo: 'LAB-001',
+              description: 'Oil service labor',
+              qty: 1.5,
+              unitPrice: 100,
+              laborOperationId: '550e8400-e29b-41d4-a716-446655440000',
+              standardAw: 1.5,
+              actualHours: 2,
+              internalCostRate: 55,
+            },
+          ],
+        }}
+        onTaskStatusChange={vi.fn()}
+        onTaskLineItemsChange={vi.fn()}
+        onTaskMechanicNotesChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Standard AW\s+1\.50/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Actual Hours')).toBeInTheDocument()
+    expect(screen.getByText(/Efficiency\s+0\.75x/i)).toBeInTheDocument()
+  })
+})

--- a/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
+++ b/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import { motion } from 'framer-motion'
 import { CircleDollarSign, Clock3, Package, Trash2, X } from 'lucide-react'
+import { useLaborOperation } from '@/api/labor'
 import { useCatalogSearch } from '@/api/workshop'
 import type { CatalogPartSearchItem, LaborOperationSearchItem } from '@/api/types'
 import { formatCurrency } from '@/lib/utils'
@@ -47,6 +48,10 @@ interface TaskLineItem {
   description: string
   qty: number
   unitPrice: number
+  laborOperationId?: string
+  standardAw?: number | null
+  actualHours?: number | null
+  internalCostRate?: number | null
 }
 
 interface RepairTask {
@@ -79,11 +84,34 @@ interface StagedLineItemDraft {
   description: string
   unitPrice: number
   label: string
+  laborOperationId?: string
+  standardAw?: number | null
+  internalCostRate?: number | null
 }
 
 const STABLE_EMPTY_ITEMS: TaskLineItem[] = []
 const STABLE_EMPTY_LABOR: LaborOperationSearchItem[] = []
 const STABLE_EMPTY_PARTS: CatalogPartSearchItem[] = []
+
+function formatHours(value: number | null | undefined) {
+  if (value == null) return '—'
+  return value.toFixed(2)
+}
+
+function calculateEfficiencyRatio(
+  standardAw: number | null | undefined,
+  actualHours: number | null | undefined,
+) {
+  if (standardAw == null || actualHours == null || actualHours <= 0) return null
+  return standardAw / actualHours
+}
+
+function getEfficiencyBadgeClass(ratio: number) {
+  if (ratio <= 1) {
+    return 'border-emerald-200 bg-emerald-100 text-emerald-700'
+  }
+  return 'border-amber-200 bg-amber-100 text-amber-700'
+}
 
 export function TaskDetailDrawer({
   workshopOrderId,
@@ -126,6 +154,16 @@ export function TaskDetailDrawer({
     workshopOrderId,
     open,
   )
+  const stagedLaborOperationId =
+    stagedLineItem?.type === 'LABOR' ? stagedLineItem.laborOperationId ?? '' : ''
+  const {
+    data: stagedLaborOperation,
+    isFetching: isFetchingStagedLaborOperation,
+  } = useLaborOperation(stagedLaborOperationId)
+  const stagedLaborInternalCostRate =
+    typeof stagedLaborOperation?.internalCost === 'number'
+      ? stagedLaborOperation.internalCost
+      : null
   const laborSuggestions = catalogSearch?.labor ?? STABLE_EMPTY_LABOR
   const partSuggestions = catalogSearch?.parts ?? STABLE_EMPTY_PARTS
 
@@ -146,6 +184,23 @@ export function TaskDetailDrawer({
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (!stagedLineItem || stagedLineItem.type !== 'LABOR') return
+    if (!stagedLineItem.laborOperationId) return
+    if (!stagedLaborOperation) return
+    if (stagedLaborOperation.id !== stagedLineItem.laborOperationId) return
+    if (stagedLineItem.internalCostRate === stagedLaborInternalCostRate) return
+
+    setStagedLineItem((current) => {
+      if (!current || current.type !== 'LABOR') return current
+      if (current.laborOperationId !== stagedLaborOperation.id) return current
+      return {
+        ...current,
+        internalCostRate: stagedLaborInternalCostRate,
+      }
+    })
+  }, [stagedLaborInternalCostRate, stagedLaborOperation, stagedLineItem])
 
   function clearQuickEntry() {
     setSearchQuery('')
@@ -204,6 +259,9 @@ export function TaskDetailDrawer({
       description: operation.description,
       unitPrice: operation.hourlyRate,
       label: `${operation.code} · ${operation.description}`,
+      laborOperationId: operation.id,
+      standardAw: operation.standardAw,
+      internalCostRate: null,
     })
     setSearchQuery(`${operation.code} · ${operation.description}`)
     setDebouncedSearchQuery('')
@@ -247,6 +305,17 @@ export function TaskDetailDrawer({
     if (!task || readOnly || !stagedLineItem) return
     const qty = Number(newQty)
     const safeQty = Number.isFinite(qty) && qty > 0 ? qty : 1
+    const stagedLaborMetadata =
+      stagedLineItem.type === 'LABOR'
+        ? {
+            laborOperationId: stagedLineItem.laborOperationId,
+            standardAw: stagedLineItem.standardAw ?? safeQty,
+            actualHours: null,
+            internalCostRate:
+              stagedLineItem.internalCostRate ?? stagedLaborInternalCostRate,
+          }
+        : {}
+
     const next: TaskLineItem = {
       id: `li-${task.id}-${items.length + 1}`,
       type: stagedLineItem.type,
@@ -254,6 +323,7 @@ export function TaskDetailDrawer({
       description: stagedLineItem.description,
       qty: safeQty,
       unitPrice: stagedLineItem.unitPrice,
+      ...stagedLaborMetadata,
     }
     addOrMergeLineItem(next)
   }
@@ -289,6 +359,25 @@ export function TaskDetailDrawer({
     )
   }
 
+  function updateLaborActualHours(
+    lineItemId: string,
+    nextActualHours: number | null,
+  ) {
+    if (!task || readOnly) return
+    const target = items.find((lineItem) => lineItem.id === lineItemId)
+    if (!target || target.type !== 'LABOR') return
+    if ((target.actualHours ?? null) === nextActualHours) return
+
+    onTaskLineItemsChange(
+      task.id,
+      items.map((lineItem) =>
+        lineItem.id === lineItemId
+          ? { ...lineItem, actualHours: nextActualHours }
+          : lineItem,
+      ),
+    )
+  }
+
   const normalizedSearchQuery = searchQuery.trim()
   const showSuggestions = !stagedLineItem && normalizedSearchQuery.length >= 2
   const hasResults = laborSuggestions.length > 0 || partSuggestions.length > 0
@@ -297,6 +386,10 @@ export function TaskDetailDrawer({
     debouncedSearchQuery === normalizedSearchQuery &&
     !isSearchingCatalog &&
     hasResults
+  const isStagedLaborMetadataLoading =
+    stagedLineItem?.type === 'LABOR' &&
+    !!stagedLineItem.laborOperationId &&
+    isFetchingStagedLaborOperation
   const isDocked = variant === 'docked'
 
   const panelBody = (
@@ -473,11 +566,18 @@ export function TaskDetailDrawer({
                         size="sm"
                         className="h-8 px-3 text-xs"
                         onClick={confirmStagedItem}
-                        disabled={readOnly || !stagedLineItem}
+                        disabled={
+                          readOnly || !stagedLineItem || isStagedLaborMetadataLoading
+                        }
                       >
                         + Add
                       </Button>
                     </div>
+                    {isStagedLaborMetadataLoading && (
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        Loading labor metadata...
+                      </p>
+                    )}
                   </div>
                 )}
 
@@ -494,71 +594,146 @@ export function TaskDetailDrawer({
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {items.map((item) => (
-                          <TableRow
-                            key={item.id}
-                            className={`transition-colors duration-500 ${
-                              highlightedRowId === item.id
-                                ? 'bg-blue-50/80 dark:bg-blue-500/20'
-                                : ''
-                            }`}
-                          >
-                            <TableCell>
-                              <Badge variant={item.type === 'LABOR' ? 'secondary' : 'outline'}>
-                                {item.type === 'LABOR' ? 'Labor' : 'Part'}
-                              </Badge>
-                            </TableCell>
-                            <TableCell className="font-medium">{item.itemNo}</TableCell>
-                            <TableCell className="text-muted-foreground">{item.description}</TableCell>
-                            <TableCell>
-                              {item.type === 'PART' && !readOnly ? (
-                                <motion.div
-                                  animate={
-                                    poppedQtyRowId === item.id
-                                      ? { scale: [1, 1.2, 1] }
-                                      : { scale: 1 }
-                                  }
-                                  transition={{ duration: 0.24, ease: 'easeOut' }}
-                                  className="origin-center"
-                                >
-                                  <Input
-                                    key={`${item.id}-${item.qty}`}
-                                    defaultValue={String(item.qty)}
-                                    inputMode="decimal"
-                                    className="h-7 w-16 text-right text-xs"
-                                    onKeyDown={(event) => {
-                                      if (event.key === 'Enter') {
-                                        event.currentTarget.blur()
-                                      }
-                                    }}
-                                    onBlur={(event) => {
-                                      const parsedQty = Number(event.currentTarget.value)
-                                      if (!Number.isFinite(parsedQty) || parsedQty <= 0) {
-                                        event.currentTarget.value = String(item.qty)
-                                        return
-                                      }
-                                      event.currentTarget.value = String(parsedQty)
-                                      updatePartQuantity(item.id, parsedQty)
-                                    }}
-                                  />
-                                </motion.div>
-                              ) : (
-                                <motion.span
-                                  animate={
-                                    poppedQtyRowId === item.id
-                                      ? { scale: [1, 1.2, 1] }
-                                      : { scale: 1 }
-                                  }
-                                  transition={{ duration: 0.24, ease: 'easeOut' }}
-                                  className="inline-block origin-center"
-                                >
-                                  {item.qty}
-                                </motion.span>
-                              )}
-                            </TableCell>
-                            <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
-                          </TableRow>
-                        ))}
+                        {items.map((item) => {
+                          const efficiencyRatio = calculateEfficiencyRatio(
+                            item.standardAw,
+                            item.actualHours,
+                          )
+
+                          return (
+                            <TableRow
+                              key={item.id}
+                              className={`transition-colors duration-500 ${
+                                highlightedRowId === item.id
+                                  ? 'bg-blue-50/80 dark:bg-blue-500/20'
+                                  : ''
+                              }`}
+                            >
+                              <TableCell>
+                                <Badge variant={item.type === 'LABOR' ? 'secondary' : 'outline'}>
+                                  {item.type === 'LABOR' ? 'Labor' : 'Part'}
+                                </Badge>
+                              </TableCell>
+                              <TableCell className="font-medium">{item.itemNo}</TableCell>
+                              <TableCell>
+                                <div className="space-y-1">
+                                  <div className="text-muted-foreground">{item.description}</div>
+                                  {item.type === 'LABOR' && (
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <Badge variant="outline" className="text-[10px]">
+                                        Standard AW {formatHours(item.standardAw)}
+                                      </Badge>
+                                      {readOnly ? (
+                                        <Badge variant="outline" className="text-[10px]">
+                                          Actual Hours {formatHours(item.actualHours)}
+                                        </Badge>
+                                      ) : (
+                                        <div className="flex items-center gap-1">
+                                          <span className="text-[10px] text-muted-foreground">
+                                            Actual Hours
+                                          </span>
+                                          <Input
+                                            key={`${item.id}-${item.actualHours ?? 'none'}`}
+                                            aria-label="Actual Hours"
+                                            defaultValue={
+                                              item.actualHours != null
+                                                ? String(item.actualHours)
+                                                : ''
+                                            }
+                                            inputMode="decimal"
+                                            className="h-7 w-20 text-right text-xs"
+                                            onKeyDown={(event) => {
+                                              if (event.key === 'Enter') {
+                                                event.currentTarget.blur()
+                                              }
+                                            }}
+                                            onBlur={(event) => {
+                                              const rawValue = event.currentTarget.value.trim()
+                                              if (rawValue === '') {
+                                                updateLaborActualHours(item.id, null)
+                                                return
+                                              }
+
+                                              const parsedHours = Number(rawValue)
+                                              if (
+                                                !Number.isFinite(parsedHours) ||
+                                                parsedHours < 0
+                                              ) {
+                                                event.currentTarget.value =
+                                                  item.actualHours != null
+                                                    ? String(item.actualHours)
+                                                    : ''
+                                                return
+                                              }
+
+                                              event.currentTarget.value = String(parsedHours)
+                                              updateLaborActualHours(item.id, parsedHours)
+                                            }}
+                                          />
+                                        </div>
+                                      )}
+                                      {efficiencyRatio != null && (
+                                        <Badge
+                                          variant="outline"
+                                          className={`text-[10px] ${getEfficiencyBadgeClass(efficiencyRatio)}`}
+                                        >
+                                          Efficiency {efficiencyRatio.toFixed(2)}x
+                                        </Badge>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              </TableCell>
+                              <TableCell>
+                                {item.type === 'PART' && !readOnly ? (
+                                  <motion.div
+                                    animate={
+                                      poppedQtyRowId === item.id
+                                        ? { scale: [1, 1.2, 1] }
+                                        : { scale: 1 }
+                                    }
+                                    transition={{ duration: 0.24, ease: 'easeOut' }}
+                                    className="origin-center"
+                                  >
+                                    <Input
+                                      key={`${item.id}-${item.qty}`}
+                                      defaultValue={String(item.qty)}
+                                      inputMode="decimal"
+                                      className="h-7 w-16 text-right text-xs"
+                                      onKeyDown={(event) => {
+                                        if (event.key === 'Enter') {
+                                          event.currentTarget.blur()
+                                        }
+                                      }}
+                                      onBlur={(event) => {
+                                        const parsedQty = Number(event.currentTarget.value)
+                                        if (!Number.isFinite(parsedQty) || parsedQty <= 0) {
+                                          event.currentTarget.value = String(item.qty)
+                                          return
+                                        }
+                                        event.currentTarget.value = String(parsedQty)
+                                        updatePartQuantity(item.id, parsedQty)
+                                      }}
+                                    />
+                                  </motion.div>
+                                ) : (
+                                  <motion.span
+                                    animate={
+                                      poppedQtyRowId === item.id
+                                        ? { scale: [1, 1.2, 1] }
+                                        : { scale: 1 }
+                                    }
+                                    transition={{ duration: 0.24, ease: 'easeOut' }}
+                                    className="inline-block origin-center"
+                                  >
+                                    {item.qty}
+                                  </motion.span>
+                                )}
+                              </TableCell>
+                              <TableCell>{formatCurrency(item.unitPrice)}</TableCell>
+                            </TableRow>
+                          )
+                        })}
                       </TableBody>
                     </Table>
                   </div>

--- a/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
+++ b/apps/core-web/src/components/workshop/TaskDetailDrawer.tsx
@@ -48,7 +48,7 @@ interface TaskLineItem {
   description: string
   qty: number
   unitPrice: number
-  laborOperationId?: string
+  laborOperationId?: string | null
   standardAw?: number | null
   actualHours?: number | null
   internalCostRate?: number | null
@@ -86,7 +86,6 @@ interface StagedLineItemDraft {
   label: string
   laborOperationId?: string
   standardAw?: number | null
-  internalCostRate?: number | null
 }
 
 const STABLE_EMPTY_ITEMS: TaskLineItem[] = []
@@ -107,7 +106,7 @@ function calculateEfficiencyRatio(
 }
 
 function getEfficiencyBadgeClass(ratio: number) {
-  if (ratio <= 1) {
+  if (ratio >= 1) {
     return 'border-emerald-200 bg-emerald-100 text-emerald-700'
   }
   return 'border-amber-200 bg-amber-100 text-amber-700'
@@ -185,23 +184,6 @@ export function TaskDetailDrawer({
     }
   }, [])
 
-  useEffect(() => {
-    if (!stagedLineItem || stagedLineItem.type !== 'LABOR') return
-    if (!stagedLineItem.laborOperationId) return
-    if (!stagedLaborOperation) return
-    if (stagedLaborOperation.id !== stagedLineItem.laborOperationId) return
-    if (stagedLineItem.internalCostRate === stagedLaborInternalCostRate) return
-
-    setStagedLineItem((current) => {
-      if (!current || current.type !== 'LABOR') return current
-      if (current.laborOperationId !== stagedLaborOperation.id) return current
-      return {
-        ...current,
-        internalCostRate: stagedLaborInternalCostRate,
-      }
-    })
-  }, [stagedLaborInternalCostRate, stagedLaborOperation, stagedLineItem])
-
   function clearQuickEntry() {
     setSearchQuery('')
     setDebouncedSearchQuery('')
@@ -261,7 +243,6 @@ export function TaskDetailDrawer({
       label: `${operation.code} · ${operation.description}`,
       laborOperationId: operation.id,
       standardAw: operation.standardAw,
-      internalCostRate: null,
     })
     setSearchQuery(`${operation.code} · ${operation.description}`)
     setDebouncedSearchQuery('')
@@ -311,8 +292,7 @@ export function TaskDetailDrawer({
             laborOperationId: stagedLineItem.laborOperationId,
             standardAw: stagedLineItem.standardAw ?? safeQty,
             actualHours: null,
-            internalCostRate:
-              stagedLineItem.internalCostRate ?? stagedLaborInternalCostRate,
+            internalCostRate: stagedLaborInternalCostRate,
           }
         : {}
 

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.line-items.test.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.line-items.test.tsx
@@ -1,0 +1,194 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkshopOrderDetails } from './WorkshopOrderDetails'
+import * as workshopApi from '@/api/workshop'
+import * as salesApi from '@/api/sales'
+import * as invoicesApi from '@/api/invoices'
+
+vi.mock('@/api/workshop')
+vi.mock('@/api/sales')
+vi.mock('@/api/invoices')
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn().mockReturnValue('toast-1'),
+  },
+}))
+
+vi.mock('@/components/workshop/TaskDetailDrawer', () => ({
+  TaskDetailDrawer: ({ open, task, onTaskLineItemsChange }: any) => {
+    if (!open || !task) return null
+    return (
+      <button
+        type='button'
+        onClick={() => {
+          onTaskLineItemsChange(task.id, [
+            {
+              id: 'line-labor-1',
+              type: 'LABOR',
+              itemNo: 'LAB-01',
+              description: 'Labor line',
+              qty: 1.25,
+              unitPrice: 120,
+              laborOperationId: '550e8400-e29b-41d4-a716-446655440000',
+              standardAw: 1.5,
+              actualHours: 1.75,
+              internalCostRate: 65,
+            },
+          ])
+        }}
+      >
+        Trigger line item save
+      </button>
+    )
+  },
+}))
+
+const baseOrder = {
+  id: 'order-1',
+  order_number: 'WO-001',
+  status: 'IN_PROGRESS' as const,
+  customer_id: 'cust-1',
+  customer: {
+    id: 'cust-1',
+    first_name: 'John',
+    last_name: 'Doe',
+    type: 'PRIVATE' as const,
+    email: 'john@example.com',
+    phone: '123456789',
+  },
+  vehicle_id: 'veh-1',
+  vehicle: {
+    id: 'veh-1',
+    year: 2020,
+    make: 'Toyota',
+    model: 'Corolla',
+    vin: 'VIN123',
+    plate: 'ABC-123',
+  },
+  odometer: 85000,
+  fuel_level: 75,
+  reportedIssue: 'Strange noise from engine',
+  notes: 'Customer waiting in lobby',
+  tasks: [
+    {
+      id: 'task-1',
+      title: 'Oil Change',
+      status: 'IN_PROGRESS' as const,
+      done: false,
+      mechanicNotes: '',
+      lineItems: [
+        {
+          id: 'line-1',
+          type: 'PART' as const,
+          itemNo: 'OIL-FLTR',
+          description: 'Oil Filter',
+          qty: 1,
+          unitPrice: 15,
+        },
+      ],
+    },
+  ],
+  invoice: null,
+  createdAt: '2026-01-15T10:30:00Z',
+}
+
+function createMutationMock(overrides: Record<string, unknown> = {}) {
+  return {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    ...overrides,
+  }
+}
+
+describe('WorkshopOrderDetails line-item persistence', () => {
+  let queryClient: QueryClient
+  const replaceTaskLineItemsMutateAsync = vi.fn().mockResolvedValue(baseOrder)
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    vi.clearAllMocks()
+
+    ;(workshopApi.useWorkshopOrder as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: baseOrder,
+      isLoading: false,
+    })
+    ;(salesApi.useInvoice as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: null,
+      isLoading: false,
+    })
+    ;(workshopApi.useUpdateWorkshopOrder as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(workshopApi.useCreateWorkshopTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(workshopApi.useDeleteWorkshopTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(workshopApi.useUpdateWorkshopTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(workshopApi.useReplaceWorkshopTaskLineItems as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock({ mutateAsync: replaceTaskLineItemsMutateAsync }),
+    )
+    ;(invoicesApi.useCreateDraftInvoice as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(invoicesApi.useIssueInvoice as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(invoicesApi.useUpdateInvoiceDiscount as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock(),
+    )
+    ;(workshopApi.useGenerateWorkshopPdf as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMutationMock({ mutateAsync: vi.fn() }),
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('forwards labor metadata fields when saving task line items', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/workshop/orders/order-1']}>
+          <Routes>
+            <Route path='/workshop/orders/:id' element={<WorkshopOrderDetails />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger line item save' }))
+
+    await waitFor(() => {
+      expect(replaceTaskLineItemsMutateAsync).toHaveBeenCalledWith({
+        orderId: 'order-1',
+        taskId: 'task-1',
+        items: [
+          {
+            type: 'LABOR',
+            itemNo: 'LAB-01',
+            description: 'Labor line',
+            qty: 1.25,
+            unitPrice: 120,
+            laborOperationId: '550e8400-e29b-41d4-a716-446655440000',
+            standardAw: 1.5,
+            actualHours: 1.75,
+            internalCostRate: 65,
+          },
+        ],
+      })
+    })
+  })
+})

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
@@ -105,6 +105,9 @@ export function WorkshopOrderDetails() {
     orderPartsTotal,
     orderLaborTotal,
     orderGrandTotal,
+    orderLaborInternalCostTotal,
+    orderLaborMarginPercent,
+    hasOrderLaborCostData,
   } = useWorkshopCalculations({
     orderTasks: order?.tasks,
     taskLineItemOverrides,
@@ -227,7 +230,18 @@ export function WorkshopOrderDetails() {
 
   const handleTaskLineItemsChange = async (
     taskId: string,
-    items: Array<{ id?: string; type: WorkshopLineItemType; itemNo: string; description: string; qty: number; unitPrice: number }>,
+    items: Array<{
+      id?: string
+      type: WorkshopLineItemType
+      itemNo: string
+      description: string
+      qty: number
+      unitPrice: number
+      laborOperationId?: string
+      standardAw?: number | null
+      actualHours?: number | null
+      internalCostRate?: number | null
+    }>,
   ) => {
     if (isLocked) return
     const saveSeq = (lineItemSaveSeq.current[taskId] ?? 0) + 1
@@ -240,6 +254,10 @@ export function WorkshopOrderDetails() {
       description: item.description,
       qty: item.qty,
       unitPrice: item.unitPrice,
+      laborOperationId: item.laborOperationId,
+      standardAw: item.standardAw ?? null,
+      actualHours: item.actualHours ?? null,
+      internalCostRate: item.internalCostRate ?? null,
     }))
     setTaskLineItemOverrides((previous) => ({
       ...previous,
@@ -249,12 +267,26 @@ export function WorkshopOrderDetails() {
       await replaceTaskLineItems.mutateAsync({
         orderId: order.id,
         taskId,
-        items: items.map(({ type, itemNo, description, qty, unitPrice }) => ({
+        items: items.map(({
           type,
           itemNo,
           description,
           qty,
           unitPrice,
+          laborOperationId,
+          standardAw,
+          actualHours,
+          internalCostRate,
+        }) => ({
+          type,
+          itemNo,
+          description,
+          qty,
+          unitPrice,
+          laborOperationId,
+          standardAw: standardAw ?? null,
+          actualHours: actualHours ?? null,
+          internalCostRate: internalCostRate ?? null,
         })),
       })
       if (lineItemSaveSeq.current[taskId] !== saveSeq) return
@@ -493,6 +525,9 @@ export function WorkshopOrderDetails() {
             orderPartsTotal={orderPartsTotal}
             orderLaborTotal={orderLaborTotal}
             orderGrandTotal={orderGrandTotal}
+            orderLaborInternalCostTotal={orderLaborInternalCostTotal}
+            orderLaborMarginPercent={orderLaborMarginPercent}
+            hasOrderLaborCostData={hasOrderLaborCostData}
             invoiceActionLabel={invoiceActionLabel}
             isInvoiceActionDisabled={isInvoiceActionDisabled}
             onCheckoutAction={() => void handleCheckoutAction()}

--- a/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderDetails.tsx
@@ -237,7 +237,7 @@ export function WorkshopOrderDetails() {
       description: string
       qty: number
       unitPrice: number
-      laborOperationId?: string
+      laborOperationId?: string | null
       standardAw?: number | null
       actualHours?: number | null
       internalCostRate?: number | null

--- a/apps/core-web/src/pages/workshop/components/OrderHeader.tsx
+++ b/apps/core-web/src/pages/workshop/components/OrderHeader.tsx
@@ -26,6 +26,9 @@ export interface OrderTopBarProps {
   orderPartsTotal: number
   orderLaborTotal: number
   orderGrandTotal: number
+  orderLaborInternalCostTotal: number
+  orderLaborMarginPercent: number | null
+  hasOrderLaborCostData: boolean
   invoiceActionLabel: string
   isInvoiceActionDisabled: boolean
   onCheckoutAction: () => void
@@ -37,6 +40,9 @@ export function OrderTopBar({
   orderPartsTotal,
   orderLaborTotal,
   orderGrandTotal,
+  orderLaborInternalCostTotal,
+  orderLaborMarginPercent,
+  hasOrderLaborCostData,
   invoiceActionLabel,
   isInvoiceActionDisabled,
   onCheckoutAction,
@@ -55,7 +61,7 @@ export function OrderTopBar({
           </div>
 
           <div className='flex w-full flex-col gap-3 lg:w-auto lg:items-end'>
-            <div className='grid grid-cols-1 sm:grid-cols-3 gap-2 lg:min-w-[460px]'>
+            <div className='grid grid-cols-1 gap-2 sm:grid-cols-3 lg:min-w-[760px] lg:grid-cols-5'>
               <div className='rounded-xl border bg-muted/40 px-3 py-2'>
                 <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
                   <Package className='h-3.5 w-3.5' />
@@ -66,10 +72,34 @@ export function OrderTopBar({
               <div className='rounded-xl border bg-muted/40 px-3 py-2'>
                 <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
                   <Clock3 className='h-3.5 w-3.5' />
-                  <span>Total Labor</span>
+                  <span>Labor Revenue</span>
                 </div>
                 <div className='mt-1 text-sm font-medium'>{formatCurrency(orderLaborTotal)}</div>
               </div>
+              {hasOrderLaborCostData && (
+                <>
+                  <div className='rounded-xl border bg-muted/40 px-3 py-2'>
+                    <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
+                      <Clock3 className='h-3.5 w-3.5' />
+                      <span>Internal Labor Cost</span>
+                    </div>
+                    <div className='mt-1 text-sm font-medium'>
+                      {formatCurrency(orderLaborInternalCostTotal)}
+                    </div>
+                  </div>
+                  <div className='rounded-xl border bg-muted/40 px-3 py-2'>
+                    <div className='flex items-center gap-1.5 text-[11px] text-muted-foreground'>
+                      <CircleDollarSign className='h-3.5 w-3.5' />
+                      <span>Est. Margin</span>
+                    </div>
+                    <div className='mt-1 text-sm font-medium'>
+                      {orderLaborMarginPercent != null
+                        ? `${orderLaborMarginPercent.toFixed(1)}%`
+                        : '—'}
+                    </div>
+                  </div>
+                </>
+              )}
               <div className='rounded-xl border border-primary/20 bg-primary/10 px-3 py-2'>
                 <div className='flex items-center gap-1.5 text-[11px] text-primary/80'>
                   <CircleDollarSign className='h-3.5 w-3.5' />

--- a/apps/core-web/src/pages/workshop/components/TaskList.tsx
+++ b/apps/core-web/src/pages/workshop/components/TaskList.tsx
@@ -124,9 +124,17 @@ export function TaskList({
                   >
                     Open
                   </Button>
-                  <span className='text-sm font-semibold'>{formatCurrency(rawTaskTotals.get(task.id)?.total ?? 0)}</span>
+                  <span className='text-sm font-semibold'>
+                    {formatCurrency(rawTaskTotals.get(task.id)?.total ?? 0)}
+                  </span>
                   <StatusBadge status={task.status} />
                 </span>
+              </div>
+              <div className='mt-1 pl-7 text-xs text-muted-foreground'>
+                Parts {formatCurrency(rawTaskTotals.get(task.id)?.parts ?? 0)} · Labor{' '}
+                {formatCurrency(rawTaskTotals.get(task.id)?.labor ?? 0)} · Std{' '}
+                {(rawTaskTotals.get(task.id)?.laborStandardHours ?? 0).toFixed(2)}h · Actual{' '}
+                {(rawTaskTotals.get(task.id)?.laborActualHours ?? 0).toFixed(2)}h
               </div>
             </div>
           ))}

--- a/apps/core-web/src/pages/workshop/hooks/useWorkshopCalculations.test.ts
+++ b/apps/core-web/src/pages/workshop/hooks/useWorkshopCalculations.test.ts
@@ -28,6 +28,9 @@ const laborLine = {
   description: 'Oil change labor',
   qty: 0.5,
   unitPrice: 80,
+  standardAw: 0.5,
+  actualHours: 0.75,
+  internalCostRate: 30,
 }
 
 const brakePads = {
@@ -153,6 +156,16 @@ describe('useWorkshopCalculations — rawTaskTotals', () => {
     expect(totals.parts).toBe(0)
     expect(totals.labor).toBe(0)
     expect(totals.total).toBe(0)
+  })
+
+  it('includes labor hours and internal cost analytics per task', () => {
+    const { result } = renderHook(() => useWorkshopCalculations(defaultInput))
+    const totals = result.current.rawTaskTotals.get('task-1')!
+
+    expect(totals.laborStandardHours).toBe(0.5)
+    expect(totals.laborActualHours).toBe(0.75)
+    expect(totals.laborInternalCost).toBe(22.5)
+    expect(totals.hasLaborCostData).toBe(true)
   })
 })
 
@@ -456,5 +469,16 @@ describe('useWorkshopCalculations — view-aware order totals', () => {
     // Labor: unchanged = 40
     expect(result.current.orderLaborTotal).toBe(40)
     expect(result.current.orderGrandTotal).toBe(53.5)
+  })
+
+  it('returns order-level labor revenue, internal cost, and margin when cost data exists', () => {
+    const { result } = renderHook(() =>
+      useWorkshopCalculations({ ...defaultInput, isCheckoutView: false }),
+    )
+
+    expect(result.current.orderLaborRevenue).toBe(40)
+    expect(result.current.orderLaborInternalCostTotal).toBe(22.5)
+    expect(result.current.orderLaborMarginPercent).toBeCloseTo(43.75)
+    expect(result.current.hasOrderLaborCostData).toBe(true)
   })
 })

--- a/apps/core-web/src/pages/workshop/hooks/useWorkshopCalculations.ts
+++ b/apps/core-web/src/pages/workshop/hooks/useWorkshopCalculations.ts
@@ -40,6 +40,10 @@ export interface TaskTotals {
   parts: number
   labor: number
   total: number
+  laborStandardHours: number
+  laborActualHours: number
+  laborInternalCost: number
+  hasLaborCostData: boolean
 }
 
 interface UseWorkshopCalculationsInput {
@@ -104,13 +108,41 @@ export function useWorkshopCalculations({
       new Map<string, TaskTotals>(
         tasks.map((task) => {
           const lineItems = task.lineItems ?? []
-          const parts = lineItems
-            .filter((li) => li.type === 'PART')
-            .reduce((sum, li) => sum + li.qty * li.unitPrice, 0)
-          const labor = lineItems
-            .filter((li) => li.type === 'LABOR')
-            .reduce((sum, li) => sum + li.qty * li.unitPrice, 0)
-          return [task.id, { parts, labor, total: parts + labor }]
+          const partsLines = lineItems.filter((li) => li.type === 'PART')
+          const laborLines = lineItems.filter((li) => li.type === 'LABOR')
+
+          const parts = partsLines.reduce((sum, li) => sum + li.qty * li.unitPrice, 0)
+          const labor = laborLines.reduce((sum, li) => sum + li.qty * li.unitPrice, 0)
+
+          const laborStandardHours = laborLines.reduce(
+            (sum, li) => sum + (li.standardAw ?? 0),
+            0,
+          )
+          const laborActualHours = laborLines.reduce(
+            (sum, li) => sum + (li.actualHours ?? 0),
+            0,
+          )
+          const laborInternalCost = laborLines.reduce((sum, li) => {
+            if (li.internalCostRate == null) return sum
+            const costHours = li.actualHours ?? li.qty
+            return sum + costHours * li.internalCostRate
+          }, 0)
+          const hasLaborCostData = laborLines.some(
+            (li) => li.internalCostRate != null,
+          )
+
+          return [
+            task.id,
+            {
+              parts,
+              labor,
+              total: parts + labor,
+              laborStandardHours,
+              laborActualHours,
+              laborInternalCost,
+              hasLaborCostData,
+            },
+          ]
         }),
       ),
     [tasks],
@@ -123,6 +155,18 @@ export function useWorkshopCalculations({
   )
   const baseOrderLaborTotal = useMemo(
     () => Array.from(rawTaskTotals.values()).reduce((sum, t) => sum + t.labor, 0),
+    [rawTaskTotals],
+  )
+  const baseOrderLaborInternalCostTotal = useMemo(
+    () =>
+      Array.from(rawTaskTotals.values()).reduce(
+        (sum, t) => sum + t.laborInternalCost,
+        0,
+      ),
+    [rawTaskTotals],
+  )
+  const hasOrderLaborCostData = useMemo(
+    () => Array.from(rawTaskTotals.values()).some((t) => t.hasLaborCostData),
     [rawTaskTotals],
   )
 
@@ -263,6 +307,12 @@ export function useWorkshopCalculations({
   const orderPartsTotal = isCheckoutView ? checkoutPartsTotal : baseOrderPartsTotal
   const orderLaborTotal = isCheckoutView ? checkoutLaborTotal : baseOrderLaborTotal
   const orderGrandTotal = orderPartsTotal + orderLaborTotal
+  const orderLaborRevenue = orderLaborTotal
+  const orderLaborInternalCostTotal = baseOrderLaborInternalCostTotal
+  const orderLaborMarginPercent =
+    hasOrderLaborCostData && orderLaborRevenue > 0
+      ? ((orderLaborRevenue - orderLaborInternalCostTotal) / orderLaborRevenue) * 100
+      : null
 
   return {
     // Normalized tasks
@@ -292,5 +342,9 @@ export function useWorkshopCalculations({
     orderPartsTotal,
     orderLaborTotal,
     orderGrandTotal,
+    orderLaborRevenue,
+    orderLaborInternalCostTotal,
+    orderLaborMarginPercent,
+    hasOrderLaborCostData,
   }
 }


### PR DESCRIPTION
## Summary
- implement labor metadata typing and payload propagation for workshop task line items
- enhance TaskDetailDrawer with Standard AW, Actual Hours editing, and efficiency badge for labor lines
- add labor analytics (task-level hours/cost + order-level labor revenue/internal cost/margin)
- add backend guardrail for invalid laborOperationId during line-item replacement
- add focused frontend and backend tests, including new workshop labor e2e coverage file

## Linear Scope
- AUT-35 FE-5: Enhance TaskDetailDrawer for labor metadata
- AUT-36 FE-6: Enhance order/task totals with labor analytics
- AUT-37 FE-8b: Update frontend types for Milestone 3 contract
- AUT-38 QA-2: E2E tests for workshop order with labor metadata

## Files Added
- apps/core-web/src/components/workshop/TaskDetailDrawer.test.tsx
- apps/core-web/src/pages/workshop/WorkshopOrderDetails.line-items.test.tsx
- apps/core-api/test/workshop-labor.e2e-spec.ts

## Validation
- passed: npm --prefix apps/core-web run test -- src/components/workshop/TaskDetailDrawer.test.tsx src/pages/workshop/WorkshopOrderDetails.line-items.test.tsx
- passed: npm --prefix apps/core-web run test -- src/pages/workshop/hooks/useWorkshopCalculations.test.ts src/components/workshop/TaskDetailDrawer.test.tsx src/pages/workshop/WorkshopOrderDetails.line-items.test.tsx
- passed: npm --prefix apps/core-api run test -- workshop.service.spec.ts

## Notes
- full backend e2e execution is currently blocked in local environment by baseline DB test setup failures (existing workshop e2e specs exhibit same issue)
- unrelated untracked local folder .agents/skills/linear/ was intentionally excluded from this PR