### PR TITLE
feat(workshop): implement pick queue drawer + execution integration

### DIFF
--- a/apps/core-web/e2e/utils/mock-factories.ts
+++ b/apps/core-web/e2e/utils/mock-factories.ts
@@ -216,8 +216,17 @@ type MockWorkshopTask = {
   title: string;
   done: boolean;
   status: string;
-  lineItems: unknown[];
+  lineItems: MockWorkshopTaskLineItem[];
   mechanicNotes: string;
+};
+
+type MockWorkshopTaskLineItem = {
+  id: string;
+  type: 'PART' | 'LABOR';
+  itemNo: string;
+  description: string;
+  qty: number;
+  unitPrice: number;
 };
 
 type MockWorkshopOrder = {
@@ -225,6 +234,8 @@ type MockWorkshopOrder = {
   order_number: string;
   status: string;
   reported_issue: string;
+  staging_location_id?: string | null;
+  stagingLocationId?: string | null;
   customer: MockCustomer;
   vehicle: MockVehicle;
   tasks: MockWorkshopTask[];
@@ -236,9 +247,11 @@ export const createMockWorkshopOrder = (
   overrides: Partial<MockWorkshopOrder> = {},
 ): MockWorkshopOrder => ({
   id: 'ws-123',
-  order_number: 'WS-2026-001',
-  status: 'OPEN',
+  order_number: 'WO-2026-0001',
+  status: 'INTAKE',
   reported_issue: 'Vehicle maintenance',
+  staging_location_id: null,
+  stagingLocationId: null,
   customer: createMockCustomer(),
   vehicle: createMockVehicle(),
   tasks: [
@@ -247,12 +260,44 @@ export const createMockWorkshopOrder = (
       title: 'General Inspection',
       done: false,
       status: 'NOT_STARTED',
-      lineItems: [],
+      lineItems: [
+        {
+          id: 'line-1',
+          type: 'PART',
+          itemNo: '06J-115-403-Q',
+          description: 'Oil Filter',
+          qty: 2,
+          unitPrice: 19.9,
+        },
+      ],
       mechanicNotes: '',
     },
   ],
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Storage Locations
+// ---------------------------------------------------------------------------
+
+type MockStorageLocation = {
+  id: string;
+  name: string;
+  code: string;
+  type: 'warehouse' | 'aisle' | 'shelf' | 'bin' | 'customer_storage' | 'staging_tote';
+  parent_id?: string | null;
+};
+
+export const createMockStorageLocation = (
+  overrides: Partial<MockStorageLocation> = {},
+): MockStorageLocation => ({
+  id: 'loc-tote-001',
+  name: 'Staging Tote 001',
+  code: 'TOTE-001',
+  type: 'staging_tote',
+  parent_id: null,
   ...overrides,
 });
 

--- a/apps/core-web/e2e/workshop-pick.spec.ts
+++ b/apps/core-web/e2e/workshop-pick.spec.ts
@@ -1,0 +1,337 @@
+import { test, expect, type Page } from '@playwright/test';
+import { AutoCorePage } from './pom/AutoCorePage';
+import {
+  createMockListResponse,
+  createMockStorageLocation,
+  createMockWorkshopOrder,
+} from './utils/mock-factories';
+
+const LIVE_PICK_SKU = '06J-115-403-Q';
+
+async function seedWorkshopOrderForPick(page: Page) {
+  const searchResponse = await page.request.get('/api/workshop/search?q=max');
+  expect(searchResponse.ok(), 'Expected workshop search API to succeed').toBeTruthy();
+
+  const searchPayload = await searchResponse.json();
+  const vehicle = (searchPayload?.data?.vehicles ?? []).find(
+    (entry: any) => entry?.customer?.id,
+  );
+  expect(vehicle, 'Expected at least one seeded vehicle with a linked customer').toBeTruthy();
+
+  const createOrderResponse = await page.request.post('/api/workshop/orders', {
+    data: {
+      customerId: vehicle.customer.id,
+      vehicleId: vehicle.id,
+      odometer: 123456,
+      fuelLevel: 50,
+      reportedIssue: 'E2E pick queue smoke',
+    },
+  });
+  expect(createOrderResponse.ok(), 'Expected workshop order creation to succeed').toBeTruthy();
+  const createdOrder = await createOrderResponse.json();
+
+  const createTaskResponse = await page.request.post(
+    `/api/workshop/orders/${createdOrder.id}/tasks`,
+    {
+      data: { title: 'E2E pickable task' },
+    },
+  );
+  expect(createTaskResponse.ok(), 'Expected workshop task creation to succeed').toBeTruthy();
+  const createdTask = await createTaskResponse.json();
+
+  const replaceLineItemsResponse = await page.request.patch(
+    `/api/workshop/orders/${createdOrder.id}/tasks/${createdTask.id}/line-items`,
+    {
+      data: {
+        items: [
+          {
+            type: 'PART',
+            itemNo: LIVE_PICK_SKU,
+            description: 'E2E smoke pick part',
+            qty: 1,
+            unitPrice: 19.9,
+          },
+        ],
+      },
+    },
+  );
+  expect(
+    replaceLineItemsResponse.ok(),
+    'Expected workshop task line item replacement to succeed',
+  ).toBeTruthy();
+
+  const orderWithPartLines = await replaceLineItemsResponse.json();
+
+  return {
+    orderId: orderWithPartLines.id as string,
+    orderNumber: (orderWithPartLines.order_number ?? createdOrder.order_number) as string,
+  };
+}
+
+async function mockPickQueueBaseRoutes(page: Page, orderId = 'ws-123') {
+  const mockedOrder = createMockWorkshopOrder({
+    id: orderId,
+    order_number: 'WO-2026-0099',
+    status: 'INTAKE',
+    tasks: [
+      {
+        id: 'task-1',
+        title: 'Oil Service',
+        done: false,
+        status: 'NOT_STARTED',
+        mechanicNotes: '',
+        lineItems: [
+          {
+            id: 'line-1',
+            type: 'PART',
+            itemNo: '06J-115-403-Q',
+            description: 'Oil Filter',
+            qty: 2,
+            unitPrice: 19.9,
+          },
+        ],
+      },
+    ],
+  });
+
+  const mockedLocations = [
+    createMockStorageLocation({
+      id: 'loc-tote-001',
+      code: 'TOTE-001',
+      name: 'Staging Tote 001',
+      type: 'staging_tote',
+    }),
+    createMockStorageLocation({
+      id: 'loc-bin-001',
+      code: 'BIN-001',
+      name: 'Primary Bin 001',
+      type: 'bin',
+    }),
+  ];
+
+  await page.route(AutoCorePage.apiRouteMatcher('/api/workshop/orders'), async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(createMockListResponse([mockedOrder])),
+    });
+  });
+
+  await page.route(new RegExp(`.*/api/workshop/orders/${orderId}(\\?.*)?$`), async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockedOrder),
+    });
+  });
+
+  await page.route(AutoCorePage.apiRouteMatcher('/api/inventory/locations'), async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockedLocations),
+    });
+  });
+
+  return { mockedOrder, mockedLocations };
+}
+
+test.describe('Workshop Pick Queue — Smoke Tests (seed-based)', () => {
+  test('should open pick drawer from a seeded pick queue row', async ({ page }) => {
+    const seededOrder = await seedWorkshopOrderForPick(page);
+    const corePage = new AutoCorePage(page, 'Order');
+
+    await corePage.navigate('/workshop/pick-list');
+
+    await expect(
+      page.getByRole('heading', { name: 'Workshop Pick Queue', exact: true }),
+    ).toBeVisible();
+
+    const searchInput = page.getByPlaceholder('Search pick queue...');
+    await searchInput.fill(seededOrder.orderNumber);
+
+    await corePage.openRowDetails(seededOrder.orderNumber);
+
+    await expect(page.getByRole('heading', { name: 'Pick Parts', exact: true })).toBeVisible();
+    await expect(
+      page
+        .locator('[data-pick-drawer-header="true"]')
+        .getByRole('button', { name: 'Confirm Pick', exact: true }),
+    ).toBeVisible();
+  });
+});
+
+test.describe('Workshop Pick Queue — Blueprint Validation (mocked)', () => {
+  test('should prefill required quantities and restore defaults via Pick All', async ({ page }) => {
+    const { mockedOrder } = await mockPickQueueBaseRoutes(page);
+
+    await page.route(
+      new RegExp(`.*/api/workshop/orders/${mockedOrder.id}/pick-parts(\\?.*)?$`),
+      async (route) => {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: mockedOrder.id,
+            stagingLocationId: 'loc-tote-001',
+            transferGroupId: 'WO-PICK-MOCK-1',
+            movedLines: [
+              {
+                workshopTaskLineItemId: 'line-1',
+                movedQuantity: 2,
+                allocations: [
+                  {
+                    sourceLocationId: 'loc-bin-001',
+                    quantity: 2,
+                    referenceId: 'WO-PICK-MOCK-1:line-1:1',
+                  },
+                ],
+              },
+            ],
+          }),
+        });
+      },
+    );
+
+    await page.goto('/workshop/pick-list');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('cell', { name: mockedOrder.order_number }).first()).toBeVisible();
+    await page.getByRole('cell', { name: mockedOrder.order_number }).first().click();
+
+    const quantityInput = page.getByLabel('Quantity for Oil Filter (06J-115-403-Q)');
+    await expect(quantityInput).toHaveValue('2');
+
+    await quantityInput.fill('1');
+    await page.getByRole('button', { name: 'Pick All', exact: true }).click();
+    await expect(quantityInput).toHaveValue('2');
+
+    await expect(
+      page
+        .locator('[data-pick-drawer-header="true"]')
+        .getByRole('button', { name: 'Confirm Pick', exact: true }),
+    ).toBeVisible();
+  });
+
+  test('should handle 409 conflict with refetch and submit normalized payload on retry', async ({ page }) => {
+    const { mockedOrder } = await mockPickQueueBaseRoutes(page);
+
+    let requestCount = 0;
+    const requestBodies: Array<Record<string, unknown>> = [];
+
+    await page.route(
+      new RegExp(`.*/api/workshop/orders/${mockedOrder.id}/pick-parts(\\?.*)?$`),
+      async (route) => {
+        requestCount += 1;
+        requestBodies.push(JSON.parse(route.request().postData() ?? '{}'));
+
+        if (requestCount === 1) {
+          await route.fulfill({
+            status: 409,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'Conflict while picking parts' }),
+          });
+          return;
+        }
+
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: mockedOrder.id,
+            stagingLocationId: 'loc-tote-001',
+            transferGroupId: 'WO-PICK-MOCK-RETRY',
+            movedLines: [
+              {
+                workshopTaskLineItemId: 'line-1',
+                movedQuantity: 2,
+                allocations: [
+                  {
+                    sourceLocationId: 'loc-bin-001',
+                    quantity: 2,
+                    referenceId: 'WO-PICK-MOCK-RETRY:line-1:1',
+                  },
+                ],
+              },
+            ],
+          }),
+        });
+      },
+    );
+
+    await page.goto('/workshop/pick-list');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('cell', { name: mockedOrder.order_number }).first().click();
+
+    await page.getByRole('dialog', { name: 'Pick Parts' }).locator('[role="combobox"]').click();
+    await page.getByRole('option', { name: /TOTE-001 - Staging Tote 001/i }).click();
+
+    const confirmPickButton = page
+      .locator('[data-pick-drawer-header="true"]')
+      .getByRole('button', { name: 'Confirm Pick', exact: true });
+
+    await confirmPickButton.click();
+    await expect(
+      page.getByText('This order was updated by another user. Data was refreshed.'),
+    ).toBeVisible();
+
+    // Keep the user-entered values after conflict for correction/retry.
+    await expect(page.getByLabel('Quantity for Oil Filter (06J-115-403-Q)')).toHaveValue('2');
+
+    await confirmPickButton.click();
+    await expect(page.getByText('Parts picked and staged successfully.')).toBeVisible();
+
+    await expect(requestCount).toBe(2);
+    expect(requestBodies[0]).toEqual({
+      destinationLocationId: 'loc-tote-001',
+      items: [{ workshopTaskLineItemId: 'line-1', quantity: 2 }],
+    });
+    expect(requestBodies[1]).toEqual({
+      destinationLocationId: 'loc-tote-001',
+      items: [{ workshopTaskLineItemId: 'line-1', quantity: 2 }],
+    });
+  });
+
+  test('should disable confirm action while mutation is pending to prevent duplicate submits', async ({
+    page,
+  }) => {
+    const { mockedOrder } = await mockPickQueueBaseRoutes(page);
+    let requestCount = 0;
+
+    await page.route(
+      new RegExp(`.*/api/workshop/orders/${mockedOrder.id}/pick-parts(\\?.*)?$`),
+      async (route) => {
+        requestCount += 1;
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: mockedOrder.id,
+            stagingLocationId: 'loc-tote-001',
+            transferGroupId: 'WO-PICK-MOCK-PENDING',
+            movedLines: [],
+          }),
+        });
+      },
+    );
+
+    await page.goto('/workshop/pick-list');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('cell', { name: mockedOrder.order_number }).first().click();
+    await page.getByRole('dialog', { name: 'Pick Parts' }).locator('[role="combobox"]').click();
+    await page.getByRole('option', { name: /TOTE-001 - Staging Tote 001/i }).click();
+
+    const confirmPickButton = page
+      .locator('[data-pick-drawer-header="true"]')
+      .getByRole('button', { name: 'Confirm Pick', exact: true });
+
+    await confirmPickButton.click();
+    await expect(confirmPickButton).toBeDisabled();
+
+    await expect(page.getByText('Parts picked and staged successfully.')).toBeVisible();
+    expect(requestCount).toBe(1);
+  });
+});

--- a/apps/core-web/src/App.tsx
+++ b/apps/core-web/src/App.tsx
@@ -29,6 +29,7 @@ import DashboardPage from './pages/DashboardPage'
 import { IntakeDashboard } from './pages/workshop/IntakeDashboard'
 import WorkshopOrderDetails from './pages/workshop/WorkshopOrderDetails'
 import WorkshopOrderList from './pages/workshop/WorkshopOrderList'
+import WorkshopPickList from './pages/workshop/WorkshopPickList'
 import CustomerList from './pages/customers/CustomerList'
 import CustomerDetail from './pages/customers/CustomerDetail'
 import VehicleDetail from './pages/vehicles/VehicleDetail'
@@ -77,6 +78,7 @@ function AppRoutes() {
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/workshop/intake" element={<IntakeDashboard />} />
             <Route path="/workshop/orders" element={<WorkshopOrderList />} />
+            <Route path="/workshop/pick-list" element={<WorkshopPickList />} />
             <Route path="/workshop/orders/:id" element={<WorkshopOrderDetails />} />
           </Routes>
         </motion.div>

--- a/apps/core-web/src/api/locations.ts
+++ b/apps/core-web/src/api/locations.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { fetchWithAuth } from './client'
 
-export type LocationType = 'warehouse' | 'aisle' | 'shelf' | 'bin' | 'customer_storage'
+export type LocationType = 'warehouse' | 'aisle' | 'shelf' | 'bin' | 'customer_storage' | 'staging_tote'
 
 export interface StorageLocation {
     id: string
@@ -34,7 +34,7 @@ export function useLocationTree() {
     })
 }
 
-export function useLocations() {
+export function useLocations(options?: { enabled?: boolean }) {
     return useQuery<StorageLocation[]>({
         queryKey: locationKeys.list(),
         queryFn: async () => {
@@ -42,6 +42,7 @@ export function useLocations() {
             if (!response.ok) throw new Error('Failed to fetch locations')
             return response.json()
         },
+        enabled: options?.enabled ?? true,
     })
 }
 

--- a/apps/core-web/src/api/types.ts
+++ b/apps/core-web/src/api/types.ts
@@ -317,6 +317,8 @@ export interface WorkshopOrder {
     id: string
     order_number: string
     status: WorkshopOrderStatus
+    staging_location_id?: string | null
+    stagingLocationId?: string | null
     customer_id: string
     customer: Customer
     vehicle_id: string
@@ -329,6 +331,36 @@ export interface WorkshopOrder {
     tasks?: WorkshopTask[]
     invoice?: Invoice | null
     createdAt: string
+}
+
+export interface WorkshopPickLineItemPayload {
+    workshopTaskLineItemId: string
+    quantity: number
+    sourceLocationId?: string
+}
+
+export interface WorkshopPickPartsPayload {
+    destinationLocationId: string
+    items: WorkshopPickLineItemPayload[]
+}
+
+export interface WorkshopPickLineAllocation {
+    sourceLocationId: string
+    quantity: number
+    referenceId: string
+}
+
+export interface WorkshopPickMovedLine {
+    workshopTaskLineItemId: string
+    movedQuantity: number
+    allocations: WorkshopPickLineAllocation[]
+}
+
+export interface WorkshopPickPartsResponse {
+    id: string
+    stagingLocationId: string
+    transferGroupId: string
+    movedLines: WorkshopPickMovedLine[]
 }
 
 export interface NormalizedWorkshopTask extends Omit<WorkshopTask, 'lineItems'> {

--- a/apps/core-web/src/api/workshop.test.tsx
+++ b/apps/core-web/src/api/workshop.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useWorkshopPickList } from './workshop'
+import { fetchWithAuth } from './client'
+import type { WorkshopOrder } from './types'
+import type { ReactNode } from 'react'
+
+vi.mock('./client', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWorkshopOrder(overrides: Partial<WorkshopOrder> = {}): WorkshopOrder {
+  return {
+    id: overrides.id ?? 'order-1',
+    order_number: overrides.order_number ?? 'WO-2026-0001',
+    status: overrides.status ?? 'INTAKE',
+    customer_id: 'customer-1',
+    customer: {
+      id: 'customer-1',
+      type: 'PRIVATE',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      email: 'ada@example.com',
+    },
+    vehicle_id: 'vehicle-1',
+    vehicle: {
+      id: 'vehicle-1',
+      make: 'Audi',
+      model: 'A4',
+      year: 2024,
+    },
+    odometer: 1000,
+    fuel_level: 0.5,
+    createdAt: '2026-04-17T00:00:00.000Z',
+    tasks: [
+      {
+        id: 'task-1',
+        title: 'Inspect',
+        status: 'IN_PROGRESS',
+        done: false,
+        lineItems: [
+          {
+            id: 'line-1',
+            type: 'PART',
+            itemNo: 'PART-1',
+            description: 'Part 1',
+            qty: 1,
+            unitPrice: 10,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function createJsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response
+}
+
+describe('useWorkshopPickList', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads all backend pages before applying pick eligibility filters', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(createJsonResponse({
+        data: [createWorkshopOrder({
+          id: 'scheduled-order',
+          status: 'SCHEDULED',
+          tasks: [],
+        })],
+        meta: {
+          total: 101,
+          page: 1,
+          pageSize: 100,
+          pageCount: 2,
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        data: [createWorkshopOrder({
+          id: 'eligible-order',
+          order_number: 'WO-2026-0101',
+        })],
+        meta: {
+          total: 101,
+          page: 2,
+          pageSize: 100,
+          pageCount: 2,
+        },
+      }))
+
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(
+      () => useWorkshopPickList({ page: 1, pageSize: 25, filters: [] }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(fetchWithAuth).toHaveBeenCalledTimes(2)
+    expect(result.current.data?.data.map((order) => order.id)).toEqual(['eligible-order'])
+    expect(result.current.data?.meta.total).toBe(1)
+  })
+})

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -7,7 +7,6 @@ import type {
   RegisterIntakePayload,
   WorkshopLineItemType,
   WorkshopOrder,
-  WorkshopOrderStatus,
   WorkshopPickPartsPayload,
   WorkshopPickPartsResponse,
   WorkshopSearchResponse,
@@ -15,12 +14,15 @@ import type {
 } from './types'
 import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
 import { buildDataTableUrl } from './data-table-query'
+import {
+  getWorkshopCustomerDisplayName,
+  isWorkshopOrderPickEligible,
+} from '@/features/workshop/pick-utils'
 
 const WORKSHOP_API = '/api/workshop'
 const LABOR_API = '/api/labor'
 const CATALOG_API = '/api/catalog'
-const PICK_LIST_SOURCE_PAGE_SIZE = 500
-const PICK_ELIGIBLE_ORDER_STATUSES = new Set<WorkshopOrderStatus>(['INTAKE', 'IN_PROGRESS'])
+const PICK_LIST_SOURCE_PAGE_SIZE = 100
 
 const workshopOrderDetailKey = (id: string) => ['workshop', 'order', id] as const
 
@@ -80,13 +82,6 @@ function normalizeOrder(order: any): WorkshopOrder {
   }
 }
 
-function getCustomerDisplayName(order: WorkshopOrder) {
-  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
-    return order.customer.company_name
-  }
-  return `${order.customer.first_name ?? ''} ${order.customer.last_name ?? ''}`.trim()
-}
-
 function countPickablePartLines(order: WorkshopOrder) {
   let count = 0
   for (const task of order.tasks ?? []) {
@@ -111,10 +106,6 @@ function totalPickablePartQuantity(order: WorkshopOrder) {
   return total
 }
 
-function isPickListEligibleOrder(order: WorkshopOrder) {
-  return PICK_ELIGIBLE_ORDER_STATUSES.has(order.status) && countPickablePartLines(order) > 0
-}
-
 function comparePickListOrders(
   left: WorkshopOrder,
   right: WorkshopOrder,
@@ -128,7 +119,7 @@ function comparePickListOrders(
   }
 
   if (sortField === 'customer') {
-    return direction * getCustomerDisplayName(left).localeCompare(getCustomerDisplayName(right))
+    return direction * getWorkshopCustomerDisplayName(left).localeCompare(getWorkshopCustomerDisplayName(right))
   }
 
   if (sortField === 'vehicle') {
@@ -161,6 +152,21 @@ async function parseErrorResponse(response: Response, fallbackMessage: string): 
   return error
 }
 
+async function fetchWorkshopOrdersPage(queryParams: DataTableQueryParams): Promise<WorkshopOrderResponse> {
+  const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, queryParams, {
+    searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
+  })
+
+  const response = await fetchWithAuth(url)
+  if (!response.ok) throw new Error('Failed to fetch workshop pick list')
+
+  const json = await response.json()
+  return {
+    ...json,
+    data: (json.data ?? []).map(normalizeOrder),
+  }
+}
+
 export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
   return useQuery<WorkshopOrderResponse>({
     queryKey: workshopKeys.ordersPage(queryParams),
@@ -191,16 +197,19 @@ export function useWorkshopPickList(queryParams?: DataTableQueryParams) {
         sortDirection: queryParams?.sortDirection,
         filters: queryParams?.filters ?? [],
       }
-      const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, sourceQueryParams, {
-        searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
-      })
+      const firstPage = await fetchWorkshopOrdersPage(sourceQueryParams)
+      const sourcePageCount = Math.max(1, firstPage.meta.pageCount)
+      const additionalPages = sourcePageCount > 1
+        ? await Promise.all(
+          Array.from({ length: sourcePageCount - 1 }, (_, index) => fetchWorkshopOrdersPage({
+            ...sourceQueryParams,
+            page: index + 2,
+          })),
+        )
+        : []
 
-      const response = await fetchWithAuth(url)
-      if (!response.ok) throw new Error('Failed to fetch workshop pick list')
-      const json = await response.json()
-
-      const normalizedOrders = (json.data ?? []).map(normalizeOrder)
-      const filteredOrders = normalizedOrders.filter(isPickListEligibleOrder)
+      const normalizedOrders = [firstPage, ...additionalPages].flatMap((page) => page.data)
+      const filteredOrders = normalizedOrders.filter(isWorkshopOrderPickEligible)
       const sortedOrders = [...filteredOrders].sort((left, right) =>
         comparePickListOrders(left, right, queryParams?.sortField, queryParams?.sortDirection),
       )

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -7,6 +7,9 @@ import type {
   RegisterIntakePayload,
   WorkshopLineItemType,
   WorkshopOrder,
+  WorkshopOrderStatus,
+  WorkshopPickPartsPayload,
+  WorkshopPickPartsResponse,
   WorkshopSearchResponse,
   WorkshopTaskStatus,
 } from './types'
@@ -16,11 +19,23 @@ import { buildDataTableUrl } from './data-table-query'
 const WORKSHOP_API = '/api/workshop'
 const LABOR_API = '/api/labor'
 const CATALOG_API = '/api/catalog'
+const PICK_LIST_SOURCE_PAGE_SIZE = 500
+const PICK_ELIGIBLE_ORDER_STATUSES = new Set<WorkshopOrderStatus>(['INTAKE', 'IN_PROGRESS'])
+
+const workshopOrderDetailKey = (id: string) => ['workshop', 'order', id] as const
+
+type WorkshopApiError = Error & {
+  status?: number
+}
 
 export const workshopKeys = {
   all: ['workshop'] as const,
   orders: () => [...workshopKeys.all, 'orders'] as const,
-  order: (id: string) => [...workshopKeys.all, 'order', id] as const,
+  ordersPage: (queryParams?: DataTableQueryParams) => [...workshopKeys.orders(), queryParams] as const,
+  pickList: () => [...workshopKeys.all, 'pick-list'] as const,
+  pickListPage: (queryParams?: DataTableQueryParams) => [...workshopKeys.pickList(), queryParams] as const,
+  detail: (id: string) => workshopOrderDetailKey(id),
+  order: (id: string) => workshopOrderDetailKey(id),
   search: (query: string) => [...workshopKeys.all, 'search', query] as const,
 }
 
@@ -59,13 +74,96 @@ function normalizeOrder(order: any): WorkshopOrder {
     ...order,
     order_number: order.order_number ?? order.orderNumber ?? order.id,
     reportedIssue: order.reportedIssue ?? order.reported_issue ?? '',
+    stagingLocationId: order.stagingLocationId ?? order.staging_location_id ?? null,
+    staging_location_id: order.staging_location_id ?? order.stagingLocationId ?? null,
     tasks: (order.tasks ?? []).map(normalizeTask),
   }
 }
 
+function getCustomerDisplayName(order: WorkshopOrder) {
+  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
+    return order.customer.company_name
+  }
+  return `${order.customer.first_name ?? ''} ${order.customer.last_name ?? ''}`.trim()
+}
+
+function countPickablePartLines(order: WorkshopOrder) {
+  let count = 0
+  for (const task of order.tasks ?? []) {
+    for (const lineItem of task.lineItems ?? []) {
+      if (lineItem.type === 'PART' && Number(lineItem.qty) > 0) {
+        count += 1
+      }
+    }
+  }
+  return count
+}
+
+function totalPickablePartQuantity(order: WorkshopOrder) {
+  let total = 0
+  for (const task of order.tasks ?? []) {
+    for (const lineItem of task.lineItems ?? []) {
+      if (lineItem.type === 'PART' && Number(lineItem.qty) > 0) {
+        total += Number(lineItem.qty)
+      }
+    }
+  }
+  return total
+}
+
+function isPickListEligibleOrder(order: WorkshopOrder) {
+  return PICK_ELIGIBLE_ORDER_STATUSES.has(order.status) && countPickablePartLines(order) > 0
+}
+
+function comparePickListOrders(
+  left: WorkshopOrder,
+  right: WorkshopOrder,
+  sortField?: string,
+  sortDirection: 'asc' | 'desc' = 'desc',
+) {
+  const direction = sortDirection === 'asc' ? 1 : -1
+
+  if (sortField === 'orderNo' || sortField === 'order_number') {
+    return direction * (left.order_number ?? '').localeCompare(right.order_number ?? '')
+  }
+
+  if (sortField === 'customer') {
+    return direction * getCustomerDisplayName(left).localeCompare(getCustomerDisplayName(right))
+  }
+
+  if (sortField === 'vehicle') {
+    const leftVehicle = `${left.vehicle.year} ${left.vehicle.make} ${left.vehicle.model}`
+    const rightVehicle = `${right.vehicle.year} ${right.vehicle.make} ${right.vehicle.model}`
+    return direction * leftVehicle.localeCompare(rightVehicle)
+  }
+
+  if (sortField === 'status') {
+    return direction * left.status.localeCompare(right.status)
+  }
+
+  if (sortField === 'partLines') {
+    return direction * (countPickablePartLines(left) - countPickablePartLines(right))
+  }
+
+  if (sortField === 'requiredQty') {
+    return direction * (totalPickablePartQuantity(left) - totalPickablePartQuantity(right))
+  }
+
+  const leftCreatedAt = Number(new Date(left.createdAt))
+  const rightCreatedAt = Number(new Date(right.createdAt))
+  return direction * (leftCreatedAt - rightCreatedAt)
+}
+
+async function parseErrorResponse(response: Response, fallbackMessage: string): Promise<WorkshopApiError> {
+  const payload = await response.json().catch(() => ({})) as { message?: string }
+  const error = new Error(payload.message || fallbackMessage) as WorkshopApiError
+  error.status = response.status
+  return error
+}
+
 export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
   return useQuery<WorkshopOrderResponse>({
-    queryKey: [...workshopKeys.orders(), queryParams],
+    queryKey: workshopKeys.ordersPage(queryParams),
     queryFn: async () => {
       const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, queryParams, {
         searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
@@ -81,9 +179,54 @@ export function useWorkshopOrders(queryParams?: DataTableQueryParams) {
   })
 }
 
+export function useWorkshopPickList(queryParams?: DataTableQueryParams) {
+  return useQuery<WorkshopOrderResponse>({
+    queryKey: workshopKeys.pickListPage(queryParams),
+    queryFn: async () => {
+      const sourceQueryParams: DataTableQueryParams = {
+        page: 1,
+        pageSize: PICK_LIST_SOURCE_PAGE_SIZE,
+        search: queryParams?.search,
+        sortField: queryParams?.sortField,
+        sortDirection: queryParams?.sortDirection,
+        filters: queryParams?.filters ?? [],
+      }
+      const url = buildDataTableUrl(`${WORKSHOP_API}/orders`, sourceQueryParams, {
+        searchFallbackFilterFields: ['order_number', 'id', 'customer.first_name', 'customer.last_name', 'vehicle.make', 'vehicle.model', 'vehicle.plate'],
+      })
+
+      const response = await fetchWithAuth(url)
+      if (!response.ok) throw new Error('Failed to fetch workshop pick list')
+      const json = await response.json()
+
+      const normalizedOrders = (json.data ?? []).map(normalizeOrder)
+      const filteredOrders = normalizedOrders.filter(isPickListEligibleOrder)
+      const sortedOrders = [...filteredOrders].sort((left, right) =>
+        comparePickListOrders(left, right, queryParams?.sortField, queryParams?.sortDirection),
+      )
+
+      const page = queryParams?.page ?? 1
+      const pageSize = queryParams?.pageSize ?? 25
+      const offset = (page - 1) * pageSize
+      const pagedOrders = sortedOrders.slice(offset, offset + pageSize)
+      const pageCount = Math.max(1, Math.ceil(sortedOrders.length / pageSize))
+
+      return {
+        data: pagedOrders,
+        meta: {
+          total: sortedOrders.length,
+          page,
+          pageSize,
+          pageCount,
+        },
+      }
+    },
+  })
+}
+
 export function useWorkshopOrder(id: string) {
   return useQuery<WorkshopOrder>({
-    queryKey: workshopKeys.order(id),
+    queryKey: workshopKeys.detail(id),
     queryFn: async () => {
       const response = await fetchWithAuth(`${WORKSHOP_API}/orders/${id}`)
       if (!response.ok) throw new Error('Failed to fetch workshop order')
@@ -310,6 +453,28 @@ export const useReplaceWorkshopTaskLineItems = () => {
     onSuccess: (order) => {
       queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
       queryClient.setQueryData(workshopKeys.order(order.id), order)
+    },
+  })
+}
+
+export const usePickWorkshopParts = () => {
+  const queryClient = useQueryClient()
+  return useMutation<WorkshopPickPartsResponse, WorkshopApiError, { orderId: string; payload: WorkshopPickPartsPayload }>({
+    mutationFn: async ({ orderId, payload }) => {
+      const response = await fetchWithAuth(`${WORKSHOP_API}/orders/${orderId}/pick-parts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        throw await parseErrorResponse(response, 'Failed to pick parts')
+      }
+      return response.json()
+    },
+    onSuccess: (_result, { orderId }) => {
+      queryClient.invalidateQueries({ queryKey: workshopKeys.detail(orderId) })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.pickList() })
+      queryClient.invalidateQueries({ queryKey: workshopKeys.orders() })
     },
   })
 }

--- a/apps/core-web/src/components/ui/separator.tsx
+++ b/apps/core-web/src/components/ui/separator.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import * as SeparatorPrimitive from '@radix-ui/react-separator'
+import { cn } from '@/lib/utils'
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+      className,
+    )}
+    {...props}
+  />
+))
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/apps/core-web/src/features/dashboard-widgets/DashboardWidgetsGrid.tsx
+++ b/apps/core-web/src/features/dashboard-widgets/DashboardWidgetsGrid.tsx
@@ -70,10 +70,11 @@ function DashboardWidgetCard({
   }, [rows, widget.displayType, widget.metricCalculation, widget.metricField])
 
   const metricFieldType = source.fields.find((field) => field.key === widget.metricField)?.type
+  const currency = (widget as any).metricCurrency || 'EUR'
+
   const formattedMetricValue = useMemo(() => {
     if (metricValue == null) return '-'
     const locale = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
-    const currency = (widget as any).metricCurrency || 'EUR'
 
     if (widget.metricCalculation === 'sum' && metricFieldType === 'currency') {
       return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(metricValue)
@@ -82,7 +83,7 @@ function DashboardWidgetCard({
       return new Intl.NumberFormat(locale).format(metricValue)
     }
     return `${metricValue}`
-  }, [metricValue, widget.metricCalculation, metricFieldType, widget])
+  }, [currency, metricFieldType, metricValue, widget.metricCalculation])
 
   return (
     <Card className="h-full">

--- a/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.test.tsx
+++ b/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.test.tsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkshopOrderPickDrawer } from './WorkshopOrderPickDrawer'
+import * as locationsApi from '@/api/locations'
+import * as workshopApi from '@/api/workshop'
+
+vi.mock('@/api/locations')
+vi.mock('@/api/workshop')
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'order-1',
+    order_number: 'WO-2026-0001',
+    status: 'IN_PROGRESS',
+    customer: {
+      id: 'customer-1',
+      type: 'PRIVATE',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+    },
+    tasks: [
+      {
+        id: 'task-1',
+        title: 'Inspect',
+        lineItems: [
+          {
+            id: 'line-1',
+            type: 'PART',
+            itemNo: 'PART-001',
+            description: 'Air filter',
+            qty: 2,
+          },
+        ],
+      },
+    ],
+    staging_location_id: 'tote-1',
+    stagingLocationId: 'tote-1',
+    ...overrides,
+  }
+}
+
+describe('WorkshopOrderPickDrawer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+
+    ;(locationsApi.useLocations as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: [
+        { id: 'tote-1', code: 'TOTE-01', name: 'Primary Tote', type: 'staging_tote' },
+        { id: 'tote-2', code: 'TOTE-02', name: 'Overflow Tote', type: 'staging_tote' },
+      ],
+      isLoading: false,
+    })
+
+    ;(workshopApi.usePickWorkshopParts as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('keeps edited quantities when the order data refreshes while the drawer stays open', () => {
+    let order = createOrder()
+
+    ;(workshopApi.useWorkshopOrder as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      data: order,
+      isLoading: false,
+    }))
+
+    const queryClient = createQueryClient()
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <WorkshopOrderPickDrawer orderId='order-1' open={false} onOpenChange={vi.fn()} />
+      </QueryClientProvider>,
+    )
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <WorkshopOrderPickDrawer orderId='order-1' open onOpenChange={vi.fn()} />
+      </QueryClientProvider>,
+    )
+
+    vi.runAllTimers()
+
+    const quantityInput = screen.getByLabelText('Quantity for Air filter (PART-001)')
+    expect(quantityInput).toHaveValue(2)
+    expect(screen.getByRole('combobox')).toHaveTextContent('TOTE-01 - Primary Tote')
+
+    fireEvent.change(quantityInput, { target: { value: '1' } })
+    expect(quantityInput).toHaveValue(1)
+
+    order = createOrder({
+      staging_location_id: 'tote-2',
+      stagingLocationId: 'tote-2',
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Inspect',
+          lineItems: [
+            {
+              id: 'line-1',
+              type: 'PART',
+              itemNo: 'PART-001',
+              description: 'Air filter',
+              qty: 5,
+            },
+          ],
+        },
+      ],
+    })
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <WorkshopOrderPickDrawer orderId='order-1' open onOpenChange={vi.fn()} />
+      </QueryClientProvider>,
+    )
+
+    expect(screen.getByLabelText('Quantity for Air filter (PART-001)')).toHaveValue(1)
+    expect(screen.getByRole('combobox')).toHaveTextContent('TOTE-01 - Primary Tote')
+  })
+})

--- a/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
+++ b/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
@@ -4,7 +4,8 @@ import { Check, ChevronsUpDown, Loader2, MapPin, Package } from 'lucide-react'
 import { toast } from 'sonner'
 import { useLocations } from '@/api/locations'
 import { usePickWorkshopParts, useWorkshopOrder, workshopKeys } from '@/api/workshop'
-import type { WorkshopPickLineItemPayload } from '@/api/types'
+import type { StorageLocation } from '@/api/locations'
+import type { WorkshopOrder, WorkshopPickLineItemPayload } from '@/api/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -50,24 +51,27 @@ interface WorkshopOrderPickDrawerProps {
 const formatQuantity = (value: number) =>
   Number.isInteger(value) ? String(Math.trunc(value)) : String(value)
 
-export function WorkshopOrderPickDrawer({
+type WorkshopOrderPickDrawerBodyProps = WorkshopOrderPickDrawerProps & {
+  areLocationsLoading: boolean
+  isOrderLoading: boolean
+  locations: StorageLocation[] | undefined
+  order: WorkshopOrder | null | undefined
+}
+
+function WorkshopOrderPickDrawerBody({
   orderId,
   open,
   onOpenChange,
-}: WorkshopOrderPickDrawerProps) {
+  areLocationsLoading,
+  isOrderLoading,
+  locations,
+  order,
+}: WorkshopOrderPickDrawerBodyProps) {
   const queryClient = useQueryClient()
   const pickPartsMutation = usePickWorkshopParts()
   const toteTriggerRef = useRef<HTMLButtonElement | null>(null)
-  const prevOpenRef = useRef(false)
-
-  const { data: order, isLoading: isOrderLoading } = useWorkshopOrder(orderId ?? '')
-  const { data: locations, isLoading: areLocationsLoading } = useLocations({ enabled: open })
 
   const [isTotePopoverOpen, setIsTotePopoverOpen] = useState(false)
-  const [selectedStagingLocationId, setSelectedStagingLocationId] = useState<string | null>(null)
-  const [quantitiesByLineId, setQuantitiesByLineId] = useState<Record<string, string>>({})
-  const [formError, setFormError] = useState<string | null>(null)
-
   const requiredPartLines = useMemo(() => getRequiredPartLines(order), [order])
   const requiredLineCount = requiredPartLines.length
   const totalRequiredQuantity = getTotalRequiredQuantity(requiredPartLines)
@@ -80,6 +84,14 @@ export function WorkshopOrderPickDrawer({
     })
     return defaults
   }, [requiredPartLines])
+
+  const [selectedStagingLocationId, setSelectedStagingLocationId] = useState<string | null>(
+    () => order?.stagingLocationId ?? order?.staging_location_id ?? null,
+  )
+  const [quantitiesByLineId, setQuantitiesByLineId] = useState<Record<string, string>>(
+    () => defaultQuantitiesByLineId,
+  )
+  const [formError, setFormError] = useState<string | null>(null)
 
   const stagingTotes = useMemo(
     () => (locations ?? []).filter((location) => location.type === 'staging_tote'),
@@ -98,22 +110,14 @@ export function WorkshopOrderPickDrawer({
   )
 
   useEffect(() => {
-    const wasOpen = prevOpenRef.current
-    prevOpenRef.current = open
-
-    if (!open || wasOpen || !order) return
-
-    setSelectedStagingLocationId(order.stagingLocationId ?? order.staging_location_id ?? null)
-    setQuantitiesByLineId(defaultQuantitiesByLineId)
-    setIsTotePopoverOpen(false)
-    setFormError(null)
+    if (!open) return
 
     const focusTimer = window.setTimeout(() => {
       toteTriggerRef.current?.focus()
     }, 20)
 
     return () => window.clearTimeout(focusTimer)
-  }, [defaultQuantitiesByLineId, open, order])
+  }, [open])
 
   const handlePickAll = () => {
     setQuantitiesByLineId(defaultQuantitiesByLineId)
@@ -224,218 +228,243 @@ export function WorkshopOrderPickDrawer({
     isOrderLoading
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side='right' className='w-full sm:max-w-3xl p-0 flex h-full flex-col'>
-        <form
-          className='flex h-full flex-col'
-          onSubmit={(event) => {
-            event.preventDefault()
-            void handleConfirmPick()
-          }}
-        >
-          <SheetHeader className='px-6 py-4 border-b pr-14' data-pick-drawer-header='true'>
-            <div className='flex items-start justify-between gap-4'>
-              <div className='min-w-0'>
-                <SheetTitle className='text-lg font-semibold flex items-center gap-2'>
-                  <Package className='h-4 w-4' />
-                  Pick Parts
-                </SheetTitle>
-                <SheetDescription className='text-sm text-muted-foreground'>
-                  Assign parts to a staging tote for this workshop order.
-                </SheetDescription>
-                <div className='mt-2 flex flex-wrap items-center gap-2'>
-                  {order ? (
-                    <Badge variant='outline'>
-                      {order.order_number}
-                    </Badge>
-                  ) : null}
-                  {order ? (
-                    <Badge variant='outline'>
-                      {order.status}
-                    </Badge>
-                  ) : null}
-                  <Badge variant='secondary'>
-                    {requiredLineCount} lines
-                  </Badge>
-                </div>
-              </div>
+    <form
+      className='flex h-full flex-col'
+      onSubmit={(event) => {
+        event.preventDefault()
+        void handleConfirmPick()
+      }}
+    >
+      <SheetHeader className='px-6 py-4 border-b pr-14' data-pick-drawer-header='true'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='min-w-0'>
+            <SheetTitle className='text-lg font-semibold flex items-center gap-2'>
+              <Package className='h-4 w-4' />
+              Pick Parts
+            </SheetTitle>
+            <SheetDescription className='text-sm text-muted-foreground'>
+              Assign parts to a staging tote for this workshop order.
+            </SheetDescription>
+            <div className='mt-2 flex flex-wrap items-center gap-2'>
+              {order ? (
+                <Badge variant='outline'>
+                  {order.order_number}
+                </Badge>
+              ) : null}
+              {order ? (
+                <Badge variant='outline'>
+                  {order.status}
+                </Badge>
+              ) : null}
+              <Badge variant='secondary'>
+                {requiredLineCount} lines
+              </Badge>
+            </div>
+          </div>
 
-              <div className='shrink-0 flex items-center gap-2'>
+          <div className='shrink-0 flex items-center gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => onOpenChange(false)}
+              disabled={pickPartsMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isConfirmDisabled}>
+              {pickPartsMutation.isPending ? (
+                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+              ) : null}
+              Confirm Pick
+            </Button>
+          </div>
+        </div>
+      </SheetHeader>
+
+      <div className='px-6 py-4 space-y-4 flex-1 min-h-0'>
+        <div className='space-y-2'>
+          <div className='text-sm font-medium text-foreground'>
+            Destination Tote
+          </div>
+          {areLocationsLoading && stagingTotes.length === 0 ? (
+            <div className='space-y-2'>
+              <div className='h-9 w-full rounded-md bg-slate-100 animate-pulse' />
+              <div className='h-4 w-64 rounded bg-slate-100 animate-pulse' />
+            </div>
+          ) : (
+            <Popover open={isTotePopoverOpen} onOpenChange={setIsTotePopoverOpen}>
+              <PopoverTrigger asChild>
                 <Button
+                  ref={toteTriggerRef}
                   type='button'
                   variant='outline'
-                  onClick={() => onOpenChange(false)}
+                  role='combobox'
+                  aria-expanded={isTotePopoverOpen}
+                  className='w-full justify-between'
                   disabled={pickPartsMutation.isPending}
                 >
-                  Cancel
+                  <span className='truncate'>
+                    {selectedTote
+                      ? `${selectedTote.code} - ${selectedTote.name}`
+                      : 'Select staging tote...'}
+                  </span>
+                  <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
                 </Button>
-                <Button type='submit' disabled={isConfirmDisabled}>
-                  {pickPartsMutation.isPending ? (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  ) : null}
-                  Confirm Pick
-                </Button>
-              </div>
-            </div>
-          </SheetHeader>
-
-          <div className='px-6 py-4 space-y-4 flex-1 min-h-0'>
-            <div className='space-y-2'>
-              <div className='text-sm font-medium text-foreground'>
-                Destination Tote
-              </div>
-              {areLocationsLoading && stagingTotes.length === 0 ? (
-                <div className='space-y-2'>
-                  <div className='h-9 w-full rounded-md bg-slate-100 animate-pulse' />
-                  <div className='h-4 w-64 rounded bg-slate-100 animate-pulse' />
-                </div>
-              ) : (
-                <Popover open={isTotePopoverOpen} onOpenChange={setIsTotePopoverOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      ref={toteTriggerRef}
-                      type='button'
-                      variant='outline'
-                      role='combobox'
-                      aria-expanded={isTotePopoverOpen}
-                      className='w-full justify-between'
-                      disabled={pickPartsMutation.isPending}
-                    >
-                      <span className='truncate'>
-                        {selectedTote
-                          ? `${selectedTote.code} - ${selectedTote.name}`
-                          : 'Select staging tote...'}
-                      </span>
-                      <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className='w-[var(--radix-popover-trigger-width)] p-0' align='start'>
-                    <Command>
-                      <CommandInput placeholder='Search tote...' aria-label='Search tote' />
-                      <CommandList>
-                        <CommandEmpty>No staging tote found.</CommandEmpty>
-                        <CommandGroup>
-                          {stagingTotes.map((location) => (
-                            <CommandItem
-                              key={location.id}
-                              value={`${location.code} ${location.name}`}
-                              onSelect={() => {
-                                setSelectedStagingLocationId(location.id)
-                                setIsTotePopoverOpen(false)
-                                setFormError(null)
-                              }}
-                            >
-                              <Check
-                                className={cn(
-                                  'h-4 w-4',
-                                  selectedStagingLocationId === location.id ? 'opacity-100' : 'opacity-0',
-                                )}
-                              />
-                              <span className='truncate'>{location.code} - {location.name}</span>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-              )}
-              <p className='text-xs text-muted-foreground'>
-                {selectedTote
-                  ? `Selected tote ${selectedTote.code}`
-                  : 'Choose one staging tote for this transfer.'}
-              </p>
-            </div>
-
-            <Separator />
-
-            <div className='flex items-center justify-between gap-3'>
-              <div className='text-sm font-medium'>Required Parts</div>
-              <div className='flex items-center gap-2'>
-                <Badge variant='outline'>Total Qty {formatQuantity(totalRequiredQuantity)}</Badge>
-                <Button
-                  type='button'
-                  variant='ghost'
-                  size='sm'
-                  onClick={handlePickAll}
-                  disabled={requiredPartLines.length === 0 || pickPartsMutation.isPending}
-                >
-                  Pick All
-                </Button>
-              </div>
-            </div>
-
-            <ScrollArea className='flex-1 pr-2'>
-              {isOrderLoading ? (
-                <div className='space-y-2'>
-                  {Array.from({ length: 5 }).map((_, index) => (
-                    <div key={index} className='h-11 rounded-md bg-slate-100 animate-pulse' />
-                  ))}
-                </div>
-              ) : requiredPartLines.length === 0 ? (
-                <div className='rounded-md border border-dashed p-6 text-sm text-muted-foreground'>
-                  No pickable parts were found for this workshop order.
-                </div>
-              ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Part</TableHead>
-                      <TableHead>Task</TableHead>
-                      <TableHead className='text-right'>Required</TableHead>
-                      <TableHead className='w-[150px] text-right'>Pick Qty</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {requiredPartLines.map((line) => (
-                      <TableRow key={line.workshopTaskLineItemId}>
-                        <TableCell>
-                          <div className='font-medium'>{line.itemNo}</div>
-                          <div className='text-xs text-muted-foreground'>{line.description}</div>
-                        </TableCell>
-                        <TableCell className='text-sm text-muted-foreground'>{line.taskTitle}</TableCell>
-                        <TableCell className='text-right font-medium'>{formatQuantity(line.requiredQuantity)}</TableCell>
-                        <TableCell>
-                          <Input
-                            type='number'
-                            min='0'
-                            step='1'
-                            inputMode='numeric'
-                            value={quantitiesByLineId[line.workshopTaskLineItemId] ?? ''}
-                            onChange={(event) => {
-                              const value = event.target.value
-                              setQuantitiesByLineId((previous) => ({
-                                ...previous,
-                                [line.workshopTaskLineItemId]: value,
-                              }))
-                              setFormError(null)
-                            }}
-                            className='h-8 text-right'
-                            aria-label={`Quantity for ${line.description} (${line.itemNo})`}
-                            disabled={!isPickEligible || pickPartsMutation.isPending}
+              </PopoverTrigger>
+              <PopoverContent className='w-[var(--radix-popover-trigger-width)] p-0' align='start'>
+                <Command>
+                  <CommandInput placeholder='Search tote...' aria-label='Search tote' />
+                  <CommandList>
+                    <CommandEmpty>No staging tote found.</CommandEmpty>
+                    <CommandGroup>
+                      {stagingTotes.map((location) => (
+                        <CommandItem
+                          key={location.id}
+                          value={`${location.code} ${location.name}`}
+                          onSelect={() => {
+                            setSelectedStagingLocationId(location.id)
+                            setIsTotePopoverOpen(false)
+                            setFormError(null)
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              'h-4 w-4',
+                              selectedStagingLocationId === location.id ? 'opacity-100' : 'opacity-0',
+                            )}
                           />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              )}
-            </ScrollArea>
+                          <span className='truncate'>{location.code} - {location.name}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          )}
+          <p className='text-xs text-muted-foreground'>
+            {selectedTote
+              ? `Selected tote ${selectedTote.code}`
+              : 'Choose one staging tote for this transfer.'}
+          </p>
+        </div>
 
-            {!isPickEligible ? (
-              <div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 flex items-start gap-2'>
-                <MapPin className='h-4 w-4 mt-0.5 shrink-0' />
-                This workshop order is not in a pick-eligible state.
-              </div>
-            ) : null}
+        <Separator />
 
-            {formError ? (
-              <div className='rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive'>
-                {formError}
-              </div>
-            ) : null}
+        <div className='flex items-center justify-between gap-3'>
+          <div className='text-sm font-medium'>Required Parts</div>
+          <div className='flex items-center gap-2'>
+            <Badge variant='outline'>Total Qty {formatQuantity(totalRequiredQuantity)}</Badge>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={handlePickAll}
+              disabled={requiredPartLines.length === 0 || pickPartsMutation.isPending}
+            >
+              Pick All
+            </Button>
           </div>
-        </form>
+        </div>
+
+        <ScrollArea className='flex-1 pr-2'>
+          {isOrderLoading ? (
+            <div className='space-y-2'>
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div key={index} className='h-11 rounded-md bg-slate-100 animate-pulse' />
+              ))}
+            </div>
+          ) : requiredPartLines.length === 0 ? (
+            <div className='rounded-md border border-dashed p-6 text-sm text-muted-foreground'>
+              No pickable parts were found for this workshop order.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Part</TableHead>
+                  <TableHead>Task</TableHead>
+                  <TableHead className='text-right'>Required</TableHead>
+                  <TableHead className='w-[150px] text-right'>Pick Qty</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {requiredPartLines.map((line) => (
+                  <TableRow key={line.workshopTaskLineItemId}>
+                    <TableCell>
+                      <div className='font-medium'>{line.itemNo}</div>
+                      <div className='text-xs text-muted-foreground'>{line.description}</div>
+                    </TableCell>
+                    <TableCell className='text-sm text-muted-foreground'>{line.taskTitle}</TableCell>
+                    <TableCell className='text-right font-medium'>{formatQuantity(line.requiredQuantity)}</TableCell>
+                    <TableCell>
+                      <Input
+                        type='number'
+                        min='0'
+                        step='1'
+                        inputMode='numeric'
+                        value={quantitiesByLineId[line.workshopTaskLineItemId] ?? ''}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          setQuantitiesByLineId((previous) => ({
+                            ...previous,
+                            [line.workshopTaskLineItemId]: value,
+                          }))
+                          setFormError(null)
+                        }}
+                        className='h-8 text-right'
+                        aria-label={`Quantity for ${line.description} (${line.itemNo})`}
+                        disabled={!isPickEligible || pickPartsMutation.isPending}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </ScrollArea>
+
+        {!isPickEligible ? (
+          <div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 flex items-start gap-2'>
+            <MapPin className='h-4 w-4 mt-0.5 shrink-0' />
+            This workshop order is not in a pick-eligible state.
+          </div>
+        ) : null}
+
+        {formError ? (
+          <div className='rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive'>
+            {formError}
+          </div>
+        ) : null}
+      </div>
+    </form>
+  )
+}
+
+export function WorkshopOrderPickDrawer({
+  orderId,
+  open,
+  onOpenChange,
+}: WorkshopOrderPickDrawerProps) {
+  const { data: order, isLoading: isOrderLoading } = useWorkshopOrder(orderId ?? '')
+  const { data: locations, isLoading: areLocationsLoading } = useLocations({ enabled: open })
+  const drawerStateKey = open
+    ? `${orderId ?? 'no-order'}:${order?.id ?? 'loading'}`
+    : `closed:${orderId ?? 'no-order'}`
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side='right' className='w-full sm:max-w-3xl p-0 flex h-full flex-col'>
+        <WorkshopOrderPickDrawerBody
+          key={drawerStateKey}
+          orderId={orderId}
+          open={open}
+          onOpenChange={onOpenChange}
+          order={order}
+          locations={locations}
+          isOrderLoading={isOrderLoading}
+          areLocationsLoading={areLocationsLoading}
+        />
       </SheetContent>
     </Sheet>
   )

--- a/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
+++ b/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
@@ -58,6 +58,7 @@ export function WorkshopOrderPickDrawer({
   const queryClient = useQueryClient()
   const pickPartsMutation = usePickWorkshopParts()
   const toteTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const prevOpenRef = useRef(false)
 
   const { data: order, isLoading: isOrderLoading } = useWorkshopOrder(orderId ?? '')
   const { data: locations, isLoading: areLocationsLoading } = useLocations({ enabled: open })
@@ -97,7 +98,10 @@ export function WorkshopOrderPickDrawer({
   )
 
   useEffect(() => {
-    if (!open || !order) return
+    const wasOpen = prevOpenRef.current
+    prevOpenRef.current = open
+
+    if (!open || wasOpen || !order) return
 
     setSelectedStagingLocationId(order.stagingLocationId ?? order.staging_location_id ?? null)
     setQuantitiesByLineId(defaultQuantitiesByLineId)
@@ -109,14 +113,7 @@ export function WorkshopOrderPickDrawer({
     }, 20)
 
     return () => window.clearTimeout(focusTimer)
-  }, [
-    defaultQuantitiesByLineId,
-    open,
-    order,
-    order?.id,
-    order?.stagingLocationId,
-    order?.staging_location_id,
-  ])
+  }, [defaultQuantitiesByLineId, open, order])
 
   const handlePickAll = () => {
     setQuantitiesByLineId(defaultQuantitiesByLineId)

--- a/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
+++ b/apps/core-web/src/features/workshop/components/WorkshopOrderPickDrawer.tsx
@@ -1,0 +1,445 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Check, ChevronsUpDown, Loader2, MapPin, Package } from 'lucide-react'
+import { toast } from 'sonner'
+import { useLocations } from '@/api/locations'
+import { usePickWorkshopParts, useWorkshopOrder, workshopKeys } from '@/api/workshop'
+import type { WorkshopPickLineItemPayload } from '@/api/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Separator } from '@/components/ui/separator'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import {
+  getRequiredPartLines,
+  getTotalRequiredQuantity,
+  isWorkshopOrderPickEligible,
+} from '@/features/workshop/pick-utils'
+
+interface WorkshopOrderPickDrawerProps {
+  orderId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const formatQuantity = (value: number) =>
+  Number.isInteger(value) ? String(Math.trunc(value)) : String(value)
+
+export function WorkshopOrderPickDrawer({
+  orderId,
+  open,
+  onOpenChange,
+}: WorkshopOrderPickDrawerProps) {
+  const queryClient = useQueryClient()
+  const pickPartsMutation = usePickWorkshopParts()
+  const toteTriggerRef = useRef<HTMLButtonElement | null>(null)
+
+  const { data: order, isLoading: isOrderLoading } = useWorkshopOrder(orderId ?? '')
+  const { data: locations, isLoading: areLocationsLoading } = useLocations({ enabled: open })
+
+  const [isTotePopoverOpen, setIsTotePopoverOpen] = useState(false)
+  const [selectedStagingLocationId, setSelectedStagingLocationId] = useState<string | null>(null)
+  const [quantitiesByLineId, setQuantitiesByLineId] = useState<Record<string, string>>({})
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const requiredPartLines = useMemo(() => getRequiredPartLines(order), [order])
+  const requiredLineCount = requiredPartLines.length
+  const totalRequiredQuantity = getTotalRequiredQuantity(requiredPartLines)
+  const isPickEligible = isWorkshopOrderPickEligible(order)
+
+  const defaultQuantitiesByLineId = useMemo(() => {
+    const defaults: Record<string, string> = {}
+    requiredPartLines.forEach((line) => {
+      defaults[line.workshopTaskLineItemId] = formatQuantity(line.requiredQuantity)
+    })
+    return defaults
+  }, [requiredPartLines])
+
+  const stagingTotes = useMemo(
+    () => (locations ?? []).filter((location) => location.type === 'staging_tote'),
+    [locations],
+  )
+
+  const selectedTote = stagingTotes.find((location) => location.id === selectedStagingLocationId)
+
+  const hasPositiveQuantity = useMemo(
+    () =>
+      requiredPartLines.some((line) => {
+        const value = Number(quantitiesByLineId[line.workshopTaskLineItemId])
+        return Number.isFinite(value) && value > 0
+      }),
+    [requiredPartLines, quantitiesByLineId],
+  )
+
+  useEffect(() => {
+    if (!open || !order) return
+
+    setSelectedStagingLocationId(order.stagingLocationId ?? order.staging_location_id ?? null)
+    setQuantitiesByLineId(defaultQuantitiesByLineId)
+    setIsTotePopoverOpen(false)
+    setFormError(null)
+
+    const focusTimer = window.setTimeout(() => {
+      toteTriggerRef.current?.focus()
+    }, 20)
+
+    return () => window.clearTimeout(focusTimer)
+  }, [
+    defaultQuantitiesByLineId,
+    open,
+    order,
+    order?.id,
+    order?.stagingLocationId,
+    order?.staging_location_id,
+  ])
+
+  const handlePickAll = () => {
+    setQuantitiesByLineId(defaultQuantitiesByLineId)
+    setFormError(null)
+  }
+
+  const normalizeItems = (): { items: WorkshopPickLineItemPayload[]; error: string | null } => {
+    const normalizedItemsByLineId = new Map<string, WorkshopPickLineItemPayload>()
+
+    for (const line of requiredPartLines) {
+      const rawValue = quantitiesByLineId[line.workshopTaskLineItemId]?.trim() ?? ''
+      if (!rawValue) continue
+
+      const parsedQuantity = Number(rawValue)
+      if (!Number.isFinite(parsedQuantity) || parsedQuantity < 0 || !Number.isInteger(parsedQuantity)) {
+        return {
+          items: [],
+          error: `Quantity for ${line.itemNo} must be a whole number greater than or equal to zero.`,
+        }
+      }
+
+      if (parsedQuantity === 0) continue
+
+      const existing = normalizedItemsByLineId.get(line.workshopTaskLineItemId)
+      if (existing) {
+        existing.quantity += parsedQuantity
+        continue
+      }
+
+      normalizedItemsByLineId.set(line.workshopTaskLineItemId, {
+        workshopTaskLineItemId: line.workshopTaskLineItemId,
+        quantity: parsedQuantity,
+      })
+    }
+
+    return {
+      items: Array.from(normalizedItemsByLineId.values()),
+      error: null,
+    }
+  }
+
+  const handleConfirmPick = async () => {
+    if (!orderId || !order || pickPartsMutation.isPending) {
+      return
+    }
+
+    setFormError(null)
+
+    if (!isPickEligible) {
+      const message = 'This workshop order is no longer eligible for picking.'
+      setFormError(message)
+      toast.error(message)
+      return
+    }
+
+    if (!selectedStagingLocationId) {
+      const message = 'Select a staging tote before confirming the pick.'
+      setFormError(message)
+      return
+    }
+
+    const { items, error } = normalizeItems()
+    if (error) {
+      setFormError(error)
+      return
+    }
+
+    if (items.length === 0) {
+      const message = 'Enter at least one pick quantity greater than zero.'
+      setFormError(message)
+      return
+    }
+
+    try {
+      await pickPartsMutation.mutateAsync({
+        orderId,
+        payload: {
+          destinationLocationId: selectedStagingLocationId,
+          items,
+        },
+      })
+      toast.success('Parts picked and staged successfully.')
+      onOpenChange(false)
+    } catch (error) {
+      const mutationError = error as { status?: number; message?: string }
+      if (mutationError.status === 409) {
+        toast.error('This order was updated by another user. Data was refreshed.')
+        queryClient.invalidateQueries({ queryKey: workshopKeys.detail(orderId) })
+        queryClient.invalidateQueries({ queryKey: workshopKeys.pickList() })
+        return
+      }
+
+      if (mutationError.status === 404) {
+        toast.error(mutationError.message || 'Order data was not found. The drawer was closed.')
+        onOpenChange(false)
+        return
+      }
+
+      toast.error(mutationError.message || 'Failed to pick parts')
+    }
+  }
+
+  const isConfirmDisabled =
+    !isPickEligible ||
+    !selectedStagingLocationId ||
+    !hasPositiveQuantity ||
+    pickPartsMutation.isPending ||
+    isOrderLoading
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side='right' className='w-full sm:max-w-3xl p-0 flex h-full flex-col'>
+        <form
+          className='flex h-full flex-col'
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleConfirmPick()
+          }}
+        >
+          <SheetHeader className='px-6 py-4 border-b pr-14' data-pick-drawer-header='true'>
+            <div className='flex items-start justify-between gap-4'>
+              <div className='min-w-0'>
+                <SheetTitle className='text-lg font-semibold flex items-center gap-2'>
+                  <Package className='h-4 w-4' />
+                  Pick Parts
+                </SheetTitle>
+                <SheetDescription className='text-sm text-muted-foreground'>
+                  Assign parts to a staging tote for this workshop order.
+                </SheetDescription>
+                <div className='mt-2 flex flex-wrap items-center gap-2'>
+                  {order ? (
+                    <Badge variant='outline'>
+                      {order.order_number}
+                    </Badge>
+                  ) : null}
+                  {order ? (
+                    <Badge variant='outline'>
+                      {order.status}
+                    </Badge>
+                  ) : null}
+                  <Badge variant='secondary'>
+                    {requiredLineCount} lines
+                  </Badge>
+                </div>
+              </div>
+
+              <div className='shrink-0 flex items-center gap-2'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => onOpenChange(false)}
+                  disabled={pickPartsMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button type='submit' disabled={isConfirmDisabled}>
+                  {pickPartsMutation.isPending ? (
+                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                  ) : null}
+                  Confirm Pick
+                </Button>
+              </div>
+            </div>
+          </SheetHeader>
+
+          <div className='px-6 py-4 space-y-4 flex-1 min-h-0'>
+            <div className='space-y-2'>
+              <div className='text-sm font-medium text-foreground'>
+                Destination Tote
+              </div>
+              {areLocationsLoading && stagingTotes.length === 0 ? (
+                <div className='space-y-2'>
+                  <div className='h-9 w-full rounded-md bg-slate-100 animate-pulse' />
+                  <div className='h-4 w-64 rounded bg-slate-100 animate-pulse' />
+                </div>
+              ) : (
+                <Popover open={isTotePopoverOpen} onOpenChange={setIsTotePopoverOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      ref={toteTriggerRef}
+                      type='button'
+                      variant='outline'
+                      role='combobox'
+                      aria-expanded={isTotePopoverOpen}
+                      className='w-full justify-between'
+                      disabled={pickPartsMutation.isPending}
+                    >
+                      <span className='truncate'>
+                        {selectedTote
+                          ? `${selectedTote.code} - ${selectedTote.name}`
+                          : 'Select staging tote...'}
+                      </span>
+                      <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className='w-[var(--radix-popover-trigger-width)] p-0' align='start'>
+                    <Command>
+                      <CommandInput placeholder='Search tote...' aria-label='Search tote' />
+                      <CommandList>
+                        <CommandEmpty>No staging tote found.</CommandEmpty>
+                        <CommandGroup>
+                          {stagingTotes.map((location) => (
+                            <CommandItem
+                              key={location.id}
+                              value={`${location.code} ${location.name}`}
+                              onSelect={() => {
+                                setSelectedStagingLocationId(location.id)
+                                setIsTotePopoverOpen(false)
+                                setFormError(null)
+                              }}
+                            >
+                              <Check
+                                className={cn(
+                                  'h-4 w-4',
+                                  selectedStagingLocationId === location.id ? 'opacity-100' : 'opacity-0',
+                                )}
+                              />
+                              <span className='truncate'>{location.code} - {location.name}</span>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+              )}
+              <p className='text-xs text-muted-foreground'>
+                {selectedTote
+                  ? `Selected tote ${selectedTote.code}`
+                  : 'Choose one staging tote for this transfer.'}
+              </p>
+            </div>
+
+            <Separator />
+
+            <div className='flex items-center justify-between gap-3'>
+              <div className='text-sm font-medium'>Required Parts</div>
+              <div className='flex items-center gap-2'>
+                <Badge variant='outline'>Total Qty {formatQuantity(totalRequiredQuantity)}</Badge>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='sm'
+                  onClick={handlePickAll}
+                  disabled={requiredPartLines.length === 0 || pickPartsMutation.isPending}
+                >
+                  Pick All
+                </Button>
+              </div>
+            </div>
+
+            <ScrollArea className='flex-1 pr-2'>
+              {isOrderLoading ? (
+                <div className='space-y-2'>
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <div key={index} className='h-11 rounded-md bg-slate-100 animate-pulse' />
+                  ))}
+                </div>
+              ) : requiredPartLines.length === 0 ? (
+                <div className='rounded-md border border-dashed p-6 text-sm text-muted-foreground'>
+                  No pickable parts were found for this workshop order.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Part</TableHead>
+                      <TableHead>Task</TableHead>
+                      <TableHead className='text-right'>Required</TableHead>
+                      <TableHead className='w-[150px] text-right'>Pick Qty</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {requiredPartLines.map((line) => (
+                      <TableRow key={line.workshopTaskLineItemId}>
+                        <TableCell>
+                          <div className='font-medium'>{line.itemNo}</div>
+                          <div className='text-xs text-muted-foreground'>{line.description}</div>
+                        </TableCell>
+                        <TableCell className='text-sm text-muted-foreground'>{line.taskTitle}</TableCell>
+                        <TableCell className='text-right font-medium'>{formatQuantity(line.requiredQuantity)}</TableCell>
+                        <TableCell>
+                          <Input
+                            type='number'
+                            min='0'
+                            step='1'
+                            inputMode='numeric'
+                            value={quantitiesByLineId[line.workshopTaskLineItemId] ?? ''}
+                            onChange={(event) => {
+                              const value = event.target.value
+                              setQuantitiesByLineId((previous) => ({
+                                ...previous,
+                                [line.workshopTaskLineItemId]: value,
+                              }))
+                              setFormError(null)
+                            }}
+                            className='h-8 text-right'
+                            aria-label={`Quantity for ${line.description} (${line.itemNo})`}
+                            disabled={!isPickEligible || pickPartsMutation.isPending}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </ScrollArea>
+
+            {!isPickEligible ? (
+              <div className='rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 flex items-start gap-2'>
+                <MapPin className='h-4 w-4 mt-0.5 shrink-0' />
+                This workshop order is not in a pick-eligible state.
+              </div>
+            ) : null}
+
+            {formError ? (
+              <div className='rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive'>
+                {formError}
+              </div>
+            ) : null}
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/core-web/src/features/workshop/pick-utils.test.ts
+++ b/apps/core-web/src/features/workshop/pick-utils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkshopOrder } from '@/api/types'
+import {
+  PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES,
+  getWorkshopCustomerDisplayName,
+  isWorkshopOrderPickEligible,
+} from './pick-utils'
+
+function createWorkshopOrder(overrides: Partial<WorkshopOrder> = {}): WorkshopOrder {
+  return {
+    id: overrides.id ?? 'order-1',
+    order_number: overrides.order_number ?? 'WO-2026-0001',
+    status: overrides.status ?? 'INTAKE',
+    customer_id: 'customer-1',
+    customer: {
+      id: 'customer-1',
+      type: 'PRIVATE',
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      email: 'ada@example.com',
+      ...overrides.customer,
+    },
+    vehicle_id: 'vehicle-1',
+    vehicle: {
+      id: 'vehicle-1',
+      make: 'Audi',
+      model: 'A4',
+      year: 2024,
+    },
+    odometer: 1000,
+    fuel_level: 0.5,
+    createdAt: '2026-04-17T00:00:00.000Z',
+    tasks: [],
+    ...overrides,
+  }
+}
+
+describe('pick-utils', () => {
+  it('formats workshop customer names consistently', () => {
+    expect(getWorkshopCustomerDisplayName(createWorkshopOrder({
+      customer: {
+        id: 'customer-2',
+        type: 'COMPANY',
+        company_name: 'ACME Fleet',
+        first_name: '',
+        last_name: '',
+        email: 'fleet@example.com',
+      },
+    }))).toBe('ACME Fleet')
+
+    expect(getWorkshopCustomerDisplayName(createWorkshopOrder({
+      customer: {
+        id: 'customer-3',
+        type: 'PRIVATE',
+        first_name: 'Grace',
+        last_name: 'Hopper',
+        email: 'grace@example.com',
+      },
+    }))).toBe('Grace Hopper')
+  })
+
+  it('uses the shared eligible statuses for pick validation', () => {
+    expect(PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.has('INTAKE')).toBe(true)
+    expect(PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.has('IN_PROGRESS')).toBe(true)
+    expect(PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.has('COMPLETED')).toBe(false)
+
+    expect(isWorkshopOrderPickEligible(createWorkshopOrder({
+      status: 'IN_PROGRESS',
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Inspect',
+          status: 'IN_PROGRESS',
+          done: false,
+          lineItems: [
+            {
+              id: 'line-1',
+              type: 'PART',
+              itemNo: 'PART-1',
+              description: 'Part 1',
+              qty: 1,
+              unitPrice: 10,
+            },
+          ],
+        },
+      ],
+    }))).toBe(true)
+  })
+})

--- a/apps/core-web/src/features/workshop/pick-utils.ts
+++ b/apps/core-web/src/features/workshop/pick-utils.ts
@@ -3,10 +3,18 @@ import type {
   WorkshopOrderStatus,
 } from '@/api/types'
 
-export const PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES: WorkshopOrderStatus[] = [
+export const PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES = new Set<WorkshopOrderStatus>([
   'INTAKE',
   'IN_PROGRESS',
-]
+])
+
+export function getWorkshopCustomerDisplayName(order: WorkshopOrder) {
+  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
+    return order.customer.company_name
+  }
+
+  return `${order.customer.first_name ?? ''} ${order.customer.last_name ?? ''}`.trim()
+}
 
 export interface WorkshopRequiredPartLine {
   workshopTaskLineItemId: string
@@ -44,7 +52,7 @@ export function getRequiredPartLines(order: WorkshopOrder | null | undefined): W
 
 export function isWorkshopOrderPickEligible(order: WorkshopOrder | null | undefined): boolean {
   if (!order) return false
-  if (!PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.includes(order.status)) return false
+  if (!PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.has(order.status)) return false
   return getRequiredPartLines(order).length > 0
 }
 

--- a/apps/core-web/src/features/workshop/pick-utils.ts
+++ b/apps/core-web/src/features/workshop/pick-utils.ts
@@ -1,0 +1,53 @@
+import type {
+  WorkshopOrder,
+  WorkshopOrderStatus,
+} from '@/api/types'
+
+export const PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES: WorkshopOrderStatus[] = [
+  'INTAKE',
+  'IN_PROGRESS',
+]
+
+export interface WorkshopRequiredPartLine {
+  workshopTaskLineItemId: string
+  taskId: string
+  taskTitle: string
+  itemNo: string
+  description: string
+  requiredQuantity: number
+}
+
+export function getRequiredPartLines(order: WorkshopOrder | null | undefined): WorkshopRequiredPartLine[] {
+  if (!order) return []
+
+  const lines: WorkshopRequiredPartLine[] = []
+  for (const task of order.tasks ?? []) {
+    for (const lineItem of task.lineItems ?? []) {
+      const requiredQuantity = Number(lineItem.qty)
+      if (lineItem.type !== 'PART' || !Number.isFinite(requiredQuantity) || requiredQuantity <= 0) {
+        continue
+      }
+
+      lines.push({
+        workshopTaskLineItemId: lineItem.id,
+        taskId: task.id,
+        taskTitle: task.title,
+        itemNo: lineItem.itemNo,
+        description: lineItem.description,
+        requiredQuantity,
+      })
+    }
+  }
+
+  return lines
+}
+
+export function isWorkshopOrderPickEligible(order: WorkshopOrder | null | undefined): boolean {
+  if (!order) return false
+  if (!PICK_ELIGIBLE_WORKSHOP_ORDER_STATUSES.includes(order.status)) return false
+  return getRequiredPartLines(order).length > 0
+}
+
+export function getTotalRequiredQuantity(lines: WorkshopRequiredPartLine[]): number {
+  return lines.reduce((sum, line) => sum + line.requiredQuantity, 0)
+}

--- a/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
@@ -12,6 +12,7 @@ import { StatusBadge } from '@/components/status/StatusBadge'
 import { useWorkshopOrders } from '@/api/workshop'
 import type { WorkshopOrder } from '@/api/types'
 import { DASHBOARD_WIDGET_SOURCE_WORKSHOP_ORDERS } from '@/features/dashboard-widgets/sources'
+import { getWorkshopCustomerDisplayName } from '@/features/workshop/pick-utils'
 
 interface WorkshopOrderRow {
   id: string
@@ -20,13 +21,6 @@ interface WorkshopOrderRow {
   vehicle: string
   openedAt: string
   status: WorkshopOrder['status']
-}
-
-function getCustomerName(order: WorkshopOrder) {
-  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
-    return order.customer.company_name
-  }
-  return `${order.customer.first_name} ${order.customer.last_name}`.trim()
 }
 
 export default function WorkshopOrderList() {
@@ -40,7 +34,7 @@ export default function WorkshopOrderList() {
     return source.map((order) => ({
       id: order.id,
       orderNo: order.order_number ?? order.id,
-      customer: getCustomerName(order),
+      customer: getWorkshopCustomerDisplayName(order),
       vehicle: `${order.vehicle.year} ${order.vehicle.make} ${order.vehicle.model}`,
       openedAt: format(new Date(order.createdAt), 'PPP'),
       status: order.status,

--- a/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopOrderList.tsx
@@ -80,10 +80,15 @@ export default function WorkshopOrderList() {
           <h1 className='text-2xl font-semibold tracking-tight'>Workshop Orders</h1>
           <p className='text-slate-500'>Open a work order to view full job details and task drawer.</p>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className='h-4 w-4 mr-2' />
-          Order
-        </Button>
+        <div className='flex items-center gap-2'>
+          <Button variant='outline' onClick={() => navigate('/workshop/pick-list')}>
+            Pick Queue
+          </Button>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className='h-4 w-4 mr-2' />
+            Order
+          </Button>
+        </div>
       </div>
 
       <DataTable

--- a/apps/core-web/src/pages/workshop/WorkshopPickList.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopPickList.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { format } from 'date-fns'
+import { ArrowRight, ListChecks } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { DataTable } from '@/components/data-table/DataTable'
+import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header'
+import { StatusBadge } from '@/components/status/StatusBadge'
+import { useWorkshopPickList } from '@/api/workshop'
+import type { WorkshopOrder } from '@/api/types'
+import { useDataTableQuery } from '@/hooks/useDataTableQuery'
+import { WorkshopOrderPickDrawer } from '@/features/workshop/components/WorkshopOrderPickDrawer'
+import {
+  getRequiredPartLines,
+  getTotalRequiredQuantity,
+} from '@/features/workshop/pick-utils'
+
+interface WorkshopPickQueueRow {
+  id: string
+  orderNo: string
+  customer: string
+  vehicle: string
+  openedAt: string
+  status: WorkshopOrder['status']
+  partLines: number
+  requiredQty: number
+}
+
+function getCustomerName(order: WorkshopOrder) {
+  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
+    return order.customer.company_name
+  }
+  return `${order.customer.first_name} ${order.customer.last_name}`.trim()
+}
+
+function formatQuantity(value: number) {
+  return Number.isInteger(value) ? String(Math.trunc(value)) : value.toFixed(2)
+}
+
+export default function WorkshopPickList() {
+  const navigate = useNavigate()
+  const [activeOrderId, setActiveOrderId] = useState<string | null>(null)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  const { queryParams, ...tableState } = useDataTableQuery({ defaultPageSize: 10 })
+  const { data: responseData, isLoading } = useWorkshopPickList(queryParams)
+
+  const rows = useMemo<WorkshopPickQueueRow[]>(() => {
+    const source = responseData?.data ?? []
+    return source.map((order) => {
+      const requiredPartLines = getRequiredPartLines(order)
+      return {
+        id: order.id,
+        orderNo: order.order_number ?? order.id,
+        customer: getCustomerName(order),
+        vehicle: `${order.vehicle.year} ${order.vehicle.make} ${order.vehicle.model}`,
+        openedAt: format(new Date(order.createdAt), 'PPP'),
+        status: order.status,
+        partLines: requiredPartLines.length,
+        requiredQty: getTotalRequiredQuantity(requiredPartLines),
+      }
+    })
+  }, [responseData])
+
+  const columns: ColumnDef<WorkshopPickQueueRow>[] = [
+    {
+      accessorKey: 'orderNo',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Order No.' />,
+      cell: ({ row }) => <span className='font-medium'>{row.original.orderNo}</span>,
+    },
+    {
+      accessorKey: 'customer',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Customer' />,
+    },
+    {
+      accessorKey: 'vehicle',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Vehicle' />,
+    },
+    {
+      accessorKey: 'partLines',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Part Lines' />,
+      cell: ({ row }) => <span className='tabular-nums'>{row.original.partLines}</span>,
+    },
+    {
+      accessorKey: 'requiredQty',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Total Qty' />,
+      cell: ({ row }) => <span className='tabular-nums'>{formatQuantity(row.original.requiredQty)}</span>,
+    },
+    {
+      accessorKey: 'openedAt',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Opened' />,
+      cell: ({ row }) => <span className='text-muted-foreground'>{row.original.openedAt}</span>,
+    },
+    {
+      accessorKey: 'status',
+      header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+      cell: ({ row }) => <StatusBadge status={row.original.status} />,
+    },
+  ]
+
+  return (
+    <div className='w-full max-w-7xl mx-auto p-6 space-y-6'>
+      <div className='flex items-center justify-between mb-8'>
+        <div>
+          <h1 className='text-2xl font-semibold tracking-tight'>Workshop Pick Queue</h1>
+          <p className='text-slate-500'>Select an order row to open the pick drawer and stage required parts.</p>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Button variant='outline' onClick={() => navigate('/workshop/orders')}>
+            <ListChecks className='h-4 w-4 mr-2' />
+            Workshop Orders
+          </Button>
+          <Button variant='outline' onClick={() => navigate('/workshop/intake')}>
+            Intake
+            <ArrowRight className='h-4 w-4 ml-2' />
+          </Button>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={rows}
+        saveViewTitle='Workshop Pick Queue'
+        pageCount={responseData?.meta?.pageCount ?? 1}
+        isLoading={isLoading}
+        searchPlaceholder='Search pick queue...'
+        onRowClick={(row) => {
+          setActiveOrderId(row.id)
+          setIsDrawerOpen(true)
+        }}
+        {...tableState}
+      />
+
+      <WorkshopOrderPickDrawer
+        open={isDrawerOpen}
+        orderId={activeOrderId}
+        onOpenChange={(nextOpen) => {
+          setIsDrawerOpen(nextOpen)
+          if (!nextOpen) {
+            setActiveOrderId(null)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/core-web/src/pages/workshop/WorkshopPickList.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopPickList.tsx
@@ -12,6 +12,7 @@ import type { WorkshopOrder } from '@/api/types'
 import { useDataTableQuery } from '@/hooks/useDataTableQuery'
 import { WorkshopOrderPickDrawer } from '@/features/workshop/components/WorkshopOrderPickDrawer'
 import {
+  getWorkshopCustomerDisplayName,
   getRequiredPartLines,
   getTotalRequiredQuantity,
 } from '@/features/workshop/pick-utils'
@@ -25,13 +26,6 @@ interface WorkshopPickQueueRow {
   status: WorkshopOrder['status']
   partLines: number
   requiredQty: number
-}
-
-function getCustomerName(order: WorkshopOrder) {
-  if (order.customer.type === 'COMPANY' && order.customer.company_name) {
-    return order.customer.company_name
-  }
-  return `${order.customer.first_name} ${order.customer.last_name}`.trim()
 }
 
 function formatQuantity(value: number) {
@@ -53,7 +47,7 @@ export default function WorkshopPickList() {
       return {
         id: order.id,
         orderNo: order.order_number ?? order.id,
-        customer: getCustomerName(order),
+        customer: getWorkshopCustomerDisplayName(order),
         vehicle: `${order.vehicle.year} ${order.vehicle.make} ${order.vehicle.model}`,
         openedAt: format(new Date(order.createdAt), 'PPP'),
         status: order.status,


### PR DESCRIPTION
## Summary
- implement Workshop pick queue page with DataTable row-to-Sheet flow
- add new WorkshopOrderPickDrawer (Sheet) with tote combobox, quantity prefill, Pick All, and header-right Confirm Pick action
- wire TanStack Query pick mutation with destinationLocationId payload normalization, scoped invalidation, and 409 conflict handling
- add Playwright coverage for workshop pick flow (seed-based smoke + mocked blueprint suite)
- run OpenAPI + frontend type generation checks (no textual drift in generated contract artifacts)

## Linear
- AUT-56
- AUT-57
- AUT-58

## Validation
- npm --prefix apps/core-web run build
- npm --prefix apps/core-web run test:e2e -- e2e/workshop-pick.spec.ts --grep "Blueprint"
- npm --prefix apps/core-web run test:e2e -- e2e/workshop-pick.spec.ts --grep "Smoke" *(fails locally when backend at 127.0.0.1:3000 is not running)*
