### PR TITLE
⚡ [SalesService.finalize] Optimize N+1 Inventory Updates and Insertions

### DIFF
--- a/apps/core-api/src/sales/sales.service.ts
+++ b/apps/core-api/src/sales/sales.service.ts
@@ -159,13 +159,18 @@ export class SalesService {
         });
       }
 
-      // 2b. Aggregate quantities per catalog_item_id to minimize DB roundtrips
-      const itemAggregations = new Map<
+      // 2b. Iterate sequentially in memory to assign locations, then aggregate updates by (catalog_item_id + location_id)
+      const stockUpdatesMap = new Map<
         string,
-        { catalog_item_id: string; quantityToDeduct: number; items: any[] }
+        {
+          catalog_item_id: string;
+          locationId: string;
+          quantityToDeduct: number;
+        }
       >();
+      const transactionCreations: Prisma.InventoryTransactionCreateManyInput[] =
+        [];
 
-      // Dry-Run Validation and Aggregation
       for (const item of invoice.items) {
         if (!item.catalog_item_id) continue;
 
@@ -180,67 +185,53 @@ export class SalesService {
           );
         }
 
-        const agg = itemAggregations.get(item.catalog_item_id) || {
-          catalog_item_id: item.catalog_item_id,
-          quantityToDeduct: 0,
-          items: [],
-        };
-        agg.quantityToDeduct += quantityToDeduct;
-        agg.items.push(item);
-        itemAggregations.set(item.catalog_item_id, agg);
-      }
-
-      const stockUpdates: {
-        catalog_item_id: string;
-        locationId: string;
-        quantityToDeduct: number;
-      }[] = [];
-      const transactionCreations: Prisma.InventoryTransactionCreateManyInput[] =
-        [];
-
-      for (const agg of itemAggregations.values()) {
-        const stocks = stockMap.get(agg.catalog_item_id) || [];
+        const stocks = stockMap.get(item.catalog_item_id) || [];
 
         // Find first location with sufficient stock, or fallback to first one available
         const stock =
-          stocks.find((s) => s.quantity_on_hand >= agg.quantityToDeduct) ||
+          stocks.find((s) => s.quantity_on_hand >= quantityToDeduct) ||
           stocks[0];
 
         if (!stock) {
           throw new BadRequestException(
-            `No stock record found for item ${agg.items[0].description}`,
+            `No stock record found for item ${item.description}`,
           );
         }
 
-        if (stock.quantity_on_hand < agg.quantityToDeduct) {
+        // Dry run validation
+        if (stock.quantity_on_hand < quantityToDeduct) {
           throw new BadRequestException(
-            `Insufficient stock for item ${agg.items[0].description} at location ${stock.location_id} (Req: ${agg.quantityToDeduct}, Available: ${stock.quantity_on_hand})`,
+            `Insufficient stock for item ${item.description} at location ${stock.location_id} (Req: ${quantityToDeduct}, Available: ${stock.quantity_on_hand})`,
           );
         }
 
         const locationId = stock.location_id;
-        stockUpdates.push({
-          catalog_item_id: agg.catalog_item_id,
-          locationId,
-          quantityToDeduct: agg.quantityToDeduct,
-        });
+        const compositeKey = `${item.catalog_item_id}_${locationId}`;
 
-        // Track local update for potential sequential calls
-        stock.quantity_on_hand -= agg.quantityToDeduct;
+        const existingUpdate = stockUpdatesMap.get(compositeKey) || {
+          catalog_item_id: item.catalog_item_id,
+          locationId,
+          quantityToDeduct: 0,
+        };
+
+        existingUpdate.quantityToDeduct += quantityToDeduct;
+        stockUpdatesMap.set(compositeKey, existingUpdate);
+
+        // Update local stock map for subsequent items of the same catalog ID sequentially
+        stock.quantity_on_hand -= quantityToDeduct;
 
         // Preserve 1:1 audit trail granularity for transactions
-        for (const item of agg.items) {
-          transactionCreations.push({
-            item_id: item.catalog_item_id,
-            location_id: locationId,
-            quantity: new Prisma.Decimal(item.quantity).negated(),
-            type: TransactionType.SALE_ISSUE,
-            reference_id: invoiceNumber,
-          });
-        }
+        transactionCreations.push({
+          item_id: item.catalog_item_id,
+          location_id: locationId,
+          quantity: new Prisma.Decimal(item.quantity).negated(),
+          type: TransactionType.SALE_ISSUE,
+          reference_id: invoiceNumber,
+        });
       }
 
       // 2c. Execute updates concurrently and create transactions in bulk
+      const stockUpdates = Array.from(stockUpdatesMap.values());
       await chunkedPromiseAll(stockUpdates, async (update) => {
         const updateResult = await tx.inventoryStock.updateMany({
           where: {

--- a/apps/core-api/src/sales/sales.service.ts
+++ b/apps/core-api/src/sales/sales.service.ts
@@ -13,6 +13,7 @@ import {
   TransactionType,
 } from '@prisma/client';
 import type { CatalogItem, RevenueGroup, InventoryStock } from '@prisma/client';
+import { chunkedPromiseAll } from '../common/utils/promise.util';
 
 @Injectable()
 export class SalesService {
@@ -158,76 +159,120 @@ export class SalesService {
         });
       }
 
-      // 2b. Iterate sequentially through invoice items to maintain 1:1 mapping in ledger
+      // 2b. Aggregate quantities per catalog_item_id to minimize DB roundtrips
+      const itemAggregations = new Map<
+        string,
+        { catalog_item_id: string; quantityToDeduct: number; items: any[] }
+      >();
+
+      // Dry-Run Validation and Aggregation
       for (const item of invoice.items) {
-        if (item.catalog_item_id) {
-          const stocks = stockMap.get(item.catalog_item_id) || [];
-          const quantityToDeduct = Number(item.quantity);
+        if (!item.catalog_item_id) continue;
 
-          if (
-            !Number.isFinite(quantityToDeduct) ||
-            !Number.isInteger(quantityToDeduct) ||
-            quantityToDeduct <= 0
-          ) {
-            throw new BadRequestException(
-              `Invalid inventory quantity for item ${item.description}. Stock-tracked items require a positive whole-number quantity.`,
-            );
-          }
+        const quantityToDeduct = Number(item.quantity);
+        if (
+          !Number.isFinite(quantityToDeduct) ||
+          !Number.isInteger(quantityToDeduct) ||
+          quantityToDeduct <= 0
+        ) {
+          throw new BadRequestException(
+            `Invalid inventory quantity for item ${item.description}. Stock-tracked items require a positive whole-number quantity.`,
+          );
+        }
 
-          // Find first location with sufficient stock, or fallback to first one available
-          const stock =
-            stocks.find((s) => s.quantity_on_hand >= quantityToDeduct) ||
-            stocks[0];
+        const agg = itemAggregations.get(item.catalog_item_id) || {
+          catalog_item_id: item.catalog_item_id,
+          quantityToDeduct: 0,
+          items: [],
+        };
+        agg.quantityToDeduct += quantityToDeduct;
+        agg.items.push(item);
+        itemAggregations.set(item.catalog_item_id, agg);
+      }
 
-          if (!stock) {
-            throw new BadRequestException(
-              `No stock record found for item ${item.description}`,
-            );
-          }
+      const stockUpdates: {
+        catalog_item_id: string;
+        locationId: string;
+        quantityToDeduct: number;
+      }[] = [];
+      const transactionCreations: Prisma.InventoryTransactionCreateManyInput[] =
+        [];
 
-          const locationId = stock.location_id;
+      for (const agg of itemAggregations.values()) {
+        const stocks = stockMap.get(agg.catalog_item_id) || [];
 
-          // Atomic Update with Check (Optimistic Locking via WHERE clause)
-          const updateResult = await tx.inventoryStock.updateMany({
-            where: {
-              catalog_item_id: item.catalog_item_id,
-              location_id: locationId,
-              quantity_on_hand: { gte: quantityToDeduct }, // Ensure sufficient stock
-            },
-            data: {
-              quantity_on_hand: { decrement: quantityToDeduct },
-            },
-          });
+        // Find first location with sufficient stock, or fallback to first one available
+        const stock =
+          stocks.find((s) => s.quantity_on_hand >= agg.quantityToDeduct) ||
+          stocks[0];
 
-          if (updateResult.count === 0) {
-            // Refetch stock to give accurate error message if concurrency was high
-            const latestStock = await tx.inventoryStock.findUnique({
-              where: {
-                catalog_item_id_location_id: {
-                  catalog_item_id: item.catalog_item_id,
-                  location_id: locationId,
-                },
-              },
-            });
-            throw new BadRequestException(
-              `Insufficient stock for item ${item.description} at location ${locationId} (Req: ${quantityToDeduct}, Available: ${latestStock?.quantity_on_hand ?? 0})`,
-            );
-          }
+        if (!stock) {
+          throw new BadRequestException(
+            `No stock record found for item ${agg.items[0].description}`,
+          );
+        }
 
-          // Update local stock map for subsequent items of the same catalog ID
-          stock.quantity_on_hand -= quantityToDeduct;
+        if (stock.quantity_on_hand < agg.quantityToDeduct) {
+          throw new BadRequestException(
+            `Insufficient stock for item ${agg.items[0].description} at location ${stock.location_id} (Req: ${agg.quantityToDeduct}, Available: ${stock.quantity_on_hand})`,
+          );
+        }
 
-          // Create Sale Issue Transaction (Per-item for audit trail granularity)
-          await tx.inventoryTransaction.create({
-            data: {
-              item_id: item.catalog_item_id,
-              location_id: locationId,
-              quantity: new Prisma.Decimal(item.quantity).negated(),
-              type: TransactionType.SALE_ISSUE,
-              reference_id: invoiceNumber,
-            },
+        const locationId = stock.location_id;
+        stockUpdates.push({
+          catalog_item_id: agg.catalog_item_id,
+          locationId,
+          quantityToDeduct: agg.quantityToDeduct,
+        });
+
+        // Track local update for potential sequential calls
+        stock.quantity_on_hand -= agg.quantityToDeduct;
+
+        // Preserve 1:1 audit trail granularity for transactions
+        for (const item of agg.items) {
+          transactionCreations.push({
+            item_id: item.catalog_item_id,
+            location_id: locationId,
+            quantity: new Prisma.Decimal(item.quantity).negated(),
+            type: TransactionType.SALE_ISSUE,
+            reference_id: invoiceNumber,
           });
         }
+      }
+
+      // 2c. Execute updates concurrently and create transactions in bulk
+      await chunkedPromiseAll(stockUpdates, async (update) => {
+        const updateResult = await tx.inventoryStock.updateMany({
+          where: {
+            catalog_item_id: update.catalog_item_id,
+            location_id: update.locationId,
+            quantity_on_hand: { gte: update.quantityToDeduct }, // Ensure sufficient stock
+          },
+          data: {
+            quantity_on_hand: { decrement: update.quantityToDeduct },
+          },
+        });
+
+        if (updateResult.count === 0) {
+          // Refetch stock to give accurate error message if concurrency was high
+          const latestStock = await tx.inventoryStock.findUnique({
+            where: {
+              catalog_item_id_location_id: {
+                catalog_item_id: update.catalog_item_id,
+                location_id: update.locationId,
+              },
+            },
+          });
+          throw new BadRequestException(
+            `Insufficient stock for item at location ${update.locationId} (Req: ${update.quantityToDeduct}, Available: ${latestStock?.quantity_on_hand ?? 0})`,
+          );
+        }
+      });
+
+      if (transactionCreations.length > 0) {
+        await tx.inventoryTransaction.createMany({
+          data: transactionCreations,
+        });
       }
 
       // 3. Update Invoice Status and return updated invoice (Concurrency Safe)

--- a/pr_description.md
+++ b/pr_description.md
@@ -4,7 +4,8 @@
 The `SalesService.finalize` method was originally executing sequential database queries inside a `for` loop, causing an N+1 issue for both `inventoryStock` updates and `inventoryTransaction` inserts.
 
 This PR applies a hybrid aggregation approach:
-- Aggregates invoice item quantities per `catalog_item_id` and location in memory first.
+- Iterates sequentially through invoice items in memory to accurately assign `location_id` for fulfillment, splitting quantities if needed.
+- Aggregates invoice item quantities by a composite key of `${catalog_item_id}_${location_id}` in memory.
 - Performs a "Dry-Run" validation to fail fast before issuing database updates.
 - Uses `chunkedPromiseAll` to execute the reduced number of `tx.inventoryStock.updateMany` operations concurrently, staying within connection pool limits.
 - Batches the 1:1 ledger entries using `tx.inventoryTransaction.createMany` to preserve the granular audit trail while eliminating the N+1 insert queries.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,22 @@
+# ⚡ Optimize SalesService.finalize inventory updates
+
+## 💡 What
+The `SalesService.finalize` method was originally executing sequential database queries inside a `for` loop, causing an N+1 issue for both `inventoryStock` updates and `inventoryTransaction` inserts.
+
+This PR applies a hybrid aggregation approach:
+- Aggregates invoice item quantities per `catalog_item_id` and location in memory first.
+- Performs a "Dry-Run" validation to fail fast before issuing database updates.
+- Uses `chunkedPromiseAll` to execute the reduced number of `tx.inventoryStock.updateMany` operations concurrently, staying within connection pool limits.
+- Batches the 1:1 ledger entries using `tx.inventoryTransaction.createMany` to preserve the granular audit trail while eliminating the N+1 insert queries.
+
+## 🎯 Why
+Invoices with many line items (e.g., 100+ items) caused a linear increase in database roundtrips for stock deductions and ledger transactions. This led to high latency, increased lock contention inside the transaction, and potential connection pool exhaustion.
+
+By aggregating in memory and bulk inserting/updating, the number of database queries is drastically reduced to at most N (number of unique catalog items) updates and exactly 1 bulk insert, down from 2 * N total queries.
+
+## 📊 Measured Improvement
+⚠️ *Note on Benchmarks: Due to missing environment dependencies (`node_modules` unavailable, restricted network access preventing `npm install`), I was unable to execute the automated jest or ts-node benchmark scripts locally to measure the exact millisecond improvement.*
+
+However, based on the implementation details, this change provides a substantial theoretical performance improvement because:
+1. **Network I/O Reduction**: A 100-item invoice with the same catalog item drops from 200 queries inside the transaction loop down to exactly 2 queries (1 update, 1 bulk create).
+2. **Locking**: Optimistic locks via `updateMany` are applied per unique item, drastically lowering the lock contention time on the `inventoryStock` rows during large invoice processing.

--- a/test_syntax.ts
+++ b/test_syntax.ts
@@ -1,0 +1,1 @@
+import { SalesService } from './apps/core-api/src/sales/sales.service';


### PR DESCRIPTION
## 💡 What
The `SalesService.finalize` method was originally executing sequential database queries inside a `for` loop, causing an N+1 issue for both `inventoryStock` updates and `inventoryTransaction` inserts. 

This PR applies a hybrid aggregation approach:
- Aggregates invoice item quantities per `catalog_item_id` and location in memory first.
- Performs a "Dry-Run" validation to fail fast before issuing database updates.
- Uses `chunkedPromiseAll` to execute the reduced number of `tx.inventoryStock.updateMany` operations concurrently, staying within connection pool limits.
- Batches the 1:1 ledger entries using `tx.inventoryTransaction.createMany` to preserve the granular audit trail while eliminating the N+1 insert queries.

## 🎯 Why
Invoices with many line items (e.g., 100+ items) caused a linear increase in database roundtrips for stock deductions and ledger transactions. This led to high latency, increased lock contention inside the transaction, and potential connection pool exhaustion. 

By aggregating in memory and bulk inserting/updating, the number of database queries is drastically reduced to at most N (number of unique catalog items) updates and exactly 1 bulk insert, down from 2 * N total queries.

## 📊 Measured Improvement
⚠️ *Note on Benchmarks: Due to missing environment dependencies (`node_modules` unavailable, restricted network access preventing `npm install`), I was unable to execute the automated jest or ts-node benchmark scripts locally to measure the exact millisecond improvement.*

However, based on the implementation details, this change provides a substantial theoretical performance improvement because:
1. **Network I/O Reduction**: A 100-item invoice with the same catalog item drops from 200 queries inside the transaction loop down to exactly 2 queries (1 update, 1 bulk create).
2. **Locking**: Optimistic locks via `updateMany` are applied per unique item, drastically lowering the lock contention time on the `inventoryStock` rows during large invoice processing.

---
*PR created automatically by Jules for task [14517920316171231377](https://jules.google.com/task/14517920316171231377) started by @vandean25*