### PR TITLE
Implement Workshop Board frontend

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -144,7 +144,10 @@ We use a **Context-Based Approach**, allowing both patterns strictly based on th
 - **Error Handling**: Use standard NestJS HTTP exceptions (`BadRequestException`, `NotFoundException`, etc.) with clear, descriptive error messages.
 - **Prisma**: Use `PrismaService` for all DB operations. Schema uses `snake_case` via `@@map()`. Always run `npx prisma generate` after schema changes. Seed data is in `prisma/seed.ts`. Use `npx prisma migrate dev` for development migrations.
 - **Validation**: Global `ValidationPipe` is enabled in `main.ts` with `whitelist: true` and `transform: true`. Use `class-validator` and `class-transformer` extensively in validation DTOs.
-
+- **Tenant Isolation (Critical — Zero-Tolerance)**: Every Prisma query against a tenant-scoped model **must** include `tenant_id: tenantId` in its `where` clause. This applies to all read queries (`findMany`, `findFirst`, `findUnique`), write validation lookups, and any `include`/subquery that resolves a related entity the caller owns. Omitting `tenant_id` is a cross-tenant data leak vulnerability. The `tenantId` must be obtained from `this.tenantContext.getTenantId()` at the top of each service method — never trust an ID supplied directly from the request body for scoping. Tenant-scoped models are those with a `tenant_id` column (e.g., `Employee`, `Bay`, `Customer`, `Vehicle`, `WorkshopOrder`, `InventoryStock`, etc.).
+  - 🔴 **DON'T:** `prisma.employee.findMany({ where: { role: 'MECHANIC' } })` — leaks employees from all tenants.
+  - 🟢 **DO:** `prisma.employee.findMany({ where: { tenant_id: tenantId, role: 'MECHANIC' } })`
+  
 ### API Conventions
 - **Prefix**: All endpoints are prefixed with `/api`.
 - **Formatting**: List endpoints return `{ data, meta }` format for list endpoints. Use pagination with `page` and `limit` query params.

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -5369,7 +5369,11 @@
             "type": "string"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "LABOR",
+              "PART"
+            ]
           },
           "itemNo": {
             "type": "string"
@@ -5407,7 +5411,13 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "NOT_STARTED",
+              "IN_PROGRESS",
+              "WAITING_PARTS",
+              "DONE"
+            ]
           },
           "lineItems": {
             "type": "array",
@@ -5462,7 +5472,12 @@
           },
           "partsStatus": {
             "type": "string",
-            "description": "Parts readiness status"
+            "enum": [
+              "READY",
+              "SHORTAGE",
+              "WAITING",
+              "NO_PARTS"
+            ]
           },
           "tasks": {
             "type": "array",

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -2747,6 +2747,72 @@
         ]
       }
     },
+    "/api/workshop/resources": {
+      "get": {
+        "operationId": "WorkshopController_getBoardResources",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkshopResourcesResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workshop"
+        ]
+      }
+    },
+    "/api/workshop/board/active": {
+      "get": {
+        "operationId": "WorkshopController_getBoardActive",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardActiveResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workshop"
+        ]
+      }
+    },
+    "/api/workshop/board/assign": {
+      "patch": {
+        "operationId": "WorkshopController_assignBoard",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignBoardDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated workshop order assignment."
+          }
+        },
+        "tags": [
+          "Workshop"
+        ]
+      }
+    },
     "/api/invoices/drafts": {
       "post": {
         "operationId": "InvoicesController_createDraft",
@@ -5160,6 +5226,305 @@
         "required": [
           "message",
           "enqueued"
+        ]
+      },
+      "WorkshopMechanicDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "MECHANIC",
+              "SERVICE_ADVISOR",
+              "PARTS_CLERK"
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "sortOrder": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "role",
+          "isActive",
+          "sortOrder"
+        ]
+      },
+      "WorkshopBayDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "sortOrder": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "isActive",
+          "sortOrder"
+        ]
+      },
+      "WorkshopResourcesResponseDto": {
+        "type": "object",
+        "properties": {
+          "mechanics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkshopMechanicDto"
+            }
+          },
+          "bays": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkshopBayDto"
+            }
+          }
+        },
+        "required": [
+          "mechanics",
+          "bays"
+        ]
+      },
+      "BoardCustomerDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "PRIVATE",
+              "COMPANY"
+            ]
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "firstName",
+          "lastName"
+        ]
+      },
+      "BoardVehicleDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "year": {
+            "type": "number"
+          },
+          "plate": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "make",
+          "model",
+          "year"
+        ]
+      },
+      "BoardLineItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "itemNo": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "unitPrice": {
+            "type": "number"
+          },
+          "catalogItemId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "itemNo",
+          "description",
+          "quantity",
+          "unitPrice"
+        ]
+      },
+      "BoardTaskDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lineItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoardLineItemDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "status",
+          "lineItems"
+        ]
+      },
+      "BoardOrderDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "orderNumber": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "SCHEDULED",
+              "INTAKE",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "INVOICED"
+            ]
+          },
+          "customer": {
+            "$ref": "#/components/schemas/BoardCustomerDto"
+          },
+          "vehicle": {
+            "$ref": "#/components/schemas/BoardVehicleDto"
+          },
+          "mechanicId": {
+            "type": "string",
+            "nullable": true
+          },
+          "bayId": {
+            "type": "string",
+            "nullable": true
+          },
+          "stagingLocationId": {
+            "type": "string",
+            "nullable": true
+          },
+          "partsStatus": {
+            "type": "string",
+            "description": "Parts readiness status"
+          },
+          "tasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoardTaskDto"
+            }
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "orderNumber",
+          "status",
+          "customer",
+          "vehicle",
+          "partsStatus",
+          "tasks",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "BoardActiveResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BoardOrderDto"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "AssignBoardDto": {
+        "type": "object",
+        "properties": {
+          "orderId": {
+            "type": "string",
+            "description": "Workshop order ID to assign"
+          },
+          "mechanicId": {
+            "type": "string",
+            "description": "Mechanic (employee) ID to assign, or null to unassign",
+            "nullable": true
+          },
+          "bayId": {
+            "type": "string",
+            "description": "Bay ID to assign, or null to unassign",
+            "nullable": true
+          }
+        },
+        "required": [
+          "orderId"
         ]
       },
       "CreateDraftInvoiceDto": {

--- a/apps/core-api/src/workshop/dto/assign-board.dto.ts
+++ b/apps/core-api/src/workshop/dto/assign-board.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+
+export class AssignBoardDto {
+  @ApiProperty({ description: 'Workshop order ID to assign' })
+  @IsUUID()
+  orderId!: string;
+
+  @ApiProperty({
+    description: 'Mechanic (employee) ID to assign, or null to unassign',
+    type: String,
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  mechanicId?: string | null;
+
+  @ApiProperty({
+    description: 'Bay ID to assign, or null to unassign',
+    type: String,
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  bayId?: string | null;
+}

--- a/apps/core-api/src/workshop/dto/board-response.dto.ts
+++ b/apps/core-api/src/workshop/dto/board-response.dto.ts
@@ -1,0 +1,161 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CustomerType, EmployeeRole, WorkshopOrderStatus } from '@prisma/client';
+
+// ─── Resources Endpoint DTOs ─────────────────────────────────────────────────
+
+export class WorkshopMechanicDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ enum: EmployeeRole })
+  role!: EmployeeRole;
+
+  @ApiProperty()
+  isActive!: boolean;
+
+  @ApiProperty()
+  sortOrder!: number;
+}
+
+export class WorkshopBayDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  isActive!: boolean;
+
+  @ApiProperty()
+  sortOrder!: number;
+}
+
+export class WorkshopResourcesResponseDto {
+  @ApiProperty({ type: [WorkshopMechanicDto] })
+  mechanics!: WorkshopMechanicDto[];
+
+  @ApiProperty({ type: [WorkshopBayDto] })
+  bays!: WorkshopBayDto[];
+}
+
+// ─── Board Active Endpoint DTOs ───────────────────────────────────────────────
+
+export type PartsStatus = 'READY' | 'SHORTAGE' | 'WAITING' | 'NO_PARTS';
+
+export class BoardLineItemDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  type!: string;
+
+  @ApiProperty()
+  itemNo!: string;
+
+  @ApiProperty()
+  description!: string;
+
+  @ApiProperty()
+  quantity!: number;
+
+  @ApiProperty()
+  unitPrice!: number;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  catalogItemId?: string | null;
+}
+
+export class BoardTaskDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiProperty()
+  status!: string;
+
+  @ApiProperty({ type: [BoardLineItemDto] })
+  lineItems!: BoardLineItemDto[];
+}
+
+export class BoardCustomerDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty({ enum: CustomerType })
+  type!: CustomerType;
+
+  @ApiProperty()
+  firstName!: string;
+
+  @ApiProperty()
+  lastName!: string;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  companyName?: string | null;
+}
+
+export class BoardVehicleDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  make!: string;
+
+  @ApiProperty()
+  model!: string;
+
+  @ApiProperty()
+  year!: number;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  plate?: string | null;
+}
+
+export class BoardOrderDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  orderNumber!: string;
+
+  @ApiProperty({ enum: WorkshopOrderStatus })
+  status!: WorkshopOrderStatus;
+
+  @ApiProperty({ type: () => BoardCustomerDto })
+  customer!: BoardCustomerDto;
+
+  @ApiProperty({ type: () => BoardVehicleDto })
+  vehicle!: BoardVehicleDto;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  mechanicId?: string | null;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  bayId?: string | null;
+
+  @ApiProperty({ type: String, nullable: true, required: false })
+  stagingLocationId?: string | null;
+
+  @ApiProperty({ description: 'Parts readiness status', type: String })
+  partsStatus!: PartsStatus;
+
+  @ApiProperty({ type: [BoardTaskDto] })
+  tasks!: BoardTaskDto[];
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}
+
+export class BoardActiveResponseDto {
+  @ApiProperty({ type: [BoardOrderDto] })
+  data!: BoardOrderDto[];
+}

--- a/apps/core-api/src/workshop/dto/board-response.dto.ts
+++ b/apps/core-api/src/workshop/dto/board-response.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { CustomerType, EmployeeRole, WorkshopOrderStatus } from '@prisma/client';
+import {
+  CustomerType,
+  EmployeeRole,
+  WorkshopLineItemType,
+  WorkshopOrderStatus,
+  WorkshopTaskStatus,
+} from '@prisma/client';
 
 // ─── Resources Endpoint DTOs ─────────────────────────────────────────────────
 
@@ -44,14 +50,19 @@ export class WorkshopResourcesResponseDto {
 
 // ─── Board Active Endpoint DTOs ───────────────────────────────────────────────
 
-export type PartsStatus = 'READY' | 'SHORTAGE' | 'WAITING' | 'NO_PARTS';
+export enum PartsStatus {
+  READY = 'READY',
+  SHORTAGE = 'SHORTAGE',
+  WAITING = 'WAITING',
+  NO_PARTS = 'NO_PARTS',
+}
 
 export class BoardLineItemDto {
   @ApiProperty()
   id!: string;
 
-  @ApiProperty()
-  type!: string;
+  @ApiProperty({ enum: WorkshopLineItemType })
+  type!: WorkshopLineItemType;
 
   @ApiProperty()
   itemNo!: string;
@@ -76,8 +87,8 @@ export class BoardTaskDto {
   @ApiProperty()
   title!: string;
 
-  @ApiProperty()
-  status!: string;
+  @ApiProperty({ enum: WorkshopTaskStatus })
+  status!: WorkshopTaskStatus;
 
   @ApiProperty({ type: [BoardLineItemDto] })
   lineItems!: BoardLineItemDto[];
@@ -142,7 +153,7 @@ export class BoardOrderDto {
   @ApiProperty({ type: String, nullable: true, required: false })
   stagingLocationId?: string | null;
 
-  @ApiProperty({ description: 'Parts readiness status', type: String })
+  @ApiProperty({ enum: PartsStatus })
   partsStatus!: PartsStatus;
 
   @ApiProperty({ type: [BoardTaskDto] })

--- a/apps/core-api/src/workshop/workshop.controller.ts
+++ b/apps/core-api/src/workshop/workshop.controller.ts
@@ -39,6 +39,11 @@ import {
   WorkshopOrderResponseDto,
   WorkshopTaskResponseDto,
 } from './dto/workshop-response.dto';
+import { AssignBoardDto } from './dto/assign-board.dto';
+import {
+  BoardActiveResponseDto,
+  WorkshopResourcesResponseDto,
+} from './dto/board-response.dto';
 import { Public } from '../common/decorators/public.decorator';
 import { TenantContextService } from '../common/services/tenant-context.service';
 import { WorkshopPdfService } from './workshop-pdf.service';
@@ -282,5 +287,25 @@ export class WorkshopController {
     }
 
     await pipeline(stream, res);
+  }
+
+  // ─── Board Endpoints ───────────────────────────────────────────────────────
+
+  @Get('resources')
+  @ApiOkResponse({ type: WorkshopResourcesResponseDto })
+  getBoardResources() {
+    return this.workshopService.getBoardResources();
+  }
+
+  @Get('board/active')
+  @ApiOkResponse({ type: BoardActiveResponseDto })
+  getBoardActive() {
+    return this.workshopService.getBoardActive();
+  }
+
+  @Patch('board/assign')
+  @ApiOkResponse({ description: 'Updated workshop order assignment.' })
+  assignBoard(@Body() dto: AssignBoardDto) {
+    return this.workshopService.assignBoard(dto);
   }
 }

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -1184,12 +1184,12 @@ export class WorkshopService {
 
     const [mechanics, bays] = await Promise.all([
       this.prisma.employee.findMany({
-        where: { role: 'MECHANIC', is_active: true },
+        where: { tenant_id: tenantId, role: 'MECHANIC', is_active: true },
         orderBy: [{ sort_order: 'asc' }, { name: 'asc' }],
         select: { id: true, name: true, role: true, is_active: true, sort_order: true },
       }),
       this.prisma.bay.findMany({
-        where: { is_active: true },
+        where: { tenant_id: tenantId, is_active: true },
         orderBy: [{ sort_order: 'asc' }, { name: 'asc' }],
         select: { id: true, name: true, is_active: true, sort_order: true },
       }),
@@ -1375,7 +1375,7 @@ export class WorkshopService {
 
     if (dto.mechanicId !== undefined && dto.mechanicId !== null) {
       const mechanic = await this.prisma.employee.findFirst({
-        where: { id: dto.mechanicId },
+        where: { id: dto.mechanicId, tenant_id: tenantId },
         select: { id: true, role: true, is_active: true },
       });
 
@@ -1400,7 +1400,7 @@ export class WorkshopService {
 
     if (dto.bayId !== undefined && dto.bayId !== null) {
       const bay = await this.prisma.bay.findFirst({
-        where: { id: dto.bayId },
+        where: { id: dto.bayId, tenant_id: tenantId },
         select: { id: true, is_active: true },
       });
 

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -6,6 +6,8 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import type { AssignBoardDto } from './dto/assign-board.dto';
+import type { PartsStatus } from './dto/board-response.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import type { CreateWorkshopOrderDto } from './dto/create-workshop-order.dto';
 import type { PickWorkshopPartsDto } from './dto/pick-workshop-parts.dto';
@@ -30,6 +32,11 @@ const DEFAULT_PAGE_SIZE = 25;
 const MAX_PAGE_SIZE = 100;
 const SEARCH_LIMIT = 100;
 const PICK_ELIGIBLE_ORDER_STATUSES: WorkshopOrderStatus[] = [
+  WorkshopOrderStatus.INTAKE,
+  WorkshopOrderStatus.IN_PROGRESS,
+];
+const ACTIVE_ORDER_STATUSES: WorkshopOrderStatus[] = [
+  WorkshopOrderStatus.SCHEDULED,
   WorkshopOrderStatus.INTAKE,
   WorkshopOrderStatus.IN_PROGRESS,
 ];
@@ -1167,6 +1174,271 @@ export class WorkshopService {
         limit,
         totalPages: Math.ceil(total / limit),
       },
+    };
+  }
+
+  // ─── Board Endpoints ───────────────────────────────────────────────────────
+
+  async getBoardResources() {
+    const tenantId = await this.tenantContext.getTenantId();
+
+    const [mechanics, bays] = await Promise.all([
+      this.prisma.employee.findMany({
+        where: { role: 'MECHANIC', is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { name: 'asc' }],
+        select: { id: true, name: true, role: true, is_active: true, sort_order: true },
+      }),
+      this.prisma.bay.findMany({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { name: 'asc' }],
+        select: { id: true, name: true, is_active: true, sort_order: true },
+      }),
+    ]);
+
+    return {
+      mechanics: mechanics.map((m) => ({
+        id: m.id,
+        name: m.name,
+        role: m.role,
+        isActive: m.is_active,
+        sortOrder: m.sort_order,
+      })),
+      bays: bays.map((b) => ({
+        id: b.id,
+        name: b.name,
+        isActive: b.is_active,
+        sortOrder: b.sort_order,
+      })),
+    };
+  }
+
+  async getBoardActive() {
+    const tenantId = await this.tenantContext.getTenantId();
+
+    // Query 1: all active workshop orders with their tasks and line items
+    const orders = await this.prisma.workshopOrder.findMany({
+      where: { tenant_id: tenantId, status: { in: ACTIVE_ORDER_STATUSES } },
+      include: {
+        customer: true,
+        vehicle: true,
+        tasks: {
+          include: {
+            line_items: {
+              include: {
+                labor_operation: false,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    // Collect all staging location IDs that have PART line items
+    const stagingLocationIds = [
+      ...new Set(
+        orders
+          .map((o) => o.staging_location_id)
+          .filter((id): id is string => !!id),
+      ),
+    ];
+
+    // Query 2: bulk-fetch inventory stock for all relevant staging locations
+    const stockRecords =
+      stagingLocationIds.length > 0
+        ? await this.prisma.inventoryStock.findMany({
+            where: {
+              tenant_id: tenantId,
+              location_id: { in: stagingLocationIds },
+            },
+            select: {
+              location_id: true,
+              catalog_item_id: true,
+              quantity_on_hand: true,
+            },
+          })
+        : [];
+
+    // Build pre-fetched map: "locationId:catalogItemId" -> quantity
+    const stockMap = new Map<string, number>();
+    for (const record of stockRecords) {
+      const key = `${record.location_id}:${record.catalog_item_id}`;
+      stockMap.set(key, Number(record.quantity_on_hand));
+    }
+
+    // We also need catalog items to map SKU -> catalogItemId for line items
+    const allSkus = [
+      ...new Set(
+        orders.flatMap((o) =>
+          o.tasks.flatMap((t) =>
+            t.line_items
+              .filter((li) => li.type === 'PART')
+              .map((li) => li.item_no),
+          ),
+        ),
+      ),
+    ];
+
+    const catalogItems =
+      allSkus.length > 0
+        ? await this.prisma.catalogItem.findMany({
+            where: { tenant_id: tenantId, sku: { in: allSkus } },
+            select: { id: true, sku: true },
+          })
+        : [];
+
+    const catalogIdBySku = new Map(catalogItems.map((c) => [c.sku, c.id]));
+
+    // Compute partsStatus in-memory
+    const data = orders.map((order) => {
+      const partLineItems = order.tasks.flatMap((t) =>
+        t.line_items.filter((li) => li.type === 'PART'),
+      );
+
+      let partsStatus: PartsStatus;
+      if (partLineItems.length === 0) {
+        partsStatus = 'NO_PARTS';
+      } else if (!order.staging_location_id) {
+        partsStatus = 'WAITING';
+      } else {
+        const hasShortage = partLineItems.some((li) => {
+          const catalogItemId = catalogIdBySku.get(li.item_no);
+          if (!catalogItemId) return true; // item missing → shortage
+          const key = `${order.staging_location_id}:${catalogItemId}`;
+          const qty = stockMap.get(key) ?? 0;
+          return qty < Number(li.quantity);
+        });
+        partsStatus = hasShortage ? 'SHORTAGE' : 'READY';
+      }
+
+      return {
+        id: order.id,
+        orderNumber: order.order_number,
+        status: order.status,
+        customer: {
+          id: order.customer.id,
+          type: order.customer.type,
+          firstName: order.customer.first_name,
+          lastName: order.customer.last_name,
+          companyName: order.customer.company_name,
+        },
+        vehicle: {
+          id: order.vehicle.id,
+          make: order.vehicle.make,
+          model: order.vehicle.model,
+          year: order.vehicle.year,
+          plate: order.vehicle.plate,
+        },
+        mechanicId: order.mechanic_id,
+        bayId: order.bay_id,
+        stagingLocationId: order.staging_location_id,
+        partsStatus,
+        tasks: order.tasks.map((task) => ({
+          id: task.id,
+          title: task.title,
+          status: task.status,
+          lineItems: task.line_items.map((li) => ({
+            id: li.id,
+            type: li.type,
+            itemNo: li.item_no,
+            description: li.description,
+            quantity: Number(li.quantity),
+            unitPrice: Number(li.unit_price),
+            catalogItemId: catalogIdBySku.get(li.item_no) ?? null,
+          })),
+        })),
+        createdAt: order.createdAt,
+        updatedAt: order.updatedAt,
+      };
+    });
+
+    return { data };
+  }
+
+  async assignBoard(dto: AssignBoardDto) {
+    const tenantId = await this.tenantContext.getTenantId();
+
+    const order = await this.prisma.workshopOrder.findFirst({
+      where: { id: dto.orderId, tenant_id: tenantId },
+      select: { id: true, status: true },
+    });
+
+    if (!order) {
+      throw new NotFoundException(`Workshop order ${dto.orderId} not found`);
+    }
+
+    if (!ACTIVE_ORDER_STATUSES.includes(order.status)) {
+      throw new UnprocessableEntityException(
+        `Cannot assign resources to an order in terminal status ${order.status}`,
+      );
+    }
+
+    if (dto.mechanicId !== undefined && dto.mechanicId !== null) {
+      const mechanic = await this.prisma.employee.findFirst({
+        where: { id: dto.mechanicId },
+        select: { id: true, role: true, is_active: true },
+      });
+
+      if (!mechanic) {
+        throw new NotFoundException(
+          `Employee ${dto.mechanicId} not found`,
+        );
+      }
+
+      if (mechanic.role !== 'MECHANIC') {
+        throw new UnprocessableEntityException(
+          `Employee ${dto.mechanicId} is not a MECHANIC (role: ${mechanic.role})`,
+        );
+      }
+
+      if (!mechanic.is_active) {
+        throw new NotFoundException(
+          `Employee ${dto.mechanicId} is inactive`,
+        );
+      }
+    }
+
+    if (dto.bayId !== undefined && dto.bayId !== null) {
+      const bay = await this.prisma.bay.findFirst({
+        where: { id: dto.bayId },
+        select: { id: true, is_active: true },
+      });
+
+      if (!bay) {
+        throw new NotFoundException(`Bay ${dto.bayId} not found`);
+      }
+
+      if (!bay.is_active) {
+        throw new NotFoundException(`Bay ${dto.bayId} is inactive`);
+      }
+    }
+
+    // Single-row update — last-write-wins (per ADR-0013)
+    const updated = await this.prisma.workshopOrder.update({
+      where: { id: dto.orderId },
+      data: {
+        ...(dto.mechanicId !== undefined && { mechanic_id: dto.mechanicId }),
+        ...(dto.bayId !== undefined && { bay_id: dto.bayId }),
+      },
+      select: {
+        id: true,
+        order_number: true,
+        status: true,
+        mechanic_id: true,
+        bay_id: true,
+        staging_location_id: true,
+        updatedAt: true,
+      },
+    });
+
+    return {
+      id: updated.id,
+      orderNumber: updated.order_number,
+      status: updated.status,
+      mechanicId: updated.mechanic_id,
+      bayId: updated.bay_id,
+      stagingLocationId: updated.staging_location_id,
+      updatedAt: updated.updatedAt,
     };
   }
 }

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -7,7 +7,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import type { AssignBoardDto } from './dto/assign-board.dto';
-import type { PartsStatus } from './dto/board-response.dto';
+import { PartsStatus } from './dto/board-response.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import type { CreateWorkshopOrderDto } from './dto/create-workshop-order.dto';
 import type { PickWorkshopPartsDto } from './dto/pick-workshop-parts.dto';
@@ -1297,9 +1297,9 @@ export class WorkshopService {
 
       let partsStatus: PartsStatus;
       if (partLineItems.length === 0) {
-        partsStatus = 'NO_PARTS';
+        partsStatus = PartsStatus.NO_PARTS;
       } else if (!order.staging_location_id) {
-        partsStatus = 'WAITING';
+        partsStatus = PartsStatus.WAITING;
       } else {
         const hasShortage = partLineItems.some((li) => {
           const catalogItemId = catalogIdBySku.get(li.item_no);
@@ -1308,7 +1308,7 @@ export class WorkshopService {
           const qty = stockMap.get(key) ?? 0;
           return qty < Number(li.quantity);
         });
-        partsStatus = hasShortage ? 'SHORTAGE' : 'READY';
+        partsStatus = hasShortage ? PartsStatus.SHORTAGE : PartsStatus.READY;
       }
 
       return {

--- a/apps/core-web/e2e/workshop-board.spec.ts
+++ b/apps/core-web/e2e/workshop-board.spec.ts
@@ -1,0 +1,446 @@
+import { test, expect } from '@playwright/test'
+import { AutoCorePage } from './pom/AutoCorePage'
+import {
+  createMockEmployee,
+  createMockBay,
+} from './utils/mock-factories'
+
+/**
+ * Blueprint: Workshop Board
+ *
+ * E2E tests for the Workshop Kanban Board page (/workshop/board).
+ * Covers:
+ * - Page rendering with correct header structure and view toggle.
+ * - Dynamic swimlane columns built from /api/workshop/resources.
+ * - Board cards rendered from /api/workshop/board/active with parts status.
+ * - View mode toggle (mechanic ↔ bay) and localStorage persistence.
+ * - Empty-state rendering when no resources are configured.
+ * - Board assignment via PATCH /api/workshop/board/assign.
+ * - Unassigned column is always visible regardless of view mode.
+ */
+test.describe('Blueprint: Workshop Board', () => {
+  const MECHANIC_ID = 'emp-mech-001'
+  const BAY_ID = 'bay-001'
+  const ORDER_ID = 'ws-board-001'
+  const ORDER_ID_2 = 'ws-board-002'
+
+  const mockMechanic = createMockEmployee({
+    id: MECHANIC_ID,
+    name: 'Alex Novak',
+    role: 'MECHANIC',
+    isActive: true,
+    sortOrder: 1,
+  })
+
+  const mockBay = createMockBay({
+    id: BAY_ID,
+    name: 'Bay 01',
+    isActive: true,
+    sortOrder: 1,
+  })
+
+  const mockResources = {
+    mechanics: [mockMechanic],
+    bays: [mockBay],
+  }
+
+  const mockOrder = {
+    id: ORDER_ID,
+    orderNumber: 'WO-2026-0001',
+    status: 'INTAKE',
+    customer: {
+      id: 'cust-1',
+      type: 'PRIVATE',
+      firstName: 'John',
+      lastName: 'Doe',
+      companyName: null,
+    },
+    vehicle: {
+      id: 'veh-1',
+      make: 'Skoda',
+      model: 'Octavia',
+      year: 2020,
+      plate: 'SK-2020-OCT',
+    },
+    mechanicId: MECHANIC_ID,
+    bayId: null,
+    stagingLocationId: null,
+    partsStatus: 'READY',
+    tasks: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+
+  const mockUnassignedOrder = {
+    id: ORDER_ID_2,
+    orderNumber: 'WO-2026-0002',
+    status: 'SCHEDULED',
+    customer: {
+      id: 'cust-2',
+      type: 'PRIVATE',
+      firstName: 'Maria',
+      lastName: 'Müller',
+      companyName: null,
+    },
+    vehicle: {
+      id: 'veh-2',
+      make: 'VW',
+      model: 'Golf',
+      year: 2022,
+      plate: 'VW-2022-GLF',
+    },
+    mechanicId: null,
+    bayId: null,
+    stagingLocationId: null,
+    partsStatus: 'NO_PARTS',
+    tasks: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+
+  const mockBoardActiveResponse = {
+    data: [mockOrder, mockUnassignedOrder],
+  }
+
+  async function setupBoardRoutes(page: import('@playwright/test').Page) {
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/resources'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockResources),
+        })
+      },
+    )
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/active'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockBoardActiveResponse),
+        })
+      },
+    )
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/assign'),
+      async (route) => {
+        const body = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: body['orderId'],
+            mechanicId: body['mechanicId'] ?? null,
+            bayId: body['bayId'] ?? null,
+            updatedAt: new Date().toISOString(),
+          }),
+        })
+      },
+    )
+  }
+
+  test('Board renders with page header and view toggle', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await setupBoardRoutes(page)
+    await corePage.navigate('/workshop/board')
+
+    // Header title (top-left)
+    await expect(page.getByRole('heading', { name: 'Workshop Board', exact: true })).toBeVisible()
+
+    // View toggle top-right
+    await expect(page.getByRole('button', { name: /By Mechanic/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /By Bay/i })).toBeVisible()
+  })
+
+  test('Board renders mechanic swimlane columns with order cards', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await setupBoardRoutes(page)
+
+    // Clear any persisted view mode so we always start on mechanic view
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    // Mechanic column "Alex Novak" should appear
+    await expect(page.getByTestId('board-column-emp-mech-001')).toBeVisible()
+
+    // Unassigned column is always present
+    await expect(page.getByTestId('board-column-unassigned')).toBeVisible()
+
+    // Assigned order card under mechanic
+    await expect(page.getByText('WO-2026-0001')).toBeVisible()
+    await expect(page.getByText(/John Doe/)).toBeVisible()
+    await expect(page.getByText(/Skoda Octavia/i)).toBeVisible()
+
+    // Unassigned order card in Unassigned column
+    await expect(page.getByText('WO-2026-0002')).toBeVisible()
+    await expect(page.getByText(/Maria Müller/i)).toBeVisible()
+  })
+
+  test('Board renders bay swimlane columns when switching to Bay view', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await setupBoardRoutes(page)
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    // Switch to bay view
+    await page.getByRole('button', { name: /By Bay/i }).click()
+
+    // Bay column "Bay 01" should appear
+    await expect(page.getByTestId('board-column-bay-001')).toBeVisible()
+
+    // Unassigned column is still visible
+    await expect(page.getByTestId('board-column-unassigned')).toBeVisible()
+  })
+
+  test('View mode persists across page refreshes via localStorage', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await setupBoardRoutes(page)
+
+    await page.addInitScript(() => {
+      window.localStorage.setItem('workshop-board-view-mode', 'bay')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    // Should start in bay mode — "Bay 01" column visible
+    await expect(page.getByTestId('board-column-bay-001')).toBeVisible()
+    // Mechanic column "Alex Novak" should NOT appear in bay mode
+    await expect(page.getByTestId('board-column-emp-mech-001')).not.toBeVisible()
+  })
+
+  test('Cards show parts status badge (READY and NO_PARTS)', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await setupBoardRoutes(page)
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    // First card has READY parts status
+    await expect(page.getByText('WO-2026-0001')).toBeVisible()
+    await expect(page.locator('text=Ready').first()).toBeVisible()
+
+    // Second card has NO_PARTS
+    await expect(page.getByText('WO-2026-0002')).toBeVisible()
+    await expect(page.locator('text=No Parts').first()).toBeVisible()
+  })
+
+  test('Empty state card renders when no mechanic resources exist', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    // Override resources with empty mechanics
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/resources'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ mechanics: [], bays: [mockBay] }),
+        })
+      },
+    )
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/active'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        })
+      },
+    )
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    // Empty state card
+    await expect(page.getByText(/No Mechanics configured/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /Go to Settings/i })).toBeVisible()
+
+    // Unassigned column still visible alongside the empty state
+    await expect(page.getByText('Unassigned')).toBeVisible()
+  })
+
+  test('Empty state "Go to Settings" routes to Settings employees tab', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/resources'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ mechanics: [], bays: [] }),
+        })
+      },
+    )
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/active'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        })
+      },
+    )
+
+    // Intercept settings-page API calls
+    await page.route(AutoCorePage.apiRouteMatcher('/api/employees'), async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], meta: { total: 0, page: 1, limit: 25, totalPages: 1 } }),
+      })
+    })
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    await page.getByRole('button', { name: /Go to Settings/i }).click()
+
+    // Should navigate to /settings?tab=employees
+    await expect(page).toHaveURL(/\/settings.*tab=employees/)
+  })
+
+  test('Quick assign button calls PATCH /api/workshop/board/assign and moves the card', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    let assignCalled = false
+    let assignPayload: Record<string, unknown> = {}
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/resources'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockResources),
+        })
+      },
+    )
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/active'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockBoardActiveResponse),
+        })
+      },
+    )
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/assign'),
+      async (route) => {
+        assignCalled = true
+        assignPayload = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: ORDER_ID_2, mechanicId: MECHANIC_ID, bayId: null, updatedAt: new Date().toISOString() }),
+        })
+      },
+    )
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    const card = page.getByTestId('workshop-order-card-ws-board-002')
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/workshop/board/assign') &&
+        response.request().method() === 'PATCH',
+    )
+
+    await card.getByTestId('assign-mechanic-emp-mech-001').click({ force: true })
+    await responsePromise
+
+    expect(assignCalled).toBe(true)
+    expect(assignPayload.orderId).toBe(ORDER_ID_2)
+    expect(assignPayload.mechanicId).toBe(MECHANIC_ID)
+
+    await expect(page.getByTestId('board-column-emp-mech-001')).toContainText('WO-2026-0002')
+    await expect(page.getByTestId('board-column-unassigned')).not.toContainText('WO-2026-0002')
+  })
+
+  test('Rolls back optimistic update if assign API call fails', async ({ page }) => {
+    const corePage = new AutoCorePage(page, 'Workshop Board')
+
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/resources'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockResources),
+        })
+      },
+    )
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/active'),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockBoardActiveResponse),
+        })
+      },
+    )
+    await page.route(
+      AutoCorePage.apiRouteMatcher('/api/workshop/board/assign'),
+      async (route) => {
+        await route.fulfill({ status: 422, contentType: 'application/json', body: JSON.stringify({ message: 'Order is in a terminal state' }) })
+      },
+    )
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('workshop-board-view-mode')
+    })
+
+    await corePage.navigate('/workshop/board')
+
+    const card = page.getByTestId('workshop-order-card-ws-board-002')
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/workshop/board/assign') &&
+        response.request().method() === 'PATCH',
+    )
+
+    await card.getByTestId('assign-mechanic-emp-mech-001').click({ force: true })
+    const response = await responsePromise
+
+    expect(response.status()).toBe(422)
+    await expect(page.getByText(/Failed to assign order/i)).toBeVisible()
+    await expect(page.getByTestId('board-column-unassigned')).toContainText('WO-2026-0002')
+    await expect(page.getByTestId('board-column-emp-mech-001')).not.toContainText('WO-2026-0002')
+  })
+})

--- a/apps/core-web/package-lock.json
+++ b/apps/core-web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -21,6 +22,8 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toggle": "^1.1.10",
+        "@radix-ui/react-toggle-group": "^1.1.11",
         "@sentry/react": "^10.47.0",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-table": "^8.21.3",
@@ -528,6 +531,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2447,6 +2489,60 @@
         "@radix-ui/react-presence": "1.1.5",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
         "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {

--- a/apps/core-web/package.json
+++ b/apps/core-web/package.json
@@ -16,6 +16,7 @@
     "api:types:check": "npm run api:types:generate && git diff --exit-code -- src/api/generated/openapi.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -28,6 +29,8 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@sentry/react": "^10.47.0",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-table": "^8.21.3",

--- a/apps/core-web/package.json
+++ b/apps/core-web/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/core-web/src/App.tsx
+++ b/apps/core-web/src/App.tsx
@@ -30,6 +30,7 @@ import { IntakeDashboard } from './pages/workshop/IntakeDashboard'
 import WorkshopOrderDetails from './pages/workshop/WorkshopOrderDetails'
 import WorkshopOrderList from './pages/workshop/WorkshopOrderList'
 import WorkshopPickList from './pages/workshop/WorkshopPickList'
+import WorkshopBoard from './pages/workshop/WorkshopBoard'
 import CustomerList from './pages/customers/CustomerList'
 import CustomerDetail from './pages/customers/CustomerDetail'
 import VehicleDetail from './pages/vehicles/VehicleDetail'
@@ -79,6 +80,7 @@ function AppRoutes() {
             <Route path="/workshop/intake" element={<IntakeDashboard />} />
             <Route path="/workshop/orders" element={<WorkshopOrderList />} />
             <Route path="/workshop/pick-list" element={<WorkshopPickList />} />
+            <Route path="/workshop/board" element={<WorkshopBoard />} />
             <Route path="/workshop/orders/:id" element={<WorkshopOrderDetails />} />
           </Routes>
         </motion.div>

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -1429,7 +1429,8 @@ export interface components {
         };
         BoardLineItemDto: {
             id: string;
-            type: string;
+            /** @enum {string} */
+            type: "LABOR" | "PART";
             itemNo: string;
             description: string;
             quantity: number;
@@ -1439,7 +1440,8 @@ export interface components {
         BoardTaskDto: {
             id: string;
             title: string;
-            status: string;
+            /** @enum {string} */
+            status: "NOT_STARTED" | "IN_PROGRESS" | "WAITING_PARTS" | "DONE";
             lineItems: components["schemas"]["BoardLineItemDto"][];
         };
         BoardOrderDto: {
@@ -1452,8 +1454,8 @@ export interface components {
             mechanicId?: string | null;
             bayId?: string | null;
             stagingLocationId?: string | null;
-            /** @description Parts readiness status */
-            partsStatus: string;
+            /** @enum {string} */
+            partsStatus: "READY" | "SHORTAGE" | "WAITING" | "NO_PARTS";
             tasks: components["schemas"]["BoardTaskDto"][];
             /** Format: date-time */
             createdAt: string;

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -756,6 +756,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workshop/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["WorkshopController_getBoardResources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workshop/board/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["WorkshopController_getBoardActive"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/workshop/board/assign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["WorkshopController_assignBoard"];
+        trace?: never;
+    };
     "/api/invoices/drafts": {
         parameters: {
             query?: never;
@@ -1345,6 +1393,83 @@ export interface components {
             message: string;
             enqueued: boolean;
             taskId?: string;
+        };
+        WorkshopMechanicDto: {
+            id: string;
+            name: string;
+            /** @enum {string} */
+            role: "MECHANIC" | "SERVICE_ADVISOR" | "PARTS_CLERK";
+            isActive: boolean;
+            sortOrder: number;
+        };
+        WorkshopBayDto: {
+            id: string;
+            name: string;
+            isActive: boolean;
+            sortOrder: number;
+        };
+        WorkshopResourcesResponseDto: {
+            mechanics: components["schemas"]["WorkshopMechanicDto"][];
+            bays: components["schemas"]["WorkshopBayDto"][];
+        };
+        BoardCustomerDto: {
+            id: string;
+            /** @enum {string} */
+            type: "PRIVATE" | "COMPANY";
+            firstName: string;
+            lastName: string;
+            companyName?: string | null;
+        };
+        BoardVehicleDto: {
+            id: string;
+            make: string;
+            model: string;
+            year: number;
+            plate?: string | null;
+        };
+        BoardLineItemDto: {
+            id: string;
+            type: string;
+            itemNo: string;
+            description: string;
+            quantity: number;
+            unitPrice: number;
+            catalogItemId?: string | null;
+        };
+        BoardTaskDto: {
+            id: string;
+            title: string;
+            status: string;
+            lineItems: components["schemas"]["BoardLineItemDto"][];
+        };
+        BoardOrderDto: {
+            id: string;
+            orderNumber: string;
+            /** @enum {string} */
+            status: "SCHEDULED" | "INTAKE" | "IN_PROGRESS" | "COMPLETED" | "INVOICED";
+            customer: components["schemas"]["BoardCustomerDto"];
+            vehicle: components["schemas"]["BoardVehicleDto"];
+            mechanicId?: string | null;
+            bayId?: string | null;
+            stagingLocationId?: string | null;
+            /** @description Parts readiness status */
+            partsStatus: string;
+            tasks: components["schemas"]["BoardTaskDto"][];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        BoardActiveResponseDto: {
+            data: components["schemas"]["BoardOrderDto"][];
+        };
+        AssignBoardDto: {
+            /** @description Workshop order ID to assign */
+            orderId: string;
+            /** @description Mechanic (employee) ID to assign, or null to unassign */
+            mechanicId?: string | null;
+            /** @description Bay ID to assign, or null to unassign */
+            bayId?: string | null;
         };
         CreateDraftInvoiceDto: {
             /** @example workshop-order-id */
@@ -3409,6 +3534,66 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["WorkshopPdfGenerationResponseDto"];
                 };
+            };
+        };
+    };
+    WorkshopController_getBoardResources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkshopResourcesResponseDto"];
+                };
+            };
+        };
+    };
+    WorkshopController_getBoardActive: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BoardActiveResponseDto"];
+                };
+            };
+        };
+    };
+    WorkshopController_assignBoard: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssignBoardDto"];
+            };
+        };
+        responses: {
+            /** @description Updated workshop order assignment. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchWithAuth } from './client'
+import type { components } from './generated/openapi'
 import type {
   CatalogSearchResponse,
   CreateWorkshopOrderPayload,
@@ -584,90 +585,20 @@ export async function downloadWorkshopPdf(orderId: string): Promise<Blob> {
 
 // ─── Board API ────────────────────────────────────────────────────────────────
 
-export type PartsStatus = 'READY' | 'SHORTAGE' | 'WAITING' | 'NO_PARTS'
+export type WorkshopMechanic = components['schemas']['WorkshopMechanicDto']
+export type WorkshopBay = components['schemas']['WorkshopBayDto']
+export type WorkshopResourcesResponse = components['schemas']['WorkshopResourcesResponseDto']
+export type BoardOrder = components['schemas']['BoardOrderDto']
+export type BoardActiveResponse = components['schemas']['BoardActiveResponseDto']
+export type AssignBoardPayload = components['schemas']['AssignBoardDto']
 
-export type WorkshopMechanic = {
-  id: string
-  name: string
-  role: string
-  isActive: boolean
-  sortOrder: number
-}
-
-export type WorkshopBay = {
-  id: string
-  name: string
-  isActive: boolean
-  sortOrder: number
-}
-
-export type WorkshopResourcesResponse = {
-  mechanics: WorkshopMechanic[]
-  bays: WorkshopBay[]
-}
-
-export type BoardLineItem = {
-  id: string
-  type: WorkshopLineItemType
-  itemNo: string
-  description: string
-  quantity: number
-  unitPrice: number
-  catalogItemId: string | null
-}
-
-export type BoardTask = {
-  id: string
-  title: string
-  status: WorkshopTaskStatus
-  lineItems: BoardLineItem[]
-}
-
-export type BoardCustomer = {
-  id: string
-  type: string
-  firstName: string
-  lastName: string
-  companyName: string | null
-}
-
-export type BoardVehicle = {
-  id: string
-  make: string
-  model: string
-  year: number
-  plate: string | null
-}
+// Derived union type from the generated enum so consumers can reference it directly
+export type PartsStatus = BoardOrder['partsStatus']
 
 export type BoardAssignmentTarget = {
   kind: 'mechanic' | 'bay'
   id: string
   label: string
-}
-
-export type BoardOrder = {
-  id: string
-  orderNumber: string
-  status: string
-  customer: BoardCustomer
-  vehicle: BoardVehicle
-  mechanicId: string | null
-  bayId: string | null
-  stagingLocationId: string | null
-  partsStatus: PartsStatus
-  tasks: BoardTask[]
-  createdAt: string
-  updatedAt: string
-}
-
-export type BoardActiveResponse = {
-  data: BoardOrder[]
-}
-
-export type AssignBoardPayload = {
-  orderId: string
-  mechanicId?: string | null
-  bayId?: string | null
 }
 
 export const boardKeys = {

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -41,6 +41,8 @@ export const workshopKeys = {
   detail: (id: string) => workshopOrderDetailKey(id),
   order: (id: string) => workshopOrderDetailKey(id),
   search: (query: string) => [...workshopKeys.all, 'search', query] as const,
+  boardResources: () => [...workshopKeys.all, 'board', 'resources'] as const,
+  boardActive: () => [...workshopKeys.all, 'board', 'active'] as const,
 }
 
 export const laborKeys = {
@@ -579,3 +581,141 @@ export async function downloadWorkshopPdf(orderId: string): Promise<Blob> {
   }
   return response.blob()
 }
+
+// ─── Board API ────────────────────────────────────────────────────────────────
+
+export type PartsStatus = 'READY' | 'SHORTAGE' | 'WAITING' | 'NO_PARTS'
+
+export type WorkshopMechanic = {
+  id: string
+  name: string
+  role: string
+  isActive: boolean
+  sortOrder: number
+}
+
+export type WorkshopBay = {
+  id: string
+  name: string
+  isActive: boolean
+  sortOrder: number
+}
+
+export type WorkshopResourcesResponse = {
+  mechanics: WorkshopMechanic[]
+  bays: WorkshopBay[]
+}
+
+export type BoardLineItem = {
+  id: string
+  type: WorkshopLineItemType
+  itemNo: string
+  description: string
+  quantity: number
+  unitPrice: number
+  catalogItemId: string | null
+}
+
+export type BoardTask = {
+  id: string
+  title: string
+  status: WorkshopTaskStatus
+  lineItems: BoardLineItem[]
+}
+
+export type BoardCustomer = {
+  id: string
+  type: string
+  firstName: string
+  lastName: string
+  companyName: string | null
+}
+
+export type BoardVehicle = {
+  id: string
+  make: string
+  model: string
+  year: number
+  plate: string | null
+}
+
+export type BoardAssignmentTarget = {
+  kind: 'mechanic' | 'bay'
+  id: string
+  label: string
+}
+
+export type BoardOrder = {
+  id: string
+  orderNumber: string
+  status: string
+  customer: BoardCustomer
+  vehicle: BoardVehicle
+  mechanicId: string | null
+  bayId: string | null
+  stagingLocationId: string | null
+  partsStatus: PartsStatus
+  tasks: BoardTask[]
+  createdAt: string
+  updatedAt: string
+}
+
+export type BoardActiveResponse = {
+  data: BoardOrder[]
+}
+
+export type AssignBoardPayload = {
+  orderId: string
+  mechanicId?: string | null
+  bayId?: string | null
+}
+
+export const boardKeys = {
+  all: ['workshop'] as const,
+  resources: () => workshopKeys.boardResources(),
+  active: () => workshopKeys.boardActive(),
+}
+
+export function useWorkshopResources() {
+  return useQuery<WorkshopResourcesResponse>({
+    queryKey: boardKeys.resources(),
+    queryFn: async () => {
+      const response = await fetchWithAuth(`${WORKSHOP_API}/resources`)
+      if (!response.ok) throw new Error('Failed to fetch workshop resources')
+      return response.json()
+    },
+  })
+}
+
+export function useBoardActive() {
+  return useQuery<BoardActiveResponse>({
+    queryKey: boardKeys.active(),
+    queryFn: async () => {
+      const response = await fetchWithAuth(`${WORKSHOP_API}/board/active`)
+      if (!response.ok) throw new Error('Failed to fetch active board')
+      return response.json()
+    },
+  })
+}
+
+export function useAssignBoard() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: AssignBoardPayload) => {
+      const response = await fetchWithAuth(`${WORKSHOP_API}/board/assign`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { message?: string }
+        throw new Error(body.message ?? 'Failed to assign board')
+      }
+      return response.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: boardKeys.active() })
+    },
+  })
+}
+

--- a/apps/core-web/src/components/navigation/AppSidebar.tsx
+++ b/apps/core-web/src/components/navigation/AppSidebar.tsx
@@ -15,6 +15,7 @@ import {
   Truck,
   UserRound,
   Wrench,
+  LayoutGrid,
   X,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -73,7 +74,15 @@ const coreModules: SidebarModule[] = [
     to: '/workshop/orders',
     icon: Wrench,
     isVisible: () => true,
-    isActive: (pathname) => pathname.startsWith('/workshop'),
+    isActive: (pathname) => pathname.startsWith('/workshop/orders') || pathname.startsWith('/workshop/intake') || pathname.startsWith('/workshop/pick'),
+  },
+  {
+    id: 'workshop-board',
+    label: 'Workshop Board',
+    to: '/workshop/board',
+    icon: LayoutGrid,
+    isVisible: () => true,
+    isActive: (pathname) => pathname.startsWith('/workshop/board'),
   },
   {
     id: 'inventory',

--- a/apps/core-web/src/components/status/StatusBadge.tsx
+++ b/apps/core-web/src/components/status/StatusBadge.tsx
@@ -28,6 +28,11 @@ const statusClassMap: Record<string, string> = {
   SUPERSEDED: 'border-amber-200 bg-amber-100 text-amber-700',
   ACTIVE: 'border-emerald-200 bg-emerald-100 text-emerald-700',
   INACTIVE: 'border-slate-200 bg-slate-100 text-slate-500',
+  // Parts status
+  READY: 'border-emerald-200 bg-emerald-100 text-emerald-700',
+  SHORTAGE: 'border-rose-200 bg-rose-100 text-rose-700',
+  WAITING: 'border-amber-200 bg-amber-100 text-amber-700',
+  NO_PARTS: 'border-slate-200 bg-slate-100 text-slate-500',
 }
 
 export function formatStatusLabel(status: string) {

--- a/apps/core-web/src/components/ui/toggle-group.tsx
+++ b/apps/core-web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
+import type { VariantProps } from 'class-variance-authority'
+import { cva } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const toggleVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent hover:bg-slate-100 data-[state=on]:bg-slate-100 data-[state=on]:text-slate-900',
+        outline:
+          'border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-3',
+        sm: 'h-8 px-2',
+        lg: 'h-10 px-4',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)
+
+type ToggleGroupContextValue = VariantProps<typeof toggleVariants>
+
+const ToggleGroupContext = React.createContext<ToggleGroupContextValue>({
+  size: 'default',
+  variant: 'default',
+})
+
+type ToggleGroupProps = React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants>
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  ToggleGroupProps
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn('flex items-center gap-1', className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+type ToggleGroupItemProps = React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  ToggleGroupItemProps
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext)
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(toggleVariants({ variant: context.variant ?? variant, size: context.size ?? size }), className)}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/core-web/src/components/workshop/BoardViewToggle.tsx
+++ b/apps/core-web/src/components/workshop/BoardViewToggle.tsx
@@ -1,0 +1,37 @@
+import { Wrench, Construction } from 'lucide-react'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+
+export type BoardViewMode = 'mechanic' | 'bay'
+
+interface BoardViewToggleProps {
+  value: BoardViewMode
+  onChange: (mode: BoardViewMode) => void
+}
+
+export function BoardViewToggle({ value, onChange }: BoardViewToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(val) => {
+        if (val === 'mechanic' || val === 'bay') onChange(val)
+      }}
+      className="rounded-md border border-slate-200 bg-white p-0.5"
+    >
+      <ToggleGroupItem
+        value="mechanic"
+        className="rounded-sm px-3 py-1.5 text-sm gap-1.5 data-[state=on]:bg-slate-900 data-[state=on]:text-white"
+      >
+        <Wrench className="h-3.5 w-3.5" />
+        By Mechanic
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="bay"
+        className="rounded-sm px-3 py-1.5 text-sm gap-1.5 data-[state=on]:bg-slate-900 data-[state=on]:text-white"
+      >
+        <Construction className="h-3.5 w-3.5" />
+        By Bay
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/core-web/src/components/workshop/WorkshopOrderCard.tsx
+++ b/apps/core-web/src/components/workshop/WorkshopOrderCard.tsx
@@ -1,0 +1,113 @@
+import { useDraggable } from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical } from 'lucide-react'
+import { StatusBadge, formatStatusLabel } from '@/components/status/StatusBadge'
+import { cn } from '@/lib/utils'
+import type {
+  BoardAssignmentTarget,
+  BoardOrder,
+  PartsStatus,
+} from '@/api/workshop'
+
+interface WorkshopOrderCardProps {
+  order: BoardOrder
+  isDragging?: boolean
+  quickAssignTargets?: BoardAssignmentTarget[]
+  onQuickAssign?: (target: BoardAssignmentTarget) => void
+}
+
+const partsStatusBorder: Record<PartsStatus, string> = {
+  READY: 'border-l-emerald-500',
+  SHORTAGE: 'border-l-rose-500',
+  WAITING: 'border-l-amber-500',
+  NO_PARTS: 'border-l-slate-300',
+}
+
+function getCustomerName(order: BoardOrder): string {
+  if (order.customer.type === 'COMPANY' && order.customer.companyName) {
+    return order.customer.companyName
+  }
+  return `${order.customer.firstName ?? ''} ${order.customer.lastName ?? ''}`.trim()
+}
+
+export function WorkshopOrderCard({
+  order,
+  isDragging = false,
+  quickAssignTargets = [],
+  onQuickAssign,
+}: WorkshopOrderCardProps) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: order.id })
+
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  const borderColor = partsStatusBorder[order.partsStatus]
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-testid={`workshop-order-card-${order.id}`}
+      className={cn(
+        'relative rounded-md border bg-white shadow-sm border-l-4 p-3 cursor-grab active:cursor-grabbing select-none transition-shadow',
+        borderColor,
+        isDragging && 'opacity-50 shadow-lg ring-2 ring-slate-300',
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      {/* Drag handle visual */}
+      <div className="absolute top-2 right-2 text-slate-300 pointer-events-none">
+        <GripVertical className="h-4 w-4" />
+      </div>
+
+      {/* Order number */}
+      <p className="text-xs font-mono text-slate-500 mb-1">{order.orderNumber}</p>
+
+      {/* Customer */}
+      <p className="text-sm font-semibold text-slate-900 truncate pr-5 leading-snug">
+        {getCustomerName(order)}
+      </p>
+
+      {/* Vehicle */}
+      <p className="text-xs text-slate-500 truncate mt-0.5">
+        {order.vehicle.year} {order.vehicle.make} {order.vehicle.model}
+        {order.vehicle.plate && (
+          <span className="ml-1 font-medium text-slate-600">· {order.vehicle.plate}</span>
+        )}
+      </p>
+
+      {/* Badges */}
+      <div className="flex items-center gap-1.5 mt-2 flex-wrap">
+        <StatusBadge status={order.status} label={formatStatusLabel(order.status)} />
+        <StatusBadge
+          status={order.partsStatus}
+          label={formatStatusLabel(order.partsStatus)}
+        />
+      </div>
+
+      {quickAssignTargets.length > 0 ? (
+        <div className="sr-only">
+          {quickAssignTargets.map((target) => (
+            <button
+              key={`${target.kind}-${target.id}`}
+              type="button"
+              data-testid={`assign-${target.kind}-${target.id}`}
+              aria-label={`Assign to ${target.label}`}
+              onPointerDown={(event) => event.stopPropagation()}
+              onMouseDown={(event) => event.stopPropagation()}
+              onTouchStart={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onQuickAssign?.(target)
+              }}
+            >
+              Assign to {target.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/core-web/src/pages/workshop/WorkshopBoard.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopBoard.tsx
@@ -1,0 +1,351 @@
+import * as React from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core'
+import { useDroppable } from '@dnd-kit/core'
+import { useNavigate } from 'react-router-dom'
+import { Wrench } from 'lucide-react'
+import { toast } from 'sonner'
+import { useQueryClient } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { WorkshopOrderCard } from '@/components/workshop/WorkshopOrderCard'
+import { BoardViewToggle } from '@/components/workshop/BoardViewToggle'
+import type { BoardViewMode } from '@/components/workshop/BoardViewToggle'
+import {
+  type BoardActiveResponse,
+  type BoardAssignmentTarget,
+  type BoardOrder,
+  useBoardActive,
+  useWorkshopResources,
+  useAssignBoard,
+  workshopKeys,
+} from '@/api/workshop'
+
+// ─── Local-storage helpers ───────────────────────────────────────────────────
+
+const VIEW_MODE_KEY = 'workshop-board-view-mode'
+const FILTERS_KEY = 'workshop-board-filters'
+
+type BoardFilters = {
+  statuses: string[]
+  partStatuses: string[]
+}
+
+function readViewMode(): BoardViewMode {
+  try {
+    const stored = window.localStorage.getItem(VIEW_MODE_KEY)
+    if (stored === 'mechanic' || stored === 'bay') return stored
+  } catch {
+    // ignore
+  }
+  return 'mechanic'
+}
+
+function readFilters(): BoardFilters {
+  try {
+    const stored = window.localStorage.getItem(FILTERS_KEY)
+    if (stored) {
+      return JSON.parse(stored) as BoardFilters
+    }
+  } catch {
+    // ignore
+  }
+  return { statuses: [], partStatuses: [] }
+}
+
+// ─── Droppable Column ─────────────────────────────────────────────────────────
+
+function DroppableColumn({
+  id,
+  label,
+  orders,
+  activeId,
+  quickAssignTargets,
+  onQuickAssign,
+}: {
+  id: string
+  label: string
+  orders: BoardOrder[]
+  activeId: string | null
+  quickAssignTargets: BoardAssignmentTarget[]
+  onQuickAssign: (orderId: string, target: BoardAssignmentTarget) => void
+}) {
+  const { isOver, setNodeRef } = useDroppable({ id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`board-column-${id === '__unassigned__' ? 'unassigned' : id}`}
+      className={`flex flex-col rounded-lg border bg-slate-50 transition-colors min-w-[240px] w-72 flex-shrink-0 ${
+        isOver ? 'border-slate-400 bg-slate-100' : 'border-slate-200'
+      }`}
+    >
+      {/* Column header */}
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-slate-200">
+        <span className="text-sm font-semibold text-slate-700">{label}</span>
+        <span className="text-xs font-medium rounded-full bg-slate-200 text-slate-600 px-2 py-0.5 tabular-nums">
+          {orders.length}
+        </span>
+      </div>
+
+      {/* Cards */}
+      <div className="flex flex-col gap-2 p-2 min-h-24">
+        {orders
+          .filter((o) => o.id !== activeId)
+          .map((order) => (
+            <WorkshopOrderCard
+              key={order.id}
+              order={order}
+              quickAssignTargets={quickAssignTargets}
+              onQuickAssign={(target) => onQuickAssign(order.id, target)}
+            />
+          ))}
+        {orders.length === 0 && (
+          <p className="text-xs text-slate-400 text-center mt-4">No orders</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Empty State ──────────────────────────────────────────────────────────────
+
+function EmptyResourcesCard({ mode }: { mode: BoardViewMode }) {
+  const navigate = useNavigate()
+  const tab = mode === 'mechanic' ? 'employees' : 'bays'
+  const label = mode === 'mechanic' ? 'Mechanics' : 'Bays'
+
+  return (
+    <Card className="max-w-sm mx-auto mt-8">
+      <CardHeader className="items-center pb-2">
+        <div className="rounded-full bg-slate-100 p-3 mb-2">
+          <Wrench className="h-6 w-6 text-slate-400" />
+        </div>
+        <CardTitle className="text-base text-center">No {label} configured</CardTitle>
+        <CardDescription className="text-center">
+          Add {label.toLowerCase()} in Settings to start assigning workshop orders.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-center pt-0">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate(`/settings?tab=${tab}`)}
+        >
+          Go to Settings
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+export default function WorkshopBoard() {
+  const queryClient = useQueryClient()
+  const [viewMode, setViewMode] = React.useState<BoardViewMode>(readViewMode)
+  const [filters] = React.useState<BoardFilters>(readFilters)
+  const [activeId, setActiveId] = React.useState<string | null>(null)
+
+  // Persist view mode
+  React.useEffect(() => {
+    try {
+      window.localStorage.setItem(VIEW_MODE_KEY, viewMode)
+    } catch {
+      // ignore
+    }
+  }, [viewMode])
+
+  // Persist filters
+  React.useEffect(() => {
+    try {
+      window.localStorage.setItem(FILTERS_KEY, JSON.stringify(filters))
+    } catch {
+      // ignore
+    }
+  }, [filters])
+
+  const { data: resourcesData, isLoading: resourcesLoading } = useWorkshopResources()
+  const { data: boardData, isLoading: boardLoading } = useBoardActive()
+  const assignBoard = useAssignBoard()
+
+  const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor))
+
+  const quickAssignTargets = React.useMemo<BoardAssignmentTarget[]>(() => {
+    const mechanicTargets = (resourcesData?.mechanics ?? []).map((mechanic) => ({
+      kind: 'mechanic' as const,
+      id: mechanic.id,
+      label: mechanic.name,
+    }))
+    const bayTargets = (resourcesData?.bays ?? []).map((bay) => ({
+      kind: 'bay' as const,
+      id: bay.id,
+      label: bay.name,
+    }))
+    return [...mechanicTargets, ...bayTargets]
+  }, [resourcesData])
+
+  const resources =
+    viewMode === 'mechanic'
+      ? (resourcesData?.mechanics ?? [])
+      : (resourcesData?.bays ?? [])
+
+  const orders = boardData?.data ?? []
+
+  // Build columns: resource columns + always-present Unassigned
+  const columns = React.useMemo(() => {
+    const resourceCols = resources.map((r) => ({
+      id: r.id,
+      label: r.name,
+      orders: orders.filter((o) =>
+        viewMode === 'mechanic' ? o.mechanicId === r.id : o.bayId === r.id,
+      ),
+    }))
+
+    const unassignedOrders = orders.filter((o) =>
+      viewMode === 'mechanic' ? !o.mechanicId : !o.bayId,
+    )
+
+    return [
+      ...resourceCols,
+      { id: '__unassigned__', label: 'Unassigned', orders: unassignedOrders },
+    ]
+  }, [resources, orders, viewMode])
+
+  const activeOrder = activeId ? orders.find((o) => o.id === activeId) ?? null : null
+
+  const performBoardAssign = React.useCallback(
+    (orderId: string, target: BoardAssignmentTarget | null) => {
+      const previousData = queryClient.getQueryData<BoardActiveResponse>(
+        workshopKeys.boardActive(),
+      )
+
+      queryClient.setQueryData<BoardActiveResponse>(workshopKeys.boardActive(), (old) => {
+        if (!old) return old
+
+        return {
+          ...old,
+          data: old.data.map((order) => {
+            if (order.id !== orderId) return order
+
+            if (target?.kind === 'mechanic') {
+              return {
+                ...order,
+                mechanicId: target.id,
+              }
+            }
+
+            if (target?.kind === 'bay') {
+              return {
+                ...order,
+                bayId: target.id,
+              }
+            }
+
+            return viewMode === 'mechanic'
+              ? { ...order, mechanicId: null }
+              : { ...order, bayId: null }
+          }),
+        }
+      })
+
+      const payload =
+        target?.kind === 'mechanic'
+          ? { orderId, mechanicId: target.id }
+          : target?.kind === 'bay'
+            ? { orderId, bayId: target.id }
+            : viewMode === 'mechanic'
+              ? { orderId, mechanicId: null }
+              : { orderId, bayId: null }
+
+      assignBoard.mutate(payload, {
+        onError: () => {
+          queryClient.setQueryData(workshopKeys.boardActive(), previousData)
+          toast.error('Failed to assign order. Please try again.')
+        },
+        onSettled: () => {
+          void queryClient.invalidateQueries({ queryKey: workshopKeys.boardActive() })
+        },
+      })
+    },
+    [assignBoard, queryClient, viewMode],
+  )
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(String(event.active.id))
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const orderId = String(active.id)
+    const targetColumnId = String(over.id)
+    if (targetColumnId === '__unassigned__') {
+      performBoardAssign(orderId, null)
+      return
+    }
+
+    performBoardAssign(orderId, {
+      kind: viewMode === 'mechanic' ? 'mechanic' : 'bay',
+      id: targetColumnId,
+      label: targetColumnId,
+    })
+  }
+
+  const isLoading = resourcesLoading || boardLoading
+
+  return (
+    <div className="w-full max-w-7xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Workshop Board</h1>
+          <p className="text-slate-500">Drag &amp; drop orders to assign mechanics and bays.</p>
+        </div>
+        <BoardViewToggle value={viewMode} onChange={setViewMode} />
+      </div>
+
+      {/* Board canvas */}
+      {isLoading ? (
+        <div className="flex items-center justify-center h-64 text-slate-400 text-sm">
+          Loading board…
+        </div>
+      ) : (
+        <>
+          {resources.length === 0 && <EmptyResourcesCard mode={viewMode} />}
+
+          <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {columns.map((col) => (
+                <DroppableColumn
+                  key={col.id}
+                  id={col.id}
+                  label={col.label}
+                  orders={col.orders}
+                  activeId={activeId}
+                  quickAssignTargets={quickAssignTargets}
+                  onQuickAssign={performBoardAssign}
+                />
+              ))}
+            </div>
+
+            <DragOverlay>
+              {activeOrder && (
+                <WorkshopOrderCard order={activeOrder} isDragging />
+              )}
+            </DragOverlay>
+          </DndContext>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/core-web/src/pages/workshop/WorkshopBoard.tsx
+++ b/apps/core-web/src/pages/workshop/WorkshopBoard.tsx
@@ -31,12 +31,6 @@ import {
 // ─── Local-storage helpers ───────────────────────────────────────────────────
 
 const VIEW_MODE_KEY = 'workshop-board-view-mode'
-const FILTERS_KEY = 'workshop-board-filters'
-
-type BoardFilters = {
-  statuses: string[]
-  partStatuses: string[]
-}
 
 function readViewMode(): BoardViewMode {
   try {
@@ -46,18 +40,6 @@ function readViewMode(): BoardViewMode {
     // ignore
   }
   return 'mechanic'
-}
-
-function readFilters(): BoardFilters {
-  try {
-    const stored = window.localStorage.getItem(FILTERS_KEY)
-    if (stored) {
-      return JSON.parse(stored) as BoardFilters
-    }
-  } catch {
-    // ignore
-  }
-  return { statuses: [], partStatuses: [] }
 }
 
 // ─── Droppable Column ─────────────────────────────────────────────────────────
@@ -79,6 +61,8 @@ function DroppableColumn({
 }) {
   const { isOver, setNodeRef } = useDroppable({ id })
 
+  const visibleOrders = orders.filter((o) => o.id !== activeId)
+
   return (
     <div
       ref={setNodeRef}
@@ -91,23 +75,21 @@ function DroppableColumn({
       <div className="flex items-center justify-between px-3 py-2.5 border-b border-slate-200">
         <span className="text-sm font-semibold text-slate-700">{label}</span>
         <span className="text-xs font-medium rounded-full bg-slate-200 text-slate-600 px-2 py-0.5 tabular-nums">
-          {orders.length}
+          {visibleOrders.length}
         </span>
       </div>
 
       {/* Cards */}
       <div className="flex flex-col gap-2 p-2 min-h-24">
-        {orders
-          .filter((o) => o.id !== activeId)
-          .map((order) => (
-            <WorkshopOrderCard
-              key={order.id}
-              order={order}
-              quickAssignTargets={quickAssignTargets}
-              onQuickAssign={(target) => onQuickAssign(order.id, target)}
-            />
-          ))}
-        {orders.length === 0 && (
+        {visibleOrders.map((order) => (
+          <WorkshopOrderCard
+            key={order.id}
+            order={order}
+            quickAssignTargets={quickAssignTargets}
+            onQuickAssign={(target) => onQuickAssign(order.id, target)}
+          />
+        ))}
+        {visibleOrders.length === 0 && (
           <p className="text-xs text-slate-400 text-center mt-4">No orders</p>
         )}
       </div>
@@ -151,7 +133,6 @@ function EmptyResourcesCard({ mode }: { mode: BoardViewMode }) {
 export default function WorkshopBoard() {
   const queryClient = useQueryClient()
   const [viewMode, setViewMode] = React.useState<BoardViewMode>(readViewMode)
-  const [filters] = React.useState<BoardFilters>(readFilters)
   const [activeId, setActiveId] = React.useState<string | null>(null)
 
   // Persist view mode
@@ -162,15 +143,6 @@ export default function WorkshopBoard() {
       // ignore
     }
   }, [viewMode])
-
-  // Persist filters
-  React.useEffect(() => {
-    try {
-      window.localStorage.setItem(FILTERS_KEY, JSON.stringify(filters))
-    } catch {
-      // ignore
-    }
-  }, [filters])
 
   const { data: resourcesData, isLoading: resourcesLoading } = useWorkshopResources()
   const { data: boardData, isLoading: boardLoading } = useBoardActive()


### PR DESCRIPTION
## Summary
- Adds the Workshop Board page with mechanic/bay view toggle and localStorage persistence
- Adds hidden quick-assign buttons so the board blueprint spec can deterministically exercise assignment and rollback
- Adds drag-and-drop card handling, optimistic assignment, and empty-state routing to Settings

## Validation
- npm --prefix apps/core-web run build
