### PR TITLE
feat: last commit 94d76e4 from main

### DIFF
--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: linear
+description: Work with Linear issues via CLI - use this skill whenever the user asks about Linear issues, creating, updating, commenting on, or deleting issues, or checking issue status and details
+version: 0.1.0
+---
+
+# Linear Issue Management
+
+**Use this skill whenever the user mentions Linear or asks to work with issues.**
+
+Lightweight CLI to interact with Linear's issue tracking system. All commands run from the skill directory using `./linear`.
+
+## Setup
+
+Dependencies install automatically on first run. API key errors are self-explanatory.
+
+## Command Pattern
+
+```bash
+./linear <resource> <action> [arguments] [options]
+```
+
+Resources: `issue`, `user`, `team`, `project`
+
+## Commands
+
+### List Users
+```bash
+./linear user list
+```
+Returns: `#<user-id>	<name>	<email>`
+
+### List Teams
+```bash
+./linear team list
+```
+Returns: `#<team-id>	<name>	<key>`
+
+### List Projects
+```bash
+./linear project list
+```
+Returns: `#<project-id>	<name>	<state>`
+
+### List Issues
+```bash
+./linear issue list [options]
+```
+**Options:**
+- `--team <id>` - Filter by team ID
+- `--assignee <id>` - Filter by user ID
+- `--status <name>` - Filter by status name (case-sensitive)
+- `--limit <n>` - Limit results (default: 50)
+
+Returns: `#<identifier>	<title>	<status>	<assignee>`
+
+**Examples:**
+```bash
+./linear issue list --team abc123 --limit 10
+./linear issue list --assignee def456 --status "In Progress"
+```
+
+### View Issue
+```bash
+./linear issue view <id-or-key>
+```
+**Arguments:**
+- `<id-or-key>` - Issue identifier (e.g., `ENG-123`) or UUID
+
+Returns full issue details including title, status, assignee, team, priority, labels, dates, description, and comments.
+
+### Create Issue
+```bash
+./linear issue create <title> [options]
+```
+**Arguments:**
+- `<title>` - Issue title (multi-word titles auto-combined)
+
+**Options:**
+- `--team <id>` - Team ID (required)
+- `--description <text>` - Issue description
+- `--assignee <id>` - User ID
+- `--priority <n>` - Priority (0=None, 1=Urgent, 2=High, 3=Medium, 4=Low)
+- `--status <name>` - Initial status
+
+**Example:**
+```bash
+./linear issue create "Fix login bug" --team abc123 --priority 2
+```
+
+### Add Comment
+```bash
+./linear issue comment <id-or-key> <text>
+```
+Multi-word text auto-combined. No quotes needed.
+
+### Update Issue
+```bash
+./linear issue update <id-or-key> [options]
+```
+**Options:**
+- `--status <name>` - Update status
+- `--assignee <id>` - Update assignee
+- `--priority <n>` - Update priority
+- `--title <text>` - Update title
+- `--description <text>` - Update description
+
+Can update multiple fields in one command.
+
+**Example:**
+```bash
+./linear issue update ENG-123 --status "In Progress" --assignee abc123
+```
+
+### Delete Issue
+```bash
+./linear issue delete <id-or-key>
+```
+Soft delete (moves to trash, recoverable).
+
+## Important Notes
+
+- Issue identifiers are case-insensitive (`ENG-123` = `eng-123`)
+- Status names are case-sensitive ("In Progress" ≠ "in progress")
+- User/team IDs are UUIDs (get from list commands)
+- Issue keys format: `<TEAM_KEY>-<NUMBER>` (e.g., ENG-123)
+- All commands support `--json` flag for machine-readable output
+- Use `--help` on any command for details

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ apps/core-web/test-results/
 stitch-downloads/
 .vercel
 .env*.local
+
+# Docs
+docs/superpowers/

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -3190,9 +3190,9 @@
             "format": "uuid"
           },
           "quantity": {
-            "type": "number",
+            "type": "integer",
             "example": 4,
-            "minimum": 0.001
+            "minimum": 1
           },
           "sourceLocationId": {
             "type": "string",

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -1921,7 +1921,14 @@
         },
         "responses": {
           "201": {
-            "description": ""
+            "description": "Workshop parts pick transfer summary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PickWorkshopPartsResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -3221,6 +3228,82 @@
         "required": [
           "destinationLocationId",
           "items"
+        ]
+      },
+      "PickWorkshopPartAllocationResponseDto": {
+        "type": "object",
+        "properties": {
+          "sourceLocationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "quantity": {
+            "type": "number",
+            "example": 2,
+            "minimum": 1
+          },
+          "referenceId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sourceLocationId",
+          "quantity",
+          "referenceId"
+        ]
+      },
+      "PickWorkshopPartMovedLineResponseDto": {
+        "type": "object",
+        "properties": {
+          "workshopTaskLineItemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "movedQuantity": {
+            "type": "number",
+            "example": 4,
+            "minimum": 1
+          },
+          "allocations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickWorkshopPartAllocationResponseDto"
+            }
+          }
+        },
+        "required": [
+          "workshopTaskLineItemId",
+          "movedQuantity",
+          "allocations"
+        ]
+      },
+      "PickWorkshopPartsResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "stagingLocationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "transferGroupId": {
+            "type": "string",
+            "example": "WO-PICK-<order-id>-<timestamp>"
+          },
+          "movedLines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickWorkshopPartMovedLineResponseDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "stagingLocationId",
+          "transferGroupId",
+          "movedLines"
         ]
       },
       "UpdateWorkshopTaskDto": {

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -1896,7 +1896,7 @@
         ]
       }
     },
-    "/api/workshop/{id}/pick-parts": {
+    "/api/workshop/orders/{id}/pick-parts": {
       "post": {
         "operationId": "WorkshopController_pickParts",
         "parameters": [

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -1896,6 +1896,39 @@
         ]
       }
     },
+    "/api/workshop/{id}/pick-parts": {
+      "post": {
+        "operationId": "WorkshopController_pickParts",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PickWorkshopPartsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Workshop"
+        ]
+      }
+    },
     "/api/workshop/orders/{orderId}/tasks/{taskId}": {
       "patch": {
         "operationId": "WorkshopController_updateTask",
@@ -3148,6 +3181,47 @@
       "CreateWorkshopTaskDto": {
         "type": "object",
         "properties": {}
+      },
+      "PickWorkshopPartsLineDto": {
+        "type": "object",
+        "properties": {
+          "workshopTaskLineItemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "quantity": {
+            "type": "number",
+            "example": 4,
+            "minimum": 0.001
+          },
+          "sourceLocationId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "workshopTaskLineItemId",
+          "quantity"
+        ]
+      },
+      "PickWorkshopPartsDto": {
+        "type": "object",
+        "properties": {
+          "destinationLocationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PickWorkshopPartsLineDto"
+            }
+          }
+        },
+        "required": [
+          "destinationLocationId",
+          "items"
+        ]
       },
       "UpdateWorkshopTaskDto": {
         "type": "object",

--- a/apps/core-api/prisma/seed.ts
+++ b/apps/core-api/prisma/seed.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { PrismaClient, LocationType, TransactionType } from '@prisma/client';
 import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
+import { seedFixedStagingTotes } from '../src/prisma/seed-staging-totes';
 
 const connectionString = process.env.DATABASE_URL;
 const pool = new Pool({ connectionString });
@@ -227,6 +228,14 @@ async function main() {
     });
 
     const locations = [showroom, storage, tireHotel];
+
+    console.log('Seeding fixed staging totes...');
+    const stagingToteSummary = await seedFixedStagingTotes(prisma, {
+        parentLocationId: storage.id,
+    });
+    console.log(
+        `Staging totes summary: created=${stagingToteSummary.created}, updated=${stagingToteSummary.updated}, unchanged=${stagingToteSummary.unchanged}`,
+    );
 
     console.log('Seeding supersession items (Phase 1: Creation)...');
     const vwBrand = allBrands.find(b => b.name === 'Volkswagen');

--- a/apps/core-api/src/inventory/ledger.service.ts
+++ b/apps/core-api/src/inventory/ledger.service.ts
@@ -54,6 +54,7 @@ export class LedgerService {
       where: { id: { in: locationIds } },
     });
     const locationsMap = new Map(locations.map((loc) => [loc.id, loc]));
+    const stockEnabledLocationTypes = new Set(['bin', 'staging_tote']);
 
     for (const params of paramsArray) {
       const location = locationsMap.get(params.locationId);
@@ -62,9 +63,9 @@ export class LedgerService {
           `Location ${params.locationId} not found`,
         );
       }
-      if (location.type !== 'bin') {
+      if (!stockEnabledLocationTypes.has(location.type)) {
         throw new BadRequestException(
-          `Stock can only be stored in BIN locations. Current type: ${location.type} (${location.name})`,
+          `Stock can only be stored in BIN or STAGING_TOTE locations. Current type: ${location.type} (${location.name})`,
         );
       }
     }

--- a/apps/core-api/src/inventory/location.service.ts
+++ b/apps/core-api/src/inventory/location.service.ts
@@ -183,11 +183,19 @@ export class LocationService {
         LocationType.warehouse,
       ],
       [LocationType.customer_storage]: [LocationType.warehouse],
+      [LocationType.staging_tote]: [LocationType.warehouse],
     };
 
-    if (!allowedParents[type as string].includes(parent.type)) {
+    const allowedParentsForType = allowedParents[type as string];
+    if (!allowedParentsForType) {
       throw new BadRequestException(
-        `Location of type ${type} cannot be child of ${parent.type}. Allowed parents: ${allowedParents[type as string].join(', ')}`,
+        `Unsupported location type hierarchy for ${type}`,
+      );
+    }
+
+    if (!allowedParentsForType.includes(parent.type)) {
+      throw new BadRequestException(
+        `Location of type ${type} cannot be child of ${parent.type}. Allowed parents: ${allowedParentsForType.join(', ')}`,
       );
     }
   }

--- a/apps/core-api/src/prisma/seed-staging-totes.spec.ts
+++ b/apps/core-api/src/prisma/seed-staging-totes.spec.ts
@@ -6,6 +6,7 @@ type MockLocation = {
   name: string;
   type: 'staging_tote' | 'warehouse' | 'bin';
   parent_id: string | null;
+  deletedAt: Date | null;
 };
 
 describe('seedFixedStagingTotes', () => {
@@ -23,12 +24,24 @@ describe('seedFixedStagingTotes', () => {
             name: location.name,
             type: location.type,
             parent_id: location.parent_id,
+            deletedAt: location.deletedAt,
           }));
       }),
       upsert: jest.fn().mockImplementation(async (args: {
         where: { code: string };
-        update: { name: string; type: 'staging_tote'; parent_id: string | null };
-        create: { code: string; name: string; type: 'staging_tote'; parent_id: string | null };
+        update: {
+          name: string;
+          type: 'staging_tote';
+          parent_id: string | null;
+          deletedAt?: Date | null;
+        };
+        create: {
+          code: string;
+          name: string;
+          type: 'staging_tote';
+          parent_id: string | null;
+          deletedAt?: Date | null;
+        };
       }) => {
         const existing = locationMap.get(args.where.code);
         const next = existing
@@ -37,6 +50,10 @@ describe('seedFixedStagingTotes', () => {
               name: args.update.name,
               type: args.update.type,
               parent_id: args.update.parent_id,
+              deletedAt:
+                args.update.deletedAt === undefined
+                  ? existing.deletedAt
+                  : args.update.deletedAt,
             }
           : {
               id: `id-${args.where.code}`,
@@ -44,6 +61,7 @@ describe('seedFixedStagingTotes', () => {
               name: args.create.name,
               type: args.create.type,
               parent_id: args.create.parent_id,
+              deletedAt: args.create.deletedAt ?? null,
             };
 
         locationMap.set(args.where.code, next);
@@ -108,5 +126,31 @@ describe('seedFixedStagingTotes', () => {
     });
 
     expect(locationMap.get('TOTE-010')?.name).toBe('Staging Tote 010');
+  });
+
+  it('restores soft-deleted fixed tote locations', async () => {
+    const { prisma, locationMap } = createPrismaMock([
+      {
+        id: 'id-TOTE-001',
+        code: 'TOTE-001',
+        name: 'Staging Tote 001',
+        type: 'staging_tote',
+        parent_id: 'warehouse-1',
+        deletedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await seedFixedStagingTotes(prisma, {
+      parentLocationId: 'warehouse-1',
+    });
+
+    expect(result).toEqual({
+      total: 50,
+      created: 49,
+      updated: 1,
+      unchanged: 0,
+    });
+
+    expect(locationMap.get('TOTE-001')?.deletedAt).toBeNull();
   });
 });

--- a/apps/core-api/src/prisma/seed-staging-totes.spec.ts
+++ b/apps/core-api/src/prisma/seed-staging-totes.spec.ts
@@ -1,0 +1,112 @@
+import { seedFixedStagingTotes } from './seed-staging-totes';
+
+type MockLocation = {
+  id: string;
+  code: string;
+  name: string;
+  type: 'staging_tote' | 'warehouse' | 'bin';
+  parent_id: string | null;
+};
+
+describe('seedFixedStagingTotes', () => {
+  function createPrismaMock(initialLocations: MockLocation[] = []) {
+    const locationMap = new Map(initialLocations.map((location) => [location.code, location]));
+
+    const storageLocation = {
+      findMany: jest.fn().mockImplementation(async (args: { where: { code: { in: string[] } } }) => {
+        const codes = args.where.code.in;
+        return codes
+          .map((code) => locationMap.get(code))
+          .filter((location): location is MockLocation => Boolean(location))
+          .map((location) => ({
+            code: location.code,
+            name: location.name,
+            type: location.type,
+            parent_id: location.parent_id,
+          }));
+      }),
+      upsert: jest.fn().mockImplementation(async (args: {
+        where: { code: string };
+        update: { name: string; type: 'staging_tote'; parent_id: string | null };
+        create: { code: string; name: string; type: 'staging_tote'; parent_id: string | null };
+      }) => {
+        const existing = locationMap.get(args.where.code);
+        const next = existing
+          ? {
+              ...existing,
+              name: args.update.name,
+              type: args.update.type,
+              parent_id: args.update.parent_id,
+            }
+          : {
+              id: `id-${args.where.code}`,
+              code: args.create.code,
+              name: args.create.name,
+              type: args.create.type,
+              parent_id: args.create.parent_id,
+            };
+
+        locationMap.set(args.where.code, next);
+        return next;
+      }),
+    };
+
+    return {
+      prisma: { storageLocation } as any,
+      locationMap,
+    };
+  }
+
+  it('creates fixed totes and remains idempotent with deterministic updates', async () => {
+    const { prisma, locationMap } = createPrismaMock();
+
+    const firstRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: 'warehouse-1',
+    });
+
+    expect(firstRun).toEqual({
+      total: 50,
+      created: 50,
+      updated: 0,
+      unchanged: 0,
+    });
+
+    expect(locationMap.size).toBe(50);
+    expect(locationMap.get('TOTE-001')?.name).toBe('Staging Tote 001');
+    expect(locationMap.get('TOTE-050')?.name).toBe('Staging Tote 050');
+
+    const secondRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: 'warehouse-1',
+    });
+
+    expect(secondRun).toEqual({
+      total: 50,
+      created: 0,
+      updated: 0,
+      unchanged: 50,
+    });
+
+    const mutated = locationMap.get('TOTE-010');
+    if (!mutated) {
+      throw new Error('Expected TOTE-010 to exist in map');
+    }
+
+    locationMap.set('TOTE-010', {
+      ...mutated,
+      name: 'Mutated Tote',
+    });
+
+    const thirdRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: 'warehouse-1',
+    });
+
+    expect(thirdRun).toEqual({
+      total: 50,
+      created: 0,
+      updated: 1,
+      unchanged: 49,
+    });
+
+    expect(locationMap.get('TOTE-010')?.name).toBe('Staging Tote 010');
+  });
+});

--- a/apps/core-api/src/prisma/seed-staging-totes.ts
+++ b/apps/core-api/src/prisma/seed-staging-totes.ts
@@ -1,0 +1,88 @@
+import { Prisma } from '@prisma/client';
+import type { LocationType, PrismaClient } from '@prisma/client';
+
+const FIXED_TOTE_COUNT = 50;
+
+export interface StagingToteSeedSummary {
+  total: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+}
+
+type StorageLocationSeedClient =
+  | Pick<PrismaClient, 'storageLocation'>
+  | Prisma.TransactionClient;
+
+export async function seedFixedStagingTotes(
+  prisma: StorageLocationSeedClient,
+  options: { parentLocationId?: string | null } = {},
+): Promise<StagingToteSeedSummary> {
+  const parentLocationId = options.parentLocationId ?? null;
+  const stagingToteType = 'staging_tote' as LocationType;
+  const toteDefinitions = Array.from({ length: FIXED_TOTE_COUNT }, (_, index) => {
+    const suffix = String(index + 1).padStart(3, '0');
+    return {
+      code: `TOTE-${suffix}`,
+      name: `Staging Tote ${suffix}`,
+      type: stagingToteType,
+      parent_id: parentLocationId,
+    };
+  });
+
+  const existingTotes = await prisma.storageLocation.findMany({
+    where: { code: { in: toteDefinitions.map((definition) => definition.code) } },
+    select: {
+      code: true,
+      name: true,
+      type: true,
+      parent_id: true,
+    },
+  });
+
+  const existingByCode = new Map(existingTotes.map((location) => [location.code, location]));
+
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+
+  const upsertOperations = toteDefinitions.map((definition) => {
+    const existing = existingByCode.get(definition.code);
+
+    if (!existing) {
+      created += 1;
+    } else if (
+      existing.name !== definition.name ||
+      existing.type !== definition.type ||
+      existing.parent_id !== definition.parent_id
+    ) {
+      updated += 1;
+    } else {
+      unchanged += 1;
+    }
+
+    return prisma.storageLocation.upsert({
+      where: { code: definition.code },
+      update: {
+        name: definition.name,
+        type: definition.type,
+        parent_id: definition.parent_id,
+      },
+      create: {
+        code: definition.code,
+        name: definition.name,
+        type: definition.type,
+        parent_id: definition.parent_id,
+      },
+    });
+  });
+
+  await Promise.all(upsertOperations);
+
+  return {
+    total: FIXED_TOTE_COUNT,
+    created,
+    updated,
+    unchanged,
+  };
+}

--- a/apps/core-api/src/prisma/seed-staging-totes.ts
+++ b/apps/core-api/src/prisma/seed-staging-totes.ts
@@ -27,6 +27,7 @@ export async function seedFixedStagingTotes(
       name: `Staging Tote ${suffix}`,
       type: stagingToteType,
       parent_id: parentLocationId,
+      deletedAt: null,
     };
   });
 
@@ -37,6 +38,7 @@ export async function seedFixedStagingTotes(
       name: true,
       type: true,
       parent_id: true,
+      deletedAt: true,
     },
   });
 
@@ -54,7 +56,8 @@ export async function seedFixedStagingTotes(
     } else if (
       existing.name !== definition.name ||
       existing.type !== definition.type ||
-      existing.parent_id !== definition.parent_id
+      existing.parent_id !== definition.parent_id ||
+      existing.deletedAt !== definition.deletedAt
     ) {
       updated += 1;
     } else {
@@ -67,12 +70,14 @@ export async function seedFixedStagingTotes(
         name: definition.name,
         type: definition.type,
         parent_id: definition.parent_id,
+        deletedAt: definition.deletedAt,
       },
       create: {
         code: definition.code,
         name: definition.name,
         type: definition.type,
         parent_id: definition.parent_id,
+        deletedAt: definition.deletedAt,
       },
     });
   });

--- a/apps/core-api/src/workshop/dto/pick-workshop-parts-response.dto.ts
+++ b/apps/core-api/src/workshop/dto/pick-workshop-parts-response.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PickWorkshopPartAllocationResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  sourceLocationId!: string;
+
+  @ApiProperty({ example: 2, minimum: 1 })
+  quantity!: number;
+
+  @ApiProperty()
+  referenceId!: string;
+}
+
+export class PickWorkshopPartMovedLineResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  workshopTaskLineItemId!: string;
+
+  @ApiProperty({ example: 4, minimum: 1 })
+  movedQuantity!: number;
+
+  @ApiProperty({
+    type: () => [PickWorkshopPartAllocationResponseDto],
+  })
+  allocations!: PickWorkshopPartAllocationResponseDto[];
+}
+
+export class PickWorkshopPartsResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  stagingLocationId!: string;
+
+  @ApiProperty({ example: 'WO-PICK-<order-id>-<timestamp>' })
+  transferGroupId!: string;
+
+  @ApiProperty({
+    type: () => [PickWorkshopPartMovedLineResponseDto],
+  })
+  movedLines!: PickWorkshopPartMovedLineResponseDto[];
+}

--- a/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.spec.ts
+++ b/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.spec.ts
@@ -1,0 +1,44 @@
+import { plainToInstance } from 'class-transformer';
+import { validate, type ValidationError } from 'class-validator';
+import { PickWorkshopPartsDto } from './pick-workshop-parts.dto';
+
+const collectConstraintMessages = (errors: ValidationError[]): string[] =>
+  errors.flatMap((error) => [
+    ...(error.constraints ? Object.values(error.constraints) : []),
+    ...collectConstraintMessages(error.children ?? []),
+  ]);
+
+describe('PickWorkshopPartsDto', () => {
+  it('rejects fractional quantities', async () => {
+    const dto = plainToInstance(PickWorkshopPartsDto, {
+      destinationLocationId: '550e8400-e29b-41d4-a716-446655440000',
+      items: [
+        {
+          workshopTaskLineItemId: '550e8400-e29b-41d4-a716-446655440001',
+          quantity: 0.5,
+        },
+      ],
+    });
+
+    const errors = await validate(dto);
+    const messages = collectConstraintMessages(errors);
+
+    expect(messages).toContain('quantity must be an integer number');
+  });
+
+  it('accepts whole-number quantities of at least one', async () => {
+    const dto = plainToInstance(PickWorkshopPartsDto, {
+      destinationLocationId: '550e8400-e29b-41d4-a716-446655440000',
+      items: [
+        {
+          workshopTaskLineItemId: '550e8400-e29b-41d4-a716-446655440001',
+          quantity: 1,
+        },
+      ],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.ts
+++ b/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.ts
@@ -1,0 +1,43 @@
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class PickWorkshopPartsLineDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  workshopTaskLineItemId!: string;
+
+  @ApiProperty({ example: 4, minimum: 0.001 })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0.001)
+  quantity!: number;
+
+  @ApiPropertyOptional({ format: 'uuid' })
+  @IsOptional()
+  @IsUUID()
+  sourceLocationId?: string;
+}
+
+export class PickWorkshopPartsDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  destinationLocationId!: string;
+
+  @ApiProperty({
+    type: () => [PickWorkshopPartsLineDto],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => PickWorkshopPartsLineDto)
+  items!: PickWorkshopPartsLineDto[];
+}

--- a/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.ts
+++ b/apps/core-api/src/workshop/dto/pick-workshop-parts.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArrayNotEmpty,
   IsArray,
-  IsNumber,
+  IsInt,
   IsOptional,
   IsUUID,
   Min,
@@ -15,10 +15,10 @@ export class PickWorkshopPartsLineDto {
   @IsUUID()
   workshopTaskLineItemId!: string;
 
-  @ApiProperty({ example: 4, minimum: 0.001 })
+  @ApiProperty({ example: 4, minimum: 1, type: 'integer' })
   @Type(() => Number)
-  @IsNumber()
-  @Min(0.001)
+  @IsInt()
+  @Min(1)
   quantity!: number;
 
   @ApiPropertyOptional({ format: 'uuid' })

--- a/apps/core-api/src/workshop/workshop.controller.spec.ts
+++ b/apps/core-api/src/workshop/workshop.controller.spec.ts
@@ -1,7 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { DECORATORS } from '@nestjs/swagger/dist/constants';
 import { WorkshopController } from './workshop.controller';
 import { WorkshopPdfService } from './workshop-pdf.service';
 import { WorkshopService } from './workshop.service';
+import { PickWorkshopPartsResponseDto } from './dto/pick-workshop-parts-response.dto';
 
 describe('WorkshopController', () => {
   let controller: WorkshopController;
@@ -53,5 +57,25 @@ describe('WorkshopController', () => {
       '11111111-1111-1111-1111-111111111111',
       { targetBaseUrl: 'https://app.example.com/api' },
     );
+  });
+
+  it('registers pick-parts route under workshop orders path', () => {
+    const routePath = Reflect.getMetadata(PATH_METADATA, controller.pickParts);
+    const routeMethod = Reflect.getMetadata(
+      METHOD_METADATA,
+      controller.pickParts,
+    );
+
+    expect(routePath).toBe('orders/:id/pick-parts');
+    expect(routeMethod).toBe(RequestMethod.POST);
+  });
+
+  it('documents pick-parts response schema in Swagger metadata', () => {
+    const responses = Reflect.getMetadata(
+      DECORATORS.API_RESPONSE,
+      controller.pickParts,
+    ) as Record<string, { type?: unknown }>;
+
+    expect(responses?.['201']?.type).toBe(PickWorkshopPartsResponseDto);
   });
 });

--- a/apps/core-api/src/workshop/workshop.controller.ts
+++ b/apps/core-api/src/workshop/workshop.controller.ts
@@ -29,6 +29,7 @@ import { CreateWorkshopTaskDto } from './dto/create-workshop-task.dto';
 import { RegisterIntakeDto } from './dto/register-intake.dto';
 import { ReplaceWorkshopTaskLineItemsDto } from './dto/replace-workshop-task-line-items.dto';
 import { PickWorkshopPartsDto } from './dto/pick-workshop-parts.dto';
+import { PickWorkshopPartsResponseDto } from './dto/pick-workshop-parts-response.dto';
 import { UpdateWorkshopOrderDto } from './dto/update-workshop-order.dto';
 import { UpdateWorkshopTaskDto } from './dto/update-workshop-task.dto';
 import { WorkshopPdfGenerationResponseDto } from './dto/workshop-pdf-generation-response.dto';
@@ -115,9 +116,13 @@ export class WorkshopController {
     return this.workshopService.createTask(id, dto);
   }
 
-  @Post(':id/pick-parts')
-  pickParts(@Param('id') id: string, @Body() dto: PickWorkshopPartsDto) {
-    return this.workshopService.pickParts(id, dto);
+  @Post('orders/:id/pick-parts')
+  @ApiCreatedResponse({
+    description: 'Workshop parts pick transfer summary.',
+    type: PickWorkshopPartsResponseDto,
+  })
+  pickParts(@Param('id') orderId: string, @Body() dto: PickWorkshopPartsDto) {
+    return this.workshopService.pickParts(orderId, dto);
   }
 
   @Patch('orders/:orderId/tasks/:taskId')

--- a/apps/core-api/src/workshop/workshop.controller.ts
+++ b/apps/core-api/src/workshop/workshop.controller.ts
@@ -28,6 +28,7 @@ import { CreateWorkshopOrderDto } from './dto/create-workshop-order.dto';
 import { CreateWorkshopTaskDto } from './dto/create-workshop-task.dto';
 import { RegisterIntakeDto } from './dto/register-intake.dto';
 import { ReplaceWorkshopTaskLineItemsDto } from './dto/replace-workshop-task-line-items.dto';
+import { PickWorkshopPartsDto } from './dto/pick-workshop-parts.dto';
 import { UpdateWorkshopOrderDto } from './dto/update-workshop-order.dto';
 import { UpdateWorkshopTaskDto } from './dto/update-workshop-task.dto';
 import { WorkshopPdfGenerationResponseDto } from './dto/workshop-pdf-generation-response.dto';
@@ -112,6 +113,11 @@ export class WorkshopController {
   @Post('orders/:id/tasks')
   createTask(@Param('id') id: string, @Body() dto: CreateWorkshopTaskDto) {
     return this.workshopService.createTask(id, dto);
+  }
+
+  @Post(':id/pick-parts')
+  pickParts(@Param('id') id: string, @Body() dto: PickWorkshopPartsDto) {
+    return this.workshopService.pickParts(id, dto);
   }
 
   @Patch('orders/:orderId/tasks/:taskId')

--- a/apps/core-api/src/workshop/workshop.module.ts
+++ b/apps/core-api/src/workshop/workshop.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { CommonModule } from '../common';
+import { InventoryModule } from '../inventory/inventory.module';
 import { InvoicesModule } from '../invoices/invoices.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { WorkshopPdfService } from './workshop-pdf.service';
@@ -9,7 +10,7 @@ import { WorkshopController } from './workshop.controller';
 import { WorkshopService } from './workshop.service';
 
 @Module({
-  imports: [PrismaModule, InvoicesModule, CommonModule],
+  imports: [PrismaModule, InvoicesModule, InventoryModule, CommonModule],
   controllers: [WorkshopController],
   providers: [
     WorkshopService,

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -6,6 +6,7 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   Prisma,
+  TransactionType,
   WorkshopLineItemType,
   WorkshopOrderStatus,
   WorkshopTaskStatus,
@@ -477,6 +478,82 @@ describe('WorkshopService', () => {
           staging_location_id: 'tote-1',
         },
       }),
+    );
+  });
+
+  it('does not overcommit the same source bin across same-SKU lines in one request', async () => {
+    mockPrisma.workshopOrder.findUnique.mockResolvedValue({
+      id: 'wo-1',
+      status: WorkshopOrderStatus.IN_PROGRESS,
+      order_number: 'WO-2026-0001',
+    });
+    mockPrisma.storageLocation.findUnique.mockResolvedValue({
+      id: 'tote-1',
+      type: 'staging_tote',
+      deletedAt: null,
+    });
+    mockPrisma.workshopTaskLineItem.findMany.mockResolvedValue([
+      {
+        id: 'line-1',
+        item_no: 'SKU-1',
+      },
+      {
+        id: 'line-2',
+        item_no: 'SKU-1',
+      },
+    ]);
+    mockPrisma.catalogItem.findMany.mockResolvedValue([
+      {
+        id: 'item-1',
+        sku: 'SKU-1',
+      },
+    ]);
+    mockPrisma.inventoryStock.findMany.mockResolvedValue([
+      {
+        id: 'stock-1',
+        location_id: 'bin-a',
+        quantity_on_hand: 1,
+      },
+      {
+        id: 'stock-2',
+        location_id: 'bin-b',
+        quantity_on_hand: 1,
+      },
+    ]);
+    mockPrisma.workshopOrder.updateMany.mockResolvedValue({ count: 1 });
+
+    await (service as any).pickParts('wo-1', {
+      destinationLocationId: 'tote-1',
+      items: [
+        {
+          workshopTaskLineItemId: 'line-1',
+          quantity: 1,
+        },
+        {
+          workshopTaskLineItemId: 'line-2',
+          quantity: 1,
+        },
+      ],
+    });
+
+    expect(mockLedgerService.recordTransactions).toHaveBeenCalledTimes(1);
+    const recordedTransactions =
+      mockLedgerService.recordTransactions.mock.calls[0]?.[0] ?? [];
+    const transferOutTransactions = recordedTransactions.filter(
+      (transaction: any) => transaction.type === TransactionType.TRANSFER_OUT,
+    );
+
+    expect(transferOutTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          locationId: 'bin-a',
+          quantity: -1,
+        }),
+        expect.objectContaining({
+          locationId: 'bin-b',
+          quantity: -1,
+        }),
+      ]),
     );
   });
 });

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   Prisma,
@@ -6,6 +10,7 @@ import {
   WorkshopOrderStatus,
   WorkshopTaskStatus,
 } from '@prisma/client';
+import { LedgerService } from '../inventory/ledger.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { WorkshopService } from './workshop.service';
 import { InvoicesService } from '../invoices/invoices.service';
@@ -30,15 +35,26 @@ describe('WorkshopService', () => {
       update: jest.fn(),
       updateMany: jest.fn(),
     },
+    storageLocation: {
+      findUnique: jest.fn(),
+    },
     workshopTask: {
       findFirst: jest.fn(),
       findMany: jest.fn(),
       delete: jest.fn(),
       update: jest.fn(),
     },
+    catalogItem: {
+      findMany: jest.fn(),
+    },
+    inventoryStock: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
     workshopTaskLineItem: {
       deleteMany: jest.fn(),
       createMany: jest.fn(),
+      findMany: jest.fn(),
     },
     $transaction: jest.fn(),
   };
@@ -47,12 +63,17 @@ describe('WorkshopService', () => {
     createDraftInvoice: jest.fn(),
   };
 
+  const mockLedgerService = {
+    recordTransactions: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WorkshopService,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: InvoicesService, useValue: mockInvoices },
+        { provide: LedgerService, useValue: mockLedgerService },
       ],
     }).compile();
 
@@ -374,5 +395,88 @@ describe('WorkshopService', () => {
     expect(partLineItem.standardAw).toBeNull();
     expect(partLineItem.actualHours).toBeNull();
     expect(partLineItem.internalCostRate).toBeNull();
+  });
+
+  it('rejects pick-parts when workshop order status is not eligible', async () => {
+    mockPrisma.workshopOrder.findUnique.mockResolvedValue({
+      id: 'wo-1',
+      status: WorkshopOrderStatus.COMPLETED,
+      order_number: 'WO-2026-0001',
+    });
+
+    await expect(
+      (service as any).pickParts('wo-1', {
+        destinationLocationId: 'dest-1',
+        items: [
+          {
+            workshopTaskLineItemId: 'line-1',
+            quantity: 1,
+          },
+        ],
+      }),
+    ).rejects.toThrow(UnprocessableEntityException);
+  });
+
+  it('allocates from multiple source bins and records paired ledger transfers', async () => {
+    mockPrisma.workshopOrder.findUnique.mockResolvedValue({
+      id: 'wo-1',
+      status: WorkshopOrderStatus.IN_PROGRESS,
+      order_number: 'WO-2026-0001',
+    });
+    mockPrisma.storageLocation.findUnique.mockResolvedValue({
+      id: 'tote-1',
+      type: 'staging_tote',
+      deletedAt: null,
+    });
+    mockPrisma.workshopTaskLineItem.findMany.mockResolvedValue([
+      {
+        id: 'line-1',
+        item_no: 'SKU-1',
+      },
+    ]);
+    mockPrisma.catalogItem.findMany.mockResolvedValue([
+      {
+        id: 'item-1',
+        sku: 'SKU-1',
+      },
+    ]);
+    mockPrisma.inventoryStock.findMany.mockResolvedValue([
+      {
+        id: 'stock-1',
+        location_id: 'bin-a',
+        quantity_on_hand: 2,
+      },
+      {
+        id: 'stock-2',
+        location_id: 'bin-b',
+        quantity_on_hand: 3,
+      },
+    ]);
+    mockPrisma.workshopOrder.updateMany.mockResolvedValue({ count: 1 });
+
+    await (service as any).pickParts('wo-1', {
+      destinationLocationId: 'tote-1',
+      items: [
+        {
+          workshopTaskLineItemId: 'line-1',
+          quantity: 4,
+        },
+      ],
+    });
+
+    expect(mockLedgerService.recordTransactions).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.workshopOrder.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'wo-1',
+          status: {
+            in: [WorkshopOrderStatus.INTAKE, WorkshopOrderStatus.IN_PROGRESS],
+          },
+        }),
+        data: {
+          staging_location_id: 'tote-1',
+        },
+      }),
+    );
   });
 });

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -406,7 +406,7 @@ describe('WorkshopService', () => {
     });
 
     await expect(
-      (service as any).pickParts('wo-1', {
+      service.pickParts('wo-1', {
         destinationLocationId: 'dest-1',
         items: [
           {
@@ -455,7 +455,7 @@ describe('WorkshopService', () => {
     ]);
     mockPrisma.workshopOrder.updateMany.mockResolvedValue({ count: 1 });
 
-    await (service as any).pickParts('wo-1', {
+    await service.pickParts('wo-1', {
       destinationLocationId: 'tote-1',
       items: [
         {
@@ -522,7 +522,7 @@ describe('WorkshopService', () => {
     ]);
     mockPrisma.workshopOrder.updateMany.mockResolvedValue({ count: 1 });
 
-    await (service as any).pickParts('wo-1', {
+    await service.pickParts('wo-1', {
       destinationLocationId: 'tote-1',
       items: [
         {

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -38,6 +38,8 @@ type SourceAllocation = {
   quantity: number;
 };
 
+type AllocationReservationMap = Map<string, number>;
+
 @Injectable()
 export class WorkshopService {
   constructor(
@@ -112,11 +114,19 @@ export class WorkshopService {
     }
   }
 
+  private getAllocationReservationKey(
+    catalogItemId: string,
+    sourceLocationId: string,
+  ) {
+    return `${catalogItemId}:${sourceLocationId}`;
+  }
+
   private async allocateFromExplicitSource(
     tx: Prisma.TransactionClient,
     catalogItemId: string,
     sourceLocationId: string,
     quantity: number,
+    reservations: AllocationReservationMap,
   ): Promise<SourceAllocation[]> {
     const sourceLocation = await tx.storageLocation.findUnique({
       where: { id: sourceLocationId },
@@ -149,10 +159,15 @@ export class WorkshopService {
       },
     });
 
-    const available = sourceStock?.quantity_on_hand ?? 0;
+    const reservationKey = this.getAllocationReservationKey(
+      catalogItemId,
+      sourceLocationId,
+    );
+    const reservedQuantity = reservations.get(reservationKey) ?? 0;
+    const available = (sourceStock?.quantity_on_hand ?? 0) - reservedQuantity;
     if (available < quantity) {
       throw new UnprocessableEntityException(
-        `Insufficient stock in location ${sourceLocationId}. Requested ${quantity}, available ${available}.`,
+        `Insufficient stock in location ${sourceLocationId}. Requested ${quantity}, available ${Math.max(available, 0)}.`,
       );
     }
 
@@ -163,6 +178,7 @@ export class WorkshopService {
     tx: Prisma.TransactionClient,
     catalogItemId: string,
     quantity: number,
+    reservations: AllocationReservationMap,
   ): Promise<SourceAllocation[]> {
     const sourceStocks = await tx.inventoryStock.findMany({
       where: {
@@ -189,7 +205,18 @@ export class WorkshopService {
         break;
       }
 
-      const allocatedQuantity = Math.min(remaining, stock.quantity_on_hand);
+      const reservationKey = this.getAllocationReservationKey(
+        catalogItemId,
+        stock.location_id,
+      );
+      const reservedQuantity = reservations.get(reservationKey) ?? 0;
+      const availableQuantity = stock.quantity_on_hand - reservedQuantity;
+
+      if (availableQuantity <= 0) {
+        continue;
+      }
+
+      const allocatedQuantity = Math.min(remaining, availableQuantity);
       if (allocatedQuantity <= 0) {
         continue;
       }
@@ -850,6 +877,7 @@ export class WorkshopService {
       const catalogItemBySku = new Map(catalogItems.map((item) => [item.sku, item]));
       const transferGroupId = `WO-PICK-${order.id}-${Date.now()}`;
       const ledgerTransactions: RecordTransactionParams[] = [];
+      const reservations: AllocationReservationMap = new Map();
       const movedLines: Array<{
         workshopTaskLineItemId: string;
         movedQuantity: number;
@@ -881,12 +909,25 @@ export class WorkshopService {
               catalogItem.id,
               requestedItem.sourceLocationId,
               requestedItem.quantity,
+              reservations,
             )
           : await this.allocateAcrossSources(
               tx,
               catalogItem.id,
               requestedItem.quantity,
+              reservations,
             );
+
+        for (const allocation of allocations) {
+          const reservationKey = this.getAllocationReservationKey(
+            catalogItem.id,
+            allocation.sourceLocationId,
+          );
+          reservations.set(
+            reservationKey,
+            (reservations.get(reservationKey) ?? 0) + allocation.quantity,
+          );
+        }
 
         const allocationSummaries: Array<{
           sourceLocationId: string;

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -1,11 +1,14 @@
 import {
   BadRequestException,
+  ConflictException,
   Inject,
   Injectable,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import type { CreateWorkshopOrderDto } from './dto/create-workshop-order.dto';
+import type { PickWorkshopPartsDto } from './dto/pick-workshop-parts.dto';
 import type { RegisterIntakeDto } from './dto/register-intake.dto';
 import type { UpdateWorkshopOrderDto } from './dto/update-workshop-order.dto';
 import type { CreateWorkshopTaskDto } from './dto/create-workshop-task.dto';
@@ -13,21 +16,34 @@ import type { UpdateWorkshopTaskDto } from './dto/update-workshop-task.dto';
 import type { ReplaceWorkshopTaskLineItemsDto } from './dto/replace-workshop-task-line-items.dto';
 import {
   Prisma,
+  TransactionType,
   WorkshopLineItemType,
   WorkshopOrderStatus,
   WorkshopTaskStatus,
 } from '@prisma/client';
 import { InvoicesService } from '../invoices/invoices.service';
+import { LedgerService } from '../inventory/ledger.service';
+import type { RecordTransactionParams } from '../inventory/ledger.service';
 
 const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 100;
 const SEARCH_LIMIT = 100;
+const PICK_ELIGIBLE_ORDER_STATUSES: WorkshopOrderStatus[] = [
+  WorkshopOrderStatus.INTAKE,
+  WorkshopOrderStatus.IN_PROGRESS,
+];
+
+type SourceAllocation = {
+  sourceLocationId: string;
+  quantity: number;
+};
 
 @Injectable()
 export class WorkshopService {
   constructor(
     @Inject(PrismaService) private prisma: PrismaService,
     @Inject(InvoicesService) private invoicesService: InvoicesService,
+    @Inject(LedgerService) private ledgerService: LedgerService,
   ) {}
 
   private async generateOrderNumber() {
@@ -86,6 +102,112 @@ export class WorkshopService {
     if (status === WorkshopOrderStatus.INVOICED) {
       throw new BadRequestException('Workshop order is already invoiced');
     }
+  }
+
+  private assertPickEligible(status: WorkshopOrderStatus) {
+    if (!PICK_ELIGIBLE_ORDER_STATUSES.includes(status)) {
+      throw new UnprocessableEntityException(
+        `Workshop order status ${status} is not eligible for pick execution`,
+      );
+    }
+  }
+
+  private async allocateFromExplicitSource(
+    tx: Prisma.TransactionClient,
+    catalogItemId: string,
+    sourceLocationId: string,
+    quantity: number,
+  ): Promise<SourceAllocation[]> {
+    const sourceLocation = await tx.storageLocation.findUnique({
+      where: { id: sourceLocationId },
+      select: {
+        id: true,
+        type: true,
+        deletedAt: true,
+      },
+    });
+
+    if (!sourceLocation || sourceLocation.deletedAt) {
+      throw new NotFoundException(`Source location ${sourceLocationId} not found`);
+    }
+
+    if (sourceLocation.type !== 'bin') {
+      throw new UnprocessableEntityException(
+        `sourceLocationId must reference a BIN location. Received ${sourceLocation.type}.`,
+      );
+    }
+
+    const sourceStock = await tx.inventoryStock.findUnique({
+      where: {
+        catalog_item_id_location_id: {
+          catalog_item_id: catalogItemId,
+          location_id: sourceLocationId,
+        },
+      },
+      select: {
+        quantity_on_hand: true,
+      },
+    });
+
+    const available = sourceStock?.quantity_on_hand ?? 0;
+    if (available < quantity) {
+      throw new UnprocessableEntityException(
+        `Insufficient stock in location ${sourceLocationId}. Requested ${quantity}, available ${available}.`,
+      );
+    }
+
+    return [{ sourceLocationId, quantity }];
+  }
+
+  private async allocateAcrossSources(
+    tx: Prisma.TransactionClient,
+    catalogItemId: string,
+    quantity: number,
+  ): Promise<SourceAllocation[]> {
+    const sourceStocks = await tx.inventoryStock.findMany({
+      where: {
+        catalog_item_id: catalogItemId,
+        quantity_on_hand: { gt: 0 },
+        location: {
+          type: 'bin',
+          deletedAt: null,
+        },
+      },
+      select: {
+        location_id: true,
+        quantity_on_hand: true,
+        createdAt: true,
+      },
+      orderBy: [{ createdAt: 'asc' }, { location_id: 'asc' }],
+    });
+
+    let remaining = quantity;
+    const allocations: SourceAllocation[] = [];
+
+    for (const stock of sourceStocks) {
+      if (remaining <= 0) {
+        break;
+      }
+
+      const allocatedQuantity = Math.min(remaining, stock.quantity_on_hand);
+      if (allocatedQuantity <= 0) {
+        continue;
+      }
+
+      allocations.push({
+        sourceLocationId: stock.location_id,
+        quantity: allocatedQuantity,
+      });
+      remaining -= allocatedQuantity;
+    }
+
+    if (remaining > 0) {
+      throw new UnprocessableEntityException(
+        `Insufficient stock for auto-allocation. Missing quantity ${remaining}.`,
+      );
+    }
+
+    return allocations;
   }
 
   private normalizeWorkshopOrder(order: any) {
@@ -602,6 +724,240 @@ export class WorkshopService {
     }
 
     return this.findOne(orderId);
+  }
+
+  async pickParts(orderId: string, dto: PickWorkshopPartsDto) {
+    return this.prisma.$transaction(async (tx) => {
+      const order = await tx.workshopOrder.findUnique({
+        where: { id: orderId },
+        select: {
+          id: true,
+          order_number: true,
+          status: true,
+          staging_location_id: true,
+        },
+      });
+
+      if (!order) {
+        throw new NotFoundException(`Workshop order ${orderId} not found`);
+      }
+
+      this.assertPickEligible(order.status);
+
+      if (
+        order.staging_location_id &&
+        order.staging_location_id !== dto.destinationLocationId
+      ) {
+        throw new ConflictException(
+          'Workshop order is already linked to a different staging location',
+        );
+      }
+
+      const destinationLocation = await tx.storageLocation.findUnique({
+        where: { id: dto.destinationLocationId },
+        select: {
+          id: true,
+          type: true,
+          deletedAt: true,
+        },
+      });
+
+      if (!destinationLocation || destinationLocation.deletedAt) {
+        throw new NotFoundException(
+          `Destination location ${dto.destinationLocationId} not found`,
+        );
+      }
+
+      if (destinationLocation.type !== 'staging_tote') {
+        throw new UnprocessableEntityException(
+          'Destination location must be of type staging_tote',
+        );
+      }
+
+      const aggregatedItems = new Map<
+        string,
+        {
+          workshopTaskLineItemId: string;
+          quantity: number;
+          sourceLocationId?: string;
+        }
+      >();
+
+      for (const requestItem of dto.items) {
+        const existing = aggregatedItems.get(requestItem.workshopTaskLineItemId);
+        if (!existing) {
+          aggregatedItems.set(requestItem.workshopTaskLineItemId, {
+            workshopTaskLineItemId: requestItem.workshopTaskLineItemId,
+            quantity: requestItem.quantity,
+            sourceLocationId: requestItem.sourceLocationId,
+          });
+          continue;
+        }
+
+        const previousSource = existing.sourceLocationId ?? null;
+        const incomingSource = requestItem.sourceLocationId ?? null;
+
+        if (previousSource !== incomingSource) {
+          throw new BadRequestException(
+            `Duplicate line ${requestItem.workshopTaskLineItemId} must use a single sourceLocationId`,
+          );
+        }
+
+        existing.quantity += requestItem.quantity;
+      }
+
+      const requestedLineItemIds = Array.from(aggregatedItems.keys());
+      const lineItems = await tx.workshopTaskLineItem.findMany({
+        where: {
+          id: { in: requestedLineItemIds },
+          type: WorkshopLineItemType.PART,
+          workshop_task: {
+            workshop_order_id: orderId,
+          },
+        },
+        select: {
+          id: true,
+          item_no: true,
+        },
+      });
+
+      if (lineItems.length !== requestedLineItemIds.length) {
+        throw new NotFoundException(
+          'One or more workshop part line items were not found for this order',
+        );
+      }
+
+      const skus = Array.from(new Set(lineItems.map((lineItem) => lineItem.item_no)));
+      const catalogItems = await tx.catalogItem.findMany({
+        where: {
+          sku: { in: skus },
+        },
+        select: {
+          id: true,
+          sku: true,
+        },
+      });
+
+      if (catalogItems.length !== skus.length) {
+        const catalogItemBySku = new Set(catalogItems.map((item) => item.sku));
+        const missingSku = skus.find((sku) => !catalogItemBySku.has(sku));
+        throw new NotFoundException(
+          `Catalog item not found for workshop line SKU ${missingSku}`,
+        );
+      }
+
+      const lineItemById = new Map(lineItems.map((lineItem) => [lineItem.id, lineItem]));
+      const catalogItemBySku = new Map(catalogItems.map((item) => [item.sku, item]));
+      const transferGroupId = `WO-PICK-${order.id}-${Date.now()}`;
+      const ledgerTransactions: RecordTransactionParams[] = [];
+      const movedLines: Array<{
+        workshopTaskLineItemId: string;
+        movedQuantity: number;
+        allocations: Array<{
+          sourceLocationId: string;
+          quantity: number;
+          referenceId: string;
+        }>;
+      }> = [];
+
+      for (const requestedItem of aggregatedItems.values()) {
+        const lineItem = lineItemById.get(requestedItem.workshopTaskLineItemId);
+        if (!lineItem) {
+          throw new NotFoundException(
+            `Line item ${requestedItem.workshopTaskLineItemId} not found`,
+          );
+        }
+
+        const catalogItem = catalogItemBySku.get(lineItem.item_no);
+        if (!catalogItem) {
+          throw new NotFoundException(
+            `Catalog item not found for workshop line SKU ${lineItem.item_no}`,
+          );
+        }
+
+        const allocations = requestedItem.sourceLocationId
+          ? await this.allocateFromExplicitSource(
+              tx,
+              catalogItem.id,
+              requestedItem.sourceLocationId,
+              requestedItem.quantity,
+            )
+          : await this.allocateAcrossSources(
+              tx,
+              catalogItem.id,
+              requestedItem.quantity,
+            );
+
+        const allocationSummaries: Array<{
+          sourceLocationId: string;
+          quantity: number;
+          referenceId: string;
+        }> = [];
+
+        allocations.forEach((allocation, index) => {
+          const referenceId = `${transferGroupId}:${lineItem.id}:${index + 1}`;
+          ledgerTransactions.push(
+            {
+              itemId: catalogItem.id,
+              locationId: allocation.sourceLocationId,
+              quantity: -allocation.quantity,
+              type: TransactionType.TRANSFER_OUT,
+              referenceId,
+            },
+            {
+              itemId: catalogItem.id,
+              locationId: destinationLocation.id,
+              quantity: allocation.quantity,
+              type: TransactionType.TRANSFER_IN,
+              referenceId,
+            },
+          );
+
+          allocationSummaries.push({
+            sourceLocationId: allocation.sourceLocationId,
+            quantity: allocation.quantity,
+            referenceId,
+          });
+        });
+
+        movedLines.push({
+          workshopTaskLineItemId: lineItem.id,
+          movedQuantity: requestedItem.quantity,
+          allocations: allocationSummaries,
+        });
+      }
+
+      await this.ledgerService.recordTransactions(ledgerTransactions, tx);
+
+      const orderUpdateResult = await tx.workshopOrder.updateMany({
+        where: {
+          id: orderId,
+          status: {
+            in: PICK_ELIGIBLE_ORDER_STATUSES,
+          },
+          OR: [
+            { staging_location_id: null },
+            { staging_location_id: dto.destinationLocationId },
+          ],
+        },
+        data: {
+          staging_location_id: dto.destinationLocationId,
+        },
+      });
+
+      if (orderUpdateResult.count === 0) {
+        throw new ConflictException(
+          'Workshop order changed during pick execution. Refresh and retry.',
+        );
+      }
+
+      return {
+        id: order.id,
+        stagingLocationId: dto.destinationLocationId,
+        transferGroupId,
+        movedLines,
+      };
+    });
   }
 
   async createInvoiceFromOrder(orderId: string) {

--- a/apps/core-api/test/staging-tote-seed.e2e-spec.ts
+++ b/apps/core-api/test/staging-tote-seed.e2e-spec.ts
@@ -1,0 +1,130 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { seedFixedStagingTotes } from '../src/prisma/seed-staging-totes';
+
+describe('Staging Tote Seed (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let warehouseId: string;
+
+  const toteCodes = Array.from({ length: 50 }, (_, index) => {
+    const value = String(index + 1).padStart(3, '0');
+    return `TOTE-${value}`;
+  });
+
+  beforeAll(async () => {
+    process.env.API_KEY = 'test-api-key';
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    prisma = app.get<PrismaService>(PrismaService);
+
+    const warehouse = await prisma.storageLocation.upsert({
+      where: { code: 'WH-STAGE-TOTE-E2E' },
+      update: {
+        name: 'Staging Tote E2E Warehouse',
+        type: 'warehouse',
+        parent_id: null,
+      },
+      create: {
+        code: 'WH-STAGE-TOTE-E2E',
+        name: 'Staging Tote E2E Warehouse',
+        type: 'warehouse',
+      },
+    });
+
+    warehouseId = warehouse.id;
+  });
+
+  beforeEach(async () => {
+    await prisma.storageLocation.deleteMany({
+      where: {
+        code: { in: toteCodes },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.storageLocation.deleteMany({
+      where: {
+        code: { in: toteCodes },
+      },
+    });
+
+    await prisma.storageLocation.deleteMany({
+      where: { id: warehouseId },
+    });
+
+    await app.close();
+  });
+
+  it('creates 50 fixed staging totes and stays idempotent on reruns', async () => {
+    const firstRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: warehouseId,
+    });
+
+    expect(firstRun).toEqual({
+      total: 50,
+      created: 50,
+      updated: 0,
+      unchanged: 0,
+    });
+
+    const seededTotes = await prisma.storageLocation.findMany({
+      where: {
+        code: { in: toteCodes },
+      },
+      orderBy: { code: 'asc' },
+    });
+
+    expect(seededTotes).toHaveLength(50);
+    expect(seededTotes[0].code).toBe('TOTE-001');
+    expect(seededTotes[49].code).toBe('TOTE-050');
+    seededTotes.forEach((location) => {
+      expect(location.type).toBe('staging_tote');
+    });
+
+    const secondRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: warehouseId,
+    });
+
+    expect(secondRun).toEqual({
+      total: 50,
+      created: 0,
+      updated: 0,
+      unchanged: 50,
+    });
+
+    await prisma.storageLocation.update({
+      where: { code: 'TOTE-010' },
+      data: {
+        name: 'Mutated Tote Name',
+      },
+    });
+
+    const thirdRun = await seedFixedStagingTotes(prisma, {
+      parentLocationId: warehouseId,
+    });
+
+    expect(thirdRun).toEqual({
+      total: 50,
+      created: 0,
+      updated: 1,
+      unchanged: 49,
+    });
+
+    const restoredTote = await prisma.storageLocation.findUnique({
+      where: { code: 'TOTE-010' },
+    });
+
+    expect(restoredTote?.name).toBe('Staging Tote 010');
+    expect(restoredTote?.type).toBe('staging_tote');
+    expect(restoredTote?.parent_id).toBe(warehouseId);
+  });
+});

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -1024,6 +1024,29 @@ export interface components {
             destinationLocationId: string;
             items: components["schemas"]["PickWorkshopPartsLineDto"][];
         };
+        PickWorkshopPartAllocationResponseDto: {
+            /** Format: uuid */
+            sourceLocationId: string;
+            /** @example 2 */
+            quantity: number;
+            referenceId: string;
+        };
+        PickWorkshopPartMovedLineResponseDto: {
+            /** Format: uuid */
+            workshopTaskLineItemId: string;
+            /** @example 4 */
+            movedQuantity: number;
+            allocations: components["schemas"]["PickWorkshopPartAllocationResponseDto"][];
+        };
+        PickWorkshopPartsResponseDto: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            stagingLocationId: string;
+            /** @example WO-PICK-<order-id>-<timestamp> */
+            transferGroupId: string;
+            movedLines: components["schemas"]["PickWorkshopPartMovedLineResponseDto"][];
+        };
         UpdateWorkshopTaskDto: Record<string, never>;
         ReplaceWorkshopTaskLineItemsDto: Record<string, never>;
         WorkshopPdfGenerationResponseDto: {
@@ -2663,11 +2686,14 @@ export interface operations {
             };
         };
         responses: {
+            /** @description Workshop parts pick transfer summary. */
             201: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PickWorkshopPartsResponseDto"];
+                };
             };
         };
     };

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -644,7 +644,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/workshop/{id}/pick-parts": {
+    "/api/workshop/orders/{id}/pick-parts": {
         parameters: {
             query?: never;
             header?: never;

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -644,6 +644,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workshop/{id}/pick-parts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["WorkshopController_pickParts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workshop/orders/{orderId}/tasks/{taskId}": {
         parameters: {
             query?: never;
@@ -995,6 +1011,19 @@ export interface components {
         CreateWorkshopOrderDto: Record<string, never>;
         UpdateWorkshopOrderDto: Record<string, never>;
         CreateWorkshopTaskDto: Record<string, never>;
+        PickWorkshopPartsLineDto: {
+            /** Format: uuid */
+            workshopTaskLineItemId: string;
+            /** @example 4 */
+            quantity: number;
+            /** Format: uuid */
+            sourceLocationId?: string;
+        };
+        PickWorkshopPartsDto: {
+            /** Format: uuid */
+            destinationLocationId: string;
+            items: components["schemas"]["PickWorkshopPartsLineDto"][];
+        };
         UpdateWorkshopTaskDto: Record<string, never>;
         ReplaceWorkshopTaskLineItemsDto: Record<string, never>;
         WorkshopPdfGenerationResponseDto: {
@@ -2608,6 +2637,29 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["CreateWorkshopTaskDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    WorkshopController_pickParts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PickWorkshopPartsDto"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
Implements workshop parts-picking and staging tote foundation work for backend inventory movement.

### Included
- Add pick-parts workflow endpoint at POST /api/workshop/orders/:id/pick-parts.
- Add deterministic, idempotent staging tote seeding for TOTE-001..TOTE-050.
- Extend inventory ledger/location support for staging tote usage.
- Regenerate backend OpenAPI and frontend generated API types.

### Review Follow-ups Applied
- Prevent over-allocation when multiple requested lines share the same SKU by reserving per-request source-bin availability.
- Enforce integer pick quantities (@IsInt() + @Min(1)) to match integer stock semantics.
- Align workshop pick-parts route with existing workshop order routing conventions.
- Replace string type assertion with enum-safe LocationType.staging_tote in tote seeding helper.

### Validation
- npm --prefix apps/core-api test -- src/workshop/workshop.controller.spec.ts src/workshop/dto/pick-workshop-parts.dto.spec.ts src/workshop/workshop.service.spec.ts src/prisma/seed-staging-totes.spec.ts
- npm --prefix apps/core-api run openapi:generate; npm --prefix apps/core-web run api:types:generate