### PR TITLE
🔒 Fix timing attack vulnerability in CloudTasksWorkerGuard

### DIFF
--- a/apps/core-api/src/common/guards/cloud-tasks-worker.guard.spec.ts
+++ b/apps/core-api/src/common/guards/cloud-tasks-worker.guard.spec.ts
@@ -1,0 +1,57 @@
+import { ExecutionContext, InternalServerErrorException, UnauthorizedException, Logger } from '@nestjs/common';
+import { CloudTasksWorkerGuard } from './cloud-tasks-worker.guard';
+
+describe('CloudTasksWorkerGuard', () => {
+  let guard: CloudTasksWorkerGuard;
+
+  beforeEach(() => {
+    guard = new CloudTasksWorkerGuard();
+    process.env.CLOUD_TASKS_WORKER_SECRET = 'valid-secret';
+    jest.spyOn(Logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env.CLOUD_TASKS_WORKER_SECRET;
+    jest.clearAllMocks();
+  });
+
+  const createMockContext = (headers: Record<string, any>, ip: string = '127.0.0.1', originalUrl: string = '/path') => {
+    const mockRequest = { headers, ip, originalUrl };
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  it('should throw InternalServerErrorException if env secret is missing', () => {
+    delete process.env.CLOUD_TASKS_WORKER_SECRET;
+    const context = createMockContext({ 'x-cloud-tasks-secret': 'valid-secret' });
+    expect(() => guard.canActivate(context)).toThrow(InternalServerErrorException);
+  });
+
+  it('should return true if valid secret is provided as string', () => {
+    const context = createMockContext({ 'x-cloud-tasks-secret': 'valid-secret' });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should return true if valid secret is provided as first element of an array', () => {
+    const context = createMockContext({ 'x-cloud-tasks-secret': ['valid-secret', 'another-secret'] });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should throw UnauthorizedException and log warning if secret is invalid', () => {
+    const context = createMockContext({ 'x-cloud-tasks-secret': 'invalid-secret' }, '192.168.1.1', '/test');
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    expect(Logger.warn).toHaveBeenCalledWith(
+      'Invalid Cloud Tasks worker secret attempt from IP: 192.168.1.1 for route: /test',
+      'CloudTasksWorkerGuard'
+    );
+  });
+
+  it('should throw UnauthorizedException if header is completely missing', () => {
+    const context = createMockContext({});
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    expect(Logger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/core-api/src/common/guards/cloud-tasks-worker.guard.spec.ts
+++ b/apps/core-api/src/common/guards/cloud-tasks-worker.guard.spec.ts
@@ -1,4 +1,9 @@
-import { ExecutionContext, InternalServerErrorException, UnauthorizedException, Logger } from '@nestjs/common';
+import {
+  ExecutionContext,
+  InternalServerErrorException,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
 import { CloudTasksWorkerGuard } from './cloud-tasks-worker.guard';
 
 describe('CloudTasksWorkerGuard', () => {
@@ -7,15 +12,19 @@ describe('CloudTasksWorkerGuard', () => {
   beforeEach(() => {
     guard = new CloudTasksWorkerGuard();
     process.env.CLOUD_TASKS_WORKER_SECRET = 'valid-secret';
-    jest.spyOn(Logger, 'warn').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     delete process.env.CLOUD_TASKS_WORKER_SECRET;
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
-  const createMockContext = (headers: Record<string, any>, ip: string = '127.0.0.1', originalUrl: string = '/path') => {
+  const createMockContext = (
+    headers: Record<string, any>,
+    ip: string = '127.0.0.1',
+    originalUrl: string = '/path',
+  ) => {
     const mockRequest = { headers, ip, originalUrl };
     return {
       switchToHttp: () => ({
@@ -26,32 +35,43 @@ describe('CloudTasksWorkerGuard', () => {
 
   it('should throw InternalServerErrorException if env secret is missing', () => {
     delete process.env.CLOUD_TASKS_WORKER_SECRET;
-    const context = createMockContext({ 'x-cloud-tasks-secret': 'valid-secret' });
-    expect(() => guard.canActivate(context)).toThrow(InternalServerErrorException);
+    const context = createMockContext({
+      'x-cloud-tasks-secret': 'valid-secret',
+    });
+    expect(() => guard.canActivate(context)).toThrow(
+      InternalServerErrorException,
+    );
   });
 
   it('should return true if valid secret is provided as string', () => {
-    const context = createMockContext({ 'x-cloud-tasks-secret': 'valid-secret' });
+    const context = createMockContext({
+      'x-cloud-tasks-secret': 'valid-secret',
+    });
     expect(guard.canActivate(context)).toBe(true);
   });
 
   it('should return true if valid secret is provided as first element of an array', () => {
-    const context = createMockContext({ 'x-cloud-tasks-secret': ['valid-secret', 'another-secret'] });
+    const context = createMockContext({
+      'x-cloud-tasks-secret': ['valid-secret', 'another-secret'],
+    });
     expect(guard.canActivate(context)).toBe(true);
   });
 
   it('should throw UnauthorizedException and log warning if secret is invalid', () => {
-    const context = createMockContext({ 'x-cloud-tasks-secret': 'invalid-secret' }, '192.168.1.1', '/test');
+    const context = createMockContext(
+      { 'x-cloud-tasks-secret': 'invalid-secret' },
+      '192.168.1.1',
+      '/test',
+    );
     expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
-    expect(Logger.warn).toHaveBeenCalledWith(
+    expect(Logger.prototype.warn).toHaveBeenCalledWith(
       'Invalid Cloud Tasks worker secret attempt from IP: 192.168.1.1 for route: /test',
-      'CloudTasksWorkerGuard'
     );
   });
 
   it('should throw UnauthorizedException if header is completely missing', () => {
     const context = createMockContext({});
     expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
-    expect(Logger.warn).toHaveBeenCalled();
+    expect(Logger.prototype.warn).toHaveBeenCalled();
   });
 });

--- a/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
+++ b/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
@@ -12,6 +12,7 @@ import * as crypto from 'crypto';
 @Injectable()
 export class CloudTasksWorkerGuard implements CanActivate {
   private readonly logger = new Logger(CloudTasksWorkerGuard.name);
+  private expectedHash?: Buffer;
 
   canActivate(context: ExecutionContext) {
     const secret = process.env.CLOUD_TASKS_WORKER_SECRET;
@@ -24,13 +25,15 @@ export class CloudTasksWorkerGuard implements CanActivate {
     const headerToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
     const providedSecret = typeof headerToken === 'string' ? headerToken : '';
 
-    const expectedHash = crypto.createHash('sha256').update(secret).digest();
+    if (!this.expectedHash) {
+      this.expectedHash = crypto.createHash('sha256').update(secret).digest();
+    }
     const providedHash = crypto
       .createHash('sha256')
       .update(providedSecret)
       .digest();
 
-    if (!crypto.timingSafeEqual(expectedHash, providedHash)) {
+    if (!crypto.timingSafeEqual(this.expectedHash, providedHash)) {
       this.logger.warn(
         `Invalid Cloud Tasks worker secret attempt from IP: ${request.ip} for route: ${request.originalUrl}`,
       );

--- a/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
+++ b/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
@@ -4,8 +4,10 @@ import {
   Injectable,
   InternalServerErrorException,
   UnauthorizedException,
+  Logger,
 } from '@nestjs/common';
 import type { Request } from 'express';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class CloudTasksWorkerGuard implements CanActivate {
@@ -16,9 +18,15 @@ export class CloudTasksWorkerGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<Request>();
-    const header = request.headers['x-cloud-tasks-secret'];
+    const rawHeader = request.headers['x-cloud-tasks-secret'];
+    const headerToken = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+    const providedSecret = typeof headerToken === 'string' ? headerToken : '';
 
-    if (typeof header !== 'string' || header !== secret) {
+    const expectedHash = crypto.createHash('sha256').update(secret).digest();
+    const providedHash = crypto.createHash('sha256').update(providedSecret).digest();
+
+    if (!crypto.timingSafeEqual(expectedHash, providedHash)) {
+      Logger.warn(`Invalid Cloud Tasks worker secret attempt from IP: ${request.ip} for route: ${request.originalUrl}`, 'CloudTasksWorkerGuard');
       throw new UnauthorizedException('Unauthorized');
     }
 

--- a/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
+++ b/apps/core-api/src/common/guards/cloud-tasks-worker.guard.ts
@@ -11,6 +11,8 @@ import * as crypto from 'crypto';
 
 @Injectable()
 export class CloudTasksWorkerGuard implements CanActivate {
+  private readonly logger = new Logger(CloudTasksWorkerGuard.name);
+
   canActivate(context: ExecutionContext) {
     const secret = process.env.CLOUD_TASKS_WORKER_SECRET;
     if (!secret) {
@@ -23,10 +25,15 @@ export class CloudTasksWorkerGuard implements CanActivate {
     const providedSecret = typeof headerToken === 'string' ? headerToken : '';
 
     const expectedHash = crypto.createHash('sha256').update(secret).digest();
-    const providedHash = crypto.createHash('sha256').update(providedSecret).digest();
+    const providedHash = crypto
+      .createHash('sha256')
+      .update(providedSecret)
+      .digest();
 
     if (!crypto.timingSafeEqual(expectedHash, providedHash)) {
-      Logger.warn(`Invalid Cloud Tasks worker secret attempt from IP: ${request.ip} for route: ${request.originalUrl}`, 'CloudTasksWorkerGuard');
+      this.logger.warn(
+        `Invalid Cloud Tasks worker secret attempt from IP: ${request.ip} for route: ${request.originalUrl}`,
+      );
       throw new UnauthorizedException('Unauthorized');
     }
 


### PR DESCRIPTION
🎯 **What:** The `CloudTasksWorkerGuard` was using a standard string comparison (`header !== secret`) which is vulnerable to timing attacks. It also lacked handling for array-based HTTP headers and logging of failed attempts.
⚠️ **Risk:** If left unfixed, an attacker could measure response times to guess the `CLOUD_TASKS_WORKER_SECRET` character-by-character, potentially gaining unauthorized access to cloud task endpoints.
🛡️ **Solution:** 
- Modified the guard to use `crypto.timingSafeEqual` to guarantee constant-time execution.
- Hashed both the provided and expected secrets using SHA-256 before comparison to ensure equal lengths, preventing information leakage and `timingSafeEqual` length-mismatch crashes.
- Added normalization to safely extract the first element if the header is an array.
- Added secure logging of failed authentication attempts via `Logger.warn`, logging the IP and route but never the invalid secret itself.
- Created a comprehensive test suite in `cloud-tasks-worker.guard.spec.ts` to verify all behaviors.

---
*PR created automatically by Jules for task [10125605071230214862](https://jules.google.com/task/10125605071230214862) started by @vandean25*