### PR TITLE
Amend multi-tenancy ADR for hybrid auth

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -6,10 +6,10 @@ trigger: always_on
 You are operating under the `obra/superpowers` methodology. Before generating any code, creating plans, or executing terminal commands, you MUST read the relevant skill from the `.agents/superpowers/skills/` directory.
 
 ### Mandatory Workflows:
-1. **Planning:** Before writing code or modifying architecture, read `.agents/superpowers/skills/writing-plans/SKILL.md` and create a checklist. Do not proceed until the user approves the plan.
-2. **Test-Driven Development (TDD):** When writing code, you MUST follow the Red-Green-Refactor cycle defined in `.agents/superpowers/skills/test-driven-development/SKILL.md`.
-3. **Debugging:** If a test fails or a build error occurs, do not guess. Read `.agents/superpowers/skills/systematic-debugging/SKILL.md` and execute the formal root cause analysis.
-4. **Brainstorming:** If a user request is vague or open-ended, read `.agents/superpowers/skills/brainstorming/SKILL.md` first.
+1. **Planning:** Before writing code or modifying architecture, read `agents\skills\superpowerswriting-plans/SKILL.md` and create a checklist. Do not proceed until the user approves the plan.
+2. **Test-Driven Development (TDD):** When writing code, you MUST follow the Red-Green-Refactor cycle defined in `agents\skills\superpowerstest-driven-development/SKILL.md`.
+3. **Debugging:** If a test fails or a build error occurs, do not guess. Read `agents\skills\superpowerssystematic-debugging/SKILL.md` and execute the formal root cause analysis.
+4. **Brainstorming:** If a user request is vague or open-ended, read `agents\skills\superpowersbrainstorming/SKILL.md` first.
 
 Do not bypass these rules under any circumstances.
 

--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -3810,6 +3810,265 @@
           "bays"
         ]
       }
+    },
+    "/api/platform/tenants": {
+      "get": {
+        "operationId": "PlatformAdminController_findAll",
+        "parameters": [
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Search by tenant name or slug",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeInactive",
+            "required": false,
+            "in": "query",
+            "description": "Include inactive tenants when true",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformTenantListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "platform-tenants"
+        ]
+      },
+      "post": {
+        "operationId": "PlatformAdminController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePlatformTenantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformTenantResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "platform-tenants"
+        ]
+      }
+    },
+    "/api/platform/tenants/{id}": {
+      "patch": {
+        "operationId": "PlatformAdminController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePlatformTenantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformTenantResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "platform-tenants"
+        ]
+      }
+    },
+    "/api/tenant-members": {
+      "get": {
+        "operationId": "TenantMemberController_findAll",
+        "parameters": [
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Search by email or user name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeInactive",
+            "required": false,
+            "in": "query",
+            "description": "Include inactive memberships when true",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number (1-based)",
+            "schema": {
+              "minimum": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantMembersListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "tenant-members"
+        ]
+      }
+    },
+    "/api/tenant-members/invite": {
+      "post": {
+        "operationId": "TenantMemberController_invite",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteTenantMemberDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantMemberResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "tenant-members"
+        ]
+      }
+    },
+    "/api/tenant-members/{id}": {
+      "patch": {
+        "operationId": "TenantMemberController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantMemberDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantMemberResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "tenant-members"
+        ]
+      }
     }
   },
   "info": {
@@ -6211,6 +6470,284 @@
         "required": [
           "id"
         ]
+      },
+      "TenantPlan": {
+        "type": "string",
+        "enum": [
+          "STANDARD",
+          "PREMIUM",
+          "ENTERPRISE"
+        ]
+      },
+      "PlatformTenantResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "plan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantPlan"
+              }
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "memberCount": {
+            "type": "number"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "plan",
+          "isActive",
+          "memberCount",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PlatformTenantListMetaDto": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "page": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "totalPages": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
+      "PlatformTenantListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlatformTenantResponseDto"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PlatformTenantListMetaDto"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "CreatePlatformTenantDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string",
+            "description": "Lowercase slug used for tenant routing and lookup"
+          },
+          "plan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantPlan"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "plan"
+        ]
+      },
+      "UpdatePlatformTenantDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "plan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantPlan"
+              }
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          }
+        }
+      },
+      "TenantMemberRole": {
+        "type": "string",
+        "enum": [
+          "OWNER",
+          "ADMIN",
+          "TECH",
+          "SALES"
+        ]
+      },
+      "TenantMemberResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "object"
+          },
+          "lastName": {
+            "type": "object"
+          },
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantMemberRole"
+              }
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "tenantId",
+          "userId",
+          "email",
+          "role",
+          "isActive",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "TenantMembersListMetaDto": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "page": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "totalPages": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "limit",
+          "totalPages"
+        ]
+      },
+      "TenantMembersListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TenantMemberResponseDto"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/TenantMembersListMetaDto"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "InviteTenantMemberDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantMemberRole"
+              }
+            ]
+          }
+        },
+        "required": [
+          "email",
+          "role"
+        ]
+      },
+      "UpdateTenantMemberDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TenantMemberRole"
+              }
+            ]
+          },
+          "isActive": {
+            "type": "boolean"
+          }
+        }
       }
     }
   },

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -25,6 +25,7 @@
     "openapi:generate": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
     "openapi:check": "npm run openapi:generate && git diff --exit-code -- openapi/openapi.json",
     "gcs:lifecycle": "ts-node -r tsconfig-paths/register scripts/apply-gcs-lifecycle.ts",
+    "db:seed:platform-admin": "ts-node -r tsconfig-paths/register scripts/seed-platform-admin.ts",
     "secrets:pull": "node ../../tools/pull-secrets-from-gsm.mjs --mapping ../../secrets/gsm-mapping.json --target core-api"
   },
   "prisma": {

--- a/apps/core-api/prisma/migrations/20260423145000_hybrid_auth_membership_foundation/migration.sql
+++ b/apps/core-api/prisma/migrations/20260423145000_hybrid_auth_membership_foundation/migration.sql
@@ -1,0 +1,77 @@
+-- CreateEnum
+CREATE TYPE "TenantMemberRole" AS ENUM ('OWNER', 'ADMIN', 'TECH', 'SALES');
+
+-- CreateEnum
+CREATE TYPE "PlatformAdminRole" AS ENUM ('SUPER_ADMIN');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "firebase_uid" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "first_name" TEXT,
+    "last_name" TEXT,
+    "active_tenant_id" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tenant_members" (
+    "id" TEXT NOT NULL,
+    "tenant_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "role" "TenantMemberRole" NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tenant_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "platform_admins" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "role" "PlatformAdminRole" NOT NULL DEFAULT 'SUPER_ADMIN',
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "platform_admins_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_firebase_uid_key" ON "users"("firebase_uid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE INDEX "users_active_tenant_id_idx" ON "users"("active_tenant_id");
+
+-- CreateIndex
+CREATE INDEX "tenant_members_tenant_id_idx" ON "tenant_members"("tenant_id");
+
+-- CreateIndex
+CREATE INDEX "tenant_members_user_id_idx" ON "tenant_members"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tenant_members_tenant_id_user_id_key" ON "tenant_members"("tenant_id", "user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "platform_admins_user_id_key" ON "platform_admins"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_active_tenant_id_fkey" FOREIGN KEY ("active_tenant_id") REFERENCES "tenants"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tenant_members" ADD CONSTRAINT "tenant_members_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tenant_members" ADD CONSTRAINT "tenant_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "platform_admins" ADD CONSTRAINT "platform_admins_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -20,6 +20,17 @@ enum TenantPlan {
   ENTERPRISE
 }
 
+enum TenantMemberRole {
+  OWNER
+  ADMIN
+  TECH
+  SALES
+}
+
+enum PlatformAdminRole {
+  SUPER_ADMIN
+}
+
 model Tenant {
   id         String     @id @default(uuid())
   name       String
@@ -55,8 +66,56 @@ model Tenant {
   bays                 Bay[]
   laborCategories      LaborCategory[]
   laborOperations      LaborOperation[]
+  memberships          TenantMember[]
+  activeUsers          User[]         @relation("UserActiveTenant")
 
   @@map("tenants")
+}
+
+model User {
+  id               String         @id @default(uuid())
+  firebaseUid      String         @unique @map("firebase_uid")
+  email            String         @unique
+  firstName        String?        @map("first_name")
+  lastName         String?        @map("last_name")
+  active_tenant_id String?
+  activeTenant     Tenant?        @relation("UserActiveTenant", fields: [active_tenant_id], references: [id])
+  memberships      TenantMember[]
+  platformAdmin    PlatformAdmin?
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+
+  @@index([active_tenant_id])
+  @@map("users")
+}
+
+model TenantMember {
+  id        String           @id @default(uuid())
+  tenant_id String
+  tenant    Tenant           @relation(fields: [tenant_id], references: [id])
+  user_id   String
+  user      User             @relation(fields: [user_id], references: [id])
+  role      TenantMemberRole
+  is_active Boolean          @default(true)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@index([tenant_id])
+  @@index([user_id])
+  @@unique([tenant_id, user_id])
+  @@map("tenant_members")
+}
+
+model PlatformAdmin {
+  id        String            @id @default(uuid())
+  user_id   String            @unique
+  user      User              @relation(fields: [user_id], references: [id])
+  role      PlatformAdminRole @default(SUPER_ADMIN)
+  is_active Boolean           @default(true)
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
+
+  @@map("platform_admins")
 }
 
 // ============================================================================

--- a/apps/core-api/scripts/seed-platform-admin.spec.ts
+++ b/apps/core-api/scripts/seed-platform-admin.spec.ts
@@ -1,0 +1,128 @@
+import { PlatformAdminRole } from '@prisma/client';
+import {
+  parseSeedPlatformAdminArgs,
+  seedPlatformAdmin,
+} from './seed-platform-admin';
+
+describe('parseSeedPlatformAdminArgs', () => {
+  it('fails when --email is missing', () => {
+    expect(() => parseSeedPlatformAdminArgs([])).toThrow(
+      'Missing required --email=<email> argument.',
+    );
+  });
+
+  it('normalizes the platform admin email', () => {
+    expect(
+      parseSeedPlatformAdminArgs(['--email=Founder@AutoCore.com']),
+    ).toEqual({ email: 'founder@autocore.com' });
+  });
+});
+
+describe('seedPlatformAdmin', () => {
+  it('creates a relational user, promotes it to platform admin, and syncs Firebase claims', async () => {
+    const prisma = {
+      user: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'user-1' }),
+        update: jest.fn(),
+      },
+      platformAdmin: {
+        upsert: jest.fn().mockResolvedValue({
+          id: 'platform-admin-1',
+          role: PlatformAdminRole.SUPER_ADMIN,
+        }),
+      },
+    };
+    const firebaseAuth = {
+      getUserByEmail: jest.fn().mockResolvedValue({
+        uid: 'firebase-uid-1',
+        email: 'Founder@AutoCore.com',
+        customClaims: { supportTier: 'gold' },
+      }),
+      setCustomUserClaims: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await seedPlatformAdmin(
+      { email: 'founder@autocore.com' },
+      { prisma, firebaseAuth },
+    );
+
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { firebaseUid: 'firebase-uid-1' },
+          { email: 'founder@autocore.com' },
+        ],
+      },
+    });
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: {
+        firebaseUid: 'firebase-uid-1',
+        email: 'founder@autocore.com',
+      },
+    });
+    expect(prisma.platformAdmin.upsert).toHaveBeenCalledWith({
+      where: { user_id: 'user-1' },
+      update: {
+        role: PlatformAdminRole.SUPER_ADMIN,
+        is_active: true,
+      },
+      create: {
+        user_id: 'user-1',
+        role: PlatformAdminRole.SUPER_ADMIN,
+        is_active: true,
+      },
+    });
+    expect(firebaseAuth.setCustomUserClaims).toHaveBeenCalledWith(
+      'firebase-uid-1',
+      {
+        supportTier: 'gold',
+        platformRole: PlatformAdminRole.SUPER_ADMIN,
+      },
+    );
+    expect(result).toEqual({
+      email: 'founder@autocore.com',
+      firebaseUid: 'firebase-uid-1',
+      userId: 'user-1',
+      platformAdminId: 'platform-admin-1',
+    });
+  });
+
+  it('updates an existing relational user before reactivating platform admin access', async () => {
+    const prisma = {
+      user: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'user-9' }),
+        create: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: 'user-9' }),
+      },
+      platformAdmin: {
+        upsert: jest.fn().mockResolvedValue({
+          id: 'platform-admin-9',
+          role: PlatformAdminRole.SUPER_ADMIN,
+        }),
+      },
+    };
+    const firebaseAuth = {
+      getUserByEmail: jest.fn().mockResolvedValue({
+        uid: 'firebase-uid-9',
+        email: 'ops@autocore.com',
+        customClaims: {},
+      }),
+      setCustomUserClaims: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await seedPlatformAdmin(
+      { email: 'ops@autocore.com' },
+      { prisma, firebaseAuth },
+    );
+
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-9' },
+      data: {
+        firebaseUid: 'firebase-uid-9',
+        email: 'ops@autocore.com',
+      },
+    });
+  });
+});

--- a/apps/core-api/scripts/seed-platform-admin.ts
+++ b/apps/core-api/scripts/seed-platform-admin.ts
@@ -1,0 +1,209 @@
+import 'dotenv/config';
+import { PlatformAdminRole, PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+import { getFirebaseAdminAuth } from '../src/auth/firebase-admin';
+
+type FirebaseUserRecord = {
+  uid: string;
+  email?: string | null;
+  customClaims?: Record<string, unknown>;
+};
+
+type SeedPlatformAdminOptions = {
+  email: string;
+};
+
+type SeedPlatformAdminDependencies = {
+  prisma: {
+    user: {
+      findFirst: (args: {
+        where: {
+          OR: Array<{
+            firebaseUid?: string;
+            email?: string;
+          }>;
+        };
+      }) => Promise<{
+        id: string;
+      } | null>;
+      create: (args: {
+        data: {
+          firebaseUid: string;
+          email: string;
+        };
+      }) => Promise<{
+        id: string;
+      }>;
+      update: (args: {
+        where: { id: string };
+        data: {
+          firebaseUid: string;
+          email: string;
+        };
+      }) => Promise<{
+        id: string;
+      }>;
+    };
+    platformAdmin: {
+      upsert: (args: {
+        where: { user_id: string };
+        update: {
+          role: PlatformAdminRole;
+          is_active: boolean;
+        };
+        create: {
+          user_id: string;
+          role: PlatformAdminRole;
+          is_active: boolean;
+        };
+      }) => Promise<{
+        id: string;
+        role: PlatformAdminRole;
+      }>;
+    };
+    $disconnect?: () => Promise<void>;
+  };
+  firebaseAuth: {
+    getUserByEmail: (email: string) => Promise<FirebaseUserRecord>;
+    setCustomUserClaims: (
+      uid: string,
+      claims: Record<string, unknown>,
+    ) => Promise<void>;
+  };
+};
+
+export function parseSeedPlatformAdminArgs(
+  argv: string[],
+): SeedPlatformAdminOptions {
+  const email = readCliOption(argv, '--email');
+
+  if (!email) {
+    throw new Error('Missing required --email=<email> argument.');
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!normalizedEmail) {
+    throw new Error('Platform admin email must not be empty.');
+  }
+
+  return { email: normalizedEmail };
+}
+
+export async function seedPlatformAdmin(
+  options: SeedPlatformAdminOptions,
+  dependencies: SeedPlatformAdminDependencies,
+): Promise<{
+  email: string;
+  firebaseUid: string;
+  userId: string;
+  platformAdminId: string;
+}> {
+  const email = options.email.trim().toLowerCase();
+  const firebaseUser = await dependencies.firebaseAuth.getUserByEmail(email);
+  const resolvedEmail = (firebaseUser.email ?? email).trim().toLowerCase();
+
+  const existingUser = await dependencies.prisma.user.findFirst({
+    where: {
+      OR: [{ firebaseUid: firebaseUser.uid }, { email: resolvedEmail }],
+    },
+  });
+
+  const user = existingUser
+    ? await dependencies.prisma.user.update({
+        where: { id: existingUser.id },
+        data: {
+          firebaseUid: firebaseUser.uid,
+          email: resolvedEmail,
+        },
+      })
+    : await dependencies.prisma.user.create({
+        data: {
+          firebaseUid: firebaseUser.uid,
+          email: resolvedEmail,
+        },
+      });
+
+  const platformAdmin = await dependencies.prisma.platformAdmin.upsert({
+    where: { user_id: user.id },
+    update: {
+      role: PlatformAdminRole.SUPER_ADMIN,
+      is_active: true,
+    },
+    create: {
+      user_id: user.id,
+      role: PlatformAdminRole.SUPER_ADMIN,
+      is_active: true,
+    },
+  });
+
+  await dependencies.firebaseAuth.setCustomUserClaims(firebaseUser.uid, {
+    ...(firebaseUser.customClaims ?? {}),
+    platformRole: PlatformAdminRole.SUPER_ADMIN,
+  });
+
+  return {
+    email: resolvedEmail,
+    firebaseUid: firebaseUser.uid,
+    userId: user.id,
+    platformAdminId: platformAdmin.id,
+  };
+}
+
+export async function runSeedPlatformAdminCli(
+  argv = process.argv.slice(2),
+): Promise<void> {
+  const { email } = parseSeedPlatformAdminArgs(argv);
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is not set.');
+  }
+
+  const pool = new Pool({ connectionString });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter } as never);
+
+  try {
+    const result = await seedPlatformAdmin(
+      { email },
+      {
+        prisma,
+        firebaseAuth: getFirebaseAdminAuth(),
+      },
+    );
+
+    console.log(
+      `Platform admin seeded for ${result.email} (userId=${result.userId}, firebaseUid=${result.firebaseUid}, platformAdminId=${result.platformAdminId}).`,
+    );
+  } finally {
+    await prisma.$disconnect();
+    await pool.end();
+  }
+}
+
+function readCliOption(argv: string[], flag: string): string | undefined {
+  const inlineArg = argv.find((arg) => arg.startsWith(`${flag}=`));
+  if (inlineArg) {
+    return inlineArg.slice(flag.length + 1);
+  }
+
+  const flagIndex = argv.indexOf(flag);
+  if (flagIndex >= 0) {
+    return argv[flagIndex + 1];
+  }
+
+  return undefined;
+}
+
+if (require.main === module) {
+  runSeedPlatformAdminCli()
+    .then(() => process.exit(0))
+    .catch((error: unknown) => {
+      console.error(
+        error instanceof Error ? error.message : `Unexpected error: ${String(error)}`,
+      );
+      process.exit(1);
+    });
+}

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -29,6 +29,8 @@ import { DashboardRealtimeModule } from './dashboard-realtime/dashboard-realtime
 import { EmployeeModule } from './employee/employee.module';
 import { BayModule } from './bay/bay.module';
 import { AuthModule } from './auth/auth.module';
+import { PlatformAdminModule } from './platform-admin/platform-admin.module';
+import { TenantMemberModule } from './tenant-member/tenant-member.module';
 
 @Module({
   imports: [
@@ -50,6 +52,8 @@ import { AuthModule } from './auth/auth.module';
     EmployeeModule,
     BayModule,
     AuthModule,
+    PlatformAdminModule,
+    TenantMemberModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/core-api/src/auth/auth.module.ts
+++ b/apps/core-api/src/auth/auth.module.ts
@@ -4,11 +4,12 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { SuperAdminGuard } from './super-admin.guard';
 
 @Module({
   imports: [JwtModule.register({}), forwardRef(() => PrismaModule)],
   controllers: [AuthController],
-  providers: [AuthService, JwtAuthGuard],
-  exports: [AuthService, JwtAuthGuard],
+  providers: [AuthService, JwtAuthGuard, SuperAdminGuard],
+  exports: [AuthService, JwtAuthGuard, SuperAdminGuard],
 })
 export class AuthModule {}

--- a/apps/core-api/src/auth/auth.service.ts
+++ b/apps/core-api/src/auth/auth.service.ts
@@ -7,23 +7,26 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import {
-  applicationDefault,
-  cert,
-  getApp,
-  getApps,
-  initializeApp,
 } from 'firebase-admin/app';
 import type { DecodedIdToken } from 'firebase-admin/auth';
-import { getAuth } from 'firebase-admin/auth';
 import { PrismaService } from '../prisma/prisma.service';
-import type { AuthenticatedUser } from './types/authenticated-user';
+import { getFirebaseAdminAuth } from './firebase-admin';
+import type {
+  AuthenticatedUser,
+  TenantAuthenticatedUser,
+} from './types/authenticated-user';
 
 type AuthClaims = {
   sub: string;
   email: string;
-  tenantId: string;
-  role: string;
+  tenantId?: string;
+  role?: string;
+  platformRole?: string;
   iss?: string;
+};
+
+type AuthenticateBearerTokenOptions = {
+  allowPlatformAdmin?: boolean;
 };
 
 @Injectable()
@@ -38,9 +41,34 @@ export class AuthService {
 
   async authenticateBearerToken(
     authorizationHeader?: string,
+  ): Promise<TenantAuthenticatedUser>;
+  async authenticateBearerToken(
+    authorizationHeader: string | undefined,
+    options: { allowPlatformAdmin: true },
+  ): Promise<AuthenticatedUser>;
+  async authenticateBearerToken(
+    authorizationHeader?: string,
+    options: AuthenticateBearerTokenOptions = {},
   ): Promise<AuthenticatedUser> {
     const token = this.extractBearerToken(authorizationHeader);
-    const claims = await this.verifyToken(token);
+    const claims = await this.verifyToken(token, options);
+
+    if (
+      options.allowPlatformAdmin &&
+      typeof claims.platformRole === 'string'
+    ) {
+      return {
+        userId: claims.sub,
+        email: claims.email,
+        ...(typeof claims.tenantId === 'string'
+          ? { tenantId: claims.tenantId }
+          : {}),
+        ...(typeof claims.role === 'string' ? { role: claims.role } : {}),
+        platformRole: claims.platformRole,
+      };
+    }
+
+    this.assertTenantClaims(claims);
 
     if (
       process.env.NODE_ENV === 'test' &&
@@ -72,6 +100,9 @@ export class AuthService {
       email: claims.email,
       tenantId: claims.tenantId,
       role: claims.role,
+      ...(typeof claims.platformRole === 'string'
+        ? { platformRole: claims.platformRole }
+        : {}),
     };
   }
 
@@ -103,34 +134,53 @@ export class AuthService {
     return token;
   }
 
-  private async verifyToken(token: string): Promise<AuthClaims> {
+  private async verifyToken(
+    token: string,
+    options: AuthenticateBearerTokenOptions = {},
+  ): Promise<AuthClaims> {
     if (process.env.NODE_ENV === 'test') {
-      try {
-        const payload = await this.jwtService.verifyAsync<AuthClaims>(token, {
-          secret: this.testJwtSecret,
-        });
-        return this.assertClaims(payload);
-      } catch {
-        // Fall through to Firebase verification so auth-specific tests can still
-        // exercise rejection paths with non-fixture tokens.
+      const payload = await this.verifyTestToken(token);
+
+      if (payload) {
+        return this.assertClaims(payload, options);
       }
+
+      // Fall through to Firebase verification so auth-specific tests can still
+      // exercise rejection paths with non-fixture tokens.
     }
 
     try {
-      const decoded = await getAuth(this.getFirebaseApp()).verifyIdToken(token);
-      return this.assertClaims(this.mapFirebaseClaims(decoded));
+      const decoded = await getFirebaseAdminAuth().verifyIdToken(token);
+      return this.assertClaims(this.mapFirebaseClaims(decoded), options);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new UnauthorizedException(`Invalid or expired token: ${message}`);
     }
   }
 
-  private assertClaims(payload: Partial<AuthClaims>): AuthClaims {
+  private async verifyTestToken(token: string): Promise<AuthClaims | undefined> {
+    try {
+      return await this.jwtService.verifyAsync<AuthClaims>(token, {
+        secret: this.testJwtSecret,
+      });
+    } catch {
+      return undefined;
+    }
+  }
+
+  private assertClaims(
+    payload: Partial<AuthClaims>,
+    options: AuthenticateBearerTokenOptions = {},
+  ): AuthClaims {
+    const hasTenantClaims =
+      typeof payload.tenantId === 'string' && typeof payload.role === 'string';
+    const hasPlatformClaims =
+      options.allowPlatformAdmin && typeof payload.platformRole === 'string';
+
     if (
       typeof payload.sub !== 'string' ||
       typeof payload.email !== 'string' ||
-      typeof payload.tenantId !== 'string' ||
-      typeof payload.role !== 'string'
+      (!hasTenantClaims && !hasPlatformClaims)
     ) {
       throw new UnauthorizedException(
         'Bearer token is missing one or more required claims.',
@@ -140,10 +190,28 @@ export class AuthService {
     return {
       sub: payload.sub,
       email: payload.email,
-      tenantId: payload.tenantId,
-      role: payload.role,
+      tenantId:
+        typeof payload.tenantId === 'string' ? payload.tenantId : undefined,
+      role: typeof payload.role === 'string' ? payload.role : undefined,
+      platformRole:
+        typeof payload.platformRole === 'string'
+          ? payload.platformRole
+          : undefined,
       iss: payload.iss,
     };
+  }
+
+  private assertTenantClaims(
+    claims: AuthClaims,
+  ): asserts claims is AuthClaims & {
+    tenantId: string;
+    role: string;
+  } {
+    if (typeof claims.tenantId !== 'string' || typeof claims.role !== 'string') {
+      throw new UnauthorizedException(
+        'Bearer token is missing one or more required claims.',
+      );
+    }
   }
 
   private mapFirebaseClaims(decoded: DecodedIdToken): Partial<AuthClaims> {
@@ -161,46 +229,20 @@ export class AuthService {
           ? decoded.roles
           : undefined;
 
+    const platformRole =
+      typeof decoded.platformRole === 'string'
+        ? decoded.platformRole
+        : typeof decoded.platform_role === 'string'
+          ? decoded.platform_role
+          : undefined;
+
     return {
       sub: decoded.uid,
       email: decoded.email,
       tenantId,
       role,
+      platformRole,
       iss: decoded.iss,
     };
-  }
-
-  private getFirebaseApp() {
-    if (getApps().length > 0) {
-      return getApp();
-    }
-
-    const projectId =
-      process.env.FIREBASE_PROJECT_ID ?? process.env.GOOGLE_CLOUD_PROJECT;
-    const rawCredentials = process.env.GCP_CREDENTIALS;
-
-    if (rawCredentials) {
-      const parsed = JSON.parse(rawCredentials) as {
-        project_id?: string;
-        client_email?: string;
-        private_key?: string;
-      };
-
-      if (parsed.client_email && parsed.private_key) {
-        return initializeApp({
-          credential: cert({
-            projectId: parsed.project_id ?? projectId,
-            clientEmail: parsed.client_email,
-            privateKey: parsed.private_key,
-          }),
-          projectId: parsed.project_id ?? projectId,
-        });
-      }
-    }
-
-    return initializeApp({
-      credential: applicationDefault(),
-      projectId,
-    });
   }
 }

--- a/apps/core-api/src/auth/auth.service.ts
+++ b/apps/core-api/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import {
 } from 'firebase-admin/app';
 import type { DecodedIdToken } from 'firebase-admin/auth';
 import { PrismaService } from '../prisma/prisma.service';
+import { SystemPrismaService } from '../prisma/system-prisma.service';
 import { getFirebaseAdminAuth } from './firebase-admin';
 import type {
   AuthenticatedUser,
@@ -36,6 +37,7 @@ export class AuthService {
   constructor(
     @Inject(forwardRef(() => PrismaService))
     private readonly prisma: PrismaService,
+    private readonly systemPrisma: SystemPrismaService,
     private readonly jwtService: JwtService,
   ) {}
 
@@ -53,10 +55,7 @@ export class AuthService {
     const token = this.extractBearerToken(authorizationHeader);
     const claims = await this.verifyToken(token, options);
 
-    if (
-      options.allowPlatformAdmin &&
-      typeof claims.platformRole === 'string'
-    ) {
+    if (options.allowPlatformAdmin && typeof claims.platformRole === 'string') {
       return {
         userId: claims.sub,
         email: claims.email,
@@ -68,22 +67,49 @@ export class AuthService {
       };
     }
 
-    this.assertTenantClaims(claims);
-
     if (
-      process.env.NODE_ENV === 'test' &&
-      claims.iss === 'local-test-fixture'
+      typeof claims.tenantId === 'string' &&
+      typeof claims.role === 'string'
     ) {
-      return {
-        userId: claims.sub,
-        email: claims.email,
-        tenantId: claims.tenantId,
-        role: claims.role,
-      };
+      const tenant = await this.prisma.tenant.findFirst({
+        where: { id: claims.tenantId },
+        select: { id: true, is_active: true },
+      });
+
+      if (!tenant) {
+        throw new UnauthorizedException('Invalid tenant.');
+      }
+
+      if (!tenant.is_active) {
+        throw new ForbiddenException('Tenant is inactive.');
+      }
+
+      return typeof claims.platformRole === 'string'
+        ? {
+            userId: claims.sub,
+            email: claims.email,
+            tenantId: claims.tenantId,
+            role: claims.role,
+            platformRole: claims.platformRole,
+          }
+        : {
+            userId: claims.sub,
+            email: claims.email,
+            tenantId: claims.tenantId,
+            role: claims.role,
+          };
+    }
+
+    const tenantClaims = await this.resolveTenantClaimsFromDatabase(claims);
+
+    if (!tenantClaims) {
+      throw new UnauthorizedException(
+        'Bearer token is missing one or more required claims.',
+      );
     }
 
     const tenant = await this.prisma.tenant.findFirst({
-      where: { id: claims.tenantId },
+      where: { id: tenantClaims.tenantId },
       select: { id: true, is_active: true },
     });
 
@@ -95,15 +121,12 @@ export class AuthService {
       throw new ForbiddenException('Tenant is inactive.');
     }
 
-    return {
-      userId: claims.sub,
-      email: claims.email,
-      tenantId: claims.tenantId,
-      role: claims.role,
-      ...(typeof claims.platformRole === 'string'
-        ? { platformRole: claims.platformRole }
-        : {}),
-    };
+    return typeof claims.platformRole === 'string'
+      ? {
+          ...tenantClaims,
+          platformRole: claims.platformRole,
+        }
+      : tenantClaims;
   }
 
   createTestToken(overrides: Partial<AuthClaims> = {}): string {
@@ -172,15 +195,9 @@ export class AuthService {
     payload: Partial<AuthClaims>,
     options: AuthenticateBearerTokenOptions = {},
   ): AuthClaims {
-    const hasTenantClaims =
-      typeof payload.tenantId === 'string' && typeof payload.role === 'string';
-    const hasPlatformClaims =
-      options.allowPlatformAdmin && typeof payload.platformRole === 'string';
-
     if (
       typeof payload.sub !== 'string' ||
-      typeof payload.email !== 'string' ||
-      (!hasTenantClaims && !hasPlatformClaims)
+      typeof payload.email !== 'string'
     ) {
       throw new UnauthorizedException(
         'Bearer token is missing one or more required claims.',
@@ -201,17 +218,68 @@ export class AuthService {
     };
   }
 
-  private assertTenantClaims(
+  private async resolveTenantClaimsFromDatabase(
     claims: AuthClaims,
-  ): asserts claims is AuthClaims & {
-    tenantId: string;
-    role: string;
-  } {
-    if (typeof claims.tenantId !== 'string' || typeof claims.role !== 'string') {
-      throw new UnauthorizedException(
-        'Bearer token is missing one or more required claims.',
-      );
+  ): Promise<TenantAuthenticatedUser | null> {
+    const user = await this.systemPrisma.user.findFirst({
+      where: {
+        OR: [{ firebaseUid: claims.sub }, { email: claims.email }],
+      },
+      select: {
+        active_tenant_id: true,
+        platformAdmin: {
+          select: {
+            is_active: true,
+            role: true,
+          },
+        },
+        memberships: {
+          where: {
+            is_active: true,
+            tenant: {
+              is_active: true,
+            },
+          },
+          orderBy: [{ createdAt: 'asc' }],
+          select: {
+            tenant_id: true,
+            role: true,
+            tenant: {
+              select: {
+                id: true,
+                is_active: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return null;
     }
+
+    const activeMembership =
+      user.memberships.find(
+        (membership) => membership.tenant_id === user.active_tenant_id,
+      ) ?? user.memberships[0];
+
+    if (!activeMembership) {
+      return null;
+    }
+
+    const nextUser: TenantAuthenticatedUser = {
+      userId: claims.sub,
+      email: claims.email,
+      tenantId: activeMembership.tenant_id,
+      role: activeMembership.role,
+    };
+
+    if (user.platformAdmin?.is_active) {
+      nextUser.platformRole = user.platformAdmin.role;
+    }
+
+    return nextUser;
   }
 
   private mapFirebaseClaims(decoded: DecodedIdToken): Partial<AuthClaims> {

--- a/apps/core-api/src/auth/firebase-admin.ts
+++ b/apps/core-api/src/auth/firebase-admin.ts
@@ -1,0 +1,46 @@
+import {
+  applicationDefault,
+  cert,
+  getApp,
+  getApps,
+  initializeApp,
+} from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+export function getFirebaseAdminApp() {
+  if (getApps().length > 0) {
+    return getApp();
+  }
+
+  const projectId =
+    process.env.FIREBASE_PROJECT_ID ?? process.env.GOOGLE_CLOUD_PROJECT;
+  const rawCredentials = process.env.GCP_CREDENTIALS;
+
+  if (rawCredentials) {
+    const parsed = JSON.parse(rawCredentials) as {
+      project_id?: string;
+      client_email?: string;
+      private_key?: string;
+    };
+
+    if (parsed.client_email && parsed.private_key) {
+      return initializeApp({
+        credential: cert({
+          projectId: parsed.project_id ?? projectId,
+          clientEmail: parsed.client_email,
+          privateKey: parsed.private_key,
+        }),
+        projectId: parsed.project_id ?? projectId,
+      });
+    }
+  }
+
+  return initializeApp({
+    credential: applicationDefault(),
+    projectId,
+  });
+}
+
+export function getFirebaseAdminAuth() {
+  return getAuth(getFirebaseAdminApp());
+}

--- a/apps/core-api/src/auth/jwt-auth.guard.ts
+++ b/apps/core-api/src/auth/jwt-auth.guard.ts
@@ -1,6 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import type { Request } from 'express';
+import { ALLOW_PLATFORM_ADMIN_KEY } from '../common/decorators/allow-platform-admin.decorator';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { TenantContextService } from '../common/services/tenant-context.service';
 import { AuthService } from './auth.service';
@@ -24,13 +25,27 @@ export class JwtAuthGuard implements CanActivate {
       return true;
     }
 
+    const allowPlatformAdmin =
+      this.reflector.getAllAndOverride<boolean>(ALLOW_PLATFORM_ADMIN_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]) ?? false;
+
     const request = context
       .switchToHttp()
       .getRequest<Request & { user?: AuthenticatedUser }>();
-    request.user = await this.authService.authenticateBearerToken(
-      request.headers.authorization,
-    );
-    this.tenantContext.setAuthenticatedUser(request.user);
+    request.user = allowPlatformAdmin
+      ? await this.authService.authenticateBearerToken(
+          request.headers.authorization,
+          { allowPlatformAdmin: true },
+        )
+      : await this.authService.authenticateBearerToken(
+          request.headers.authorization,
+        );
+
+    if (request.user.tenantId) {
+      this.tenantContext.setAuthenticatedUser(request.user);
+    }
 
     return true;
   }

--- a/apps/core-api/src/auth/super-admin.guard.spec.ts
+++ b/apps/core-api/src/auth/super-admin.guard.spec.ts
@@ -1,0 +1,22 @@
+import { ExecutionContext } from '@nestjs/common';
+import { describe, expect, it } from '@jest/globals';
+import { SuperAdminGuard } from './super-admin.guard';
+
+describe('SuperAdminGuard', () => {
+  it('allows authenticated platform super admins', () => {
+    const guard = new SuperAdminGuard();
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: {
+            userId: 'firebase-admin-uid',
+            email: 'founder@autocore.com',
+            platformRole: 'SUPER_ADMIN',
+          },
+        }),
+      }),
+    } as ExecutionContext;
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/apps/core-api/src/auth/super-admin.guard.ts
+++ b/apps/core-api/src/auth/super-admin.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import type { AuthenticatedUser } from './types/authenticated-user';
+
+@Injectable()
+export class SuperAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { user?: AuthenticatedUser }>();
+
+    return request.user?.platformRole === 'SUPER_ADMIN';
+  }
+}

--- a/apps/core-api/src/auth/types/authenticated-user.ts
+++ b/apps/core-api/src/auth/types/authenticated-user.ts
@@ -1,6 +1,19 @@
-export type AuthenticatedUser = {
+export type TenantAuthenticatedUser = {
   userId: string;
   email: string;
   tenantId: string;
   role: string;
+  platformRole?: string;
 };
+
+export type PlatformAuthenticatedUser = {
+  userId: string;
+  email: string;
+  platformRole: string;
+  tenantId?: string;
+  role?: string;
+};
+
+export type AuthenticatedUser =
+  | TenantAuthenticatedUser
+  | PlatformAuthenticatedUser;

--- a/apps/core-api/src/brand/brand.service.spec.ts
+++ b/apps/core-api/src/brand/brand.service.spec.ts
@@ -61,6 +61,33 @@ describe('BrandService', () => {
     mockTenantContext.getTenantId.mockResolvedValue('test-tenant-id');
   });
 
+  it('resolves the brand delegate lazily after construction', async () => {
+    const delayedPrisma = {
+      brand: undefined,
+      catalogItem: { count: jest.fn() },
+      vendor: { count: jest.fn() },
+    };
+
+    const delayedService = new BrandService(
+      delayedPrisma as unknown as PrismaService,
+      mockTenantContext as unknown as TenantContextService,
+    );
+
+    delayedPrisma.brand = {
+      findMany: jest.fn().mockResolvedValue([{ id: 1, name: 'Audi' }]),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+    };
+
+    const result = await delayedService.findAll();
+
+    expect(result.data).toEqual([{ id: 1, name: 'Audi' }]);
+  });
+
   // ── findAll ───────────────────────────────────────────────────────────
 
   describe('findAll', () => {

--- a/apps/core-api/src/brand/brand.service.ts
+++ b/apps/core-api/src/brand/brand.service.ts
@@ -20,14 +20,20 @@ import {
 
 @Injectable()
 export class BrandService {
-  private readonly brandRepository: PrismaRepository<Brand>;
+  private brandRepository?: PrismaRepository<Brand>;
 
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(TenantContextService)
     private readonly tenantContext: TenantContextService,
-  ) {
-    this.brandRepository = new PrismaRepository<Brand>(prisma.brand);
+  ) {}
+
+  private getBrandRepository(): PrismaRepository<Brand> {
+    if (!this.brandRepository) {
+      this.brandRepository = new PrismaRepository<Brand>(this.prisma.brand);
+    }
+
+    return this.brandRepository;
   }
 
   async findAll(filters?: {
@@ -49,7 +55,7 @@ export class BrandService {
 
     // When page/limit are explicitly provided, return standard paginated result
     if (filters?.page !== undefined || filters?.limit !== undefined) {
-      return this.brandRepository.findManyPaginated({
+      return this.getBrandRepository().findManyPaginated({
         where,
         orderBy: { name: 'asc' },
         page: filters.page,
@@ -58,7 +64,7 @@ export class BrandService {
     }
 
     // Non-paginated: fetch all via repository, wrap in standard shape
-    const brands = await this.brandRepository.findMany({
+    const brands = await this.getBrandRepository().findMany({
       where,
       orderBy: { name: 'asc' },
     });
@@ -95,7 +101,7 @@ export class BrandService {
     );
 
     try {
-      return await this.brandRepository.create({
+      return await this.getBrandRepository().create({
         ...createBrandDto,
         tenant_id: tenantId,
       } as unknown as Record<string, unknown>);
@@ -117,7 +123,7 @@ export class BrandService {
     await this.validateUpdateFlags(brandId, updateBrandDto);
 
     try {
-      return await this.brandRepository.update(
+      return await this.getBrandRepository().update(
         brandId,
         updateBrandDto as unknown as Record<string, unknown>,
       );
@@ -137,7 +143,7 @@ export class BrandService {
     await this.ensureNoDependencies(brandId);
 
     try {
-      return await this.brandRepository.delete(brandId);
+      return await this.getBrandRepository().delete(brandId);
     } catch (error) {
       if (error instanceof NotFoundError) {
         throw new NotFoundException(`Brand with ID ${brandId} not found`);

--- a/apps/core-api/src/common/decorators/allow-platform-admin.decorator.ts
+++ b/apps/core-api/src/common/decorators/allow-platform-admin.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ALLOW_PLATFORM_ADMIN_KEY = 'allowPlatformAdmin';
+
+export const AllowPlatformAdmin = () =>
+  SetMetadata(ALLOW_PLATFORM_ADMIN_KEY, true);

--- a/apps/core-api/src/dashboard-realtime/dashboard-events.types.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard-events.types.ts
@@ -1,4 +1,5 @@
 export const DASHBOARD_ENTITY_UPDATED_EVENT = 'entity_updated';
+export const AUTH_CLAIMS_UPDATED_EVENT = 'auth:claims_updated';
 
 export type DashboardEntityType =
   | 'PURCHASE_ORDER'
@@ -16,6 +17,11 @@ export interface DashboardEntityUpdatedPayload {
   type: DashboardEntityType;
   action: DashboardEntityAction;
   entityId?: string;
+  timestamp: string;
+}
+
+export interface AuthClaimsUpdatedPayload {
+  reason: 'membership-updated';
   timestamp: string;
 }
 

--- a/apps/core-api/src/dashboard-realtime/dashboard-realtime.service.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard-realtime.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DashboardGateway } from './dashboard.gateway';
 import type {
+  AuthClaimsUpdatedPayload,
   DashboardEntityUpdatedPayload,
   EmitDashboardEntityUpdatedInput,
 } from './dashboard-events.types';
@@ -18,5 +19,14 @@ export class DashboardRealtimeService {
       timestamp: new Date().toISOString(),
     };
     this.dashboardGateway.emitEntityUpdated(tenantId, payload);
+  }
+
+  emitClaimsUpdated(userId: string): void {
+    const payload: AuthClaimsUpdatedPayload = {
+      reason: 'membership-updated',
+      timestamp: new Date().toISOString(),
+    };
+
+    this.dashboardGateway.emitClaimsUpdated(userId, payload);
   }
 }

--- a/apps/core-api/src/dashboard-realtime/dashboard.gateway.spec.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard.gateway.spec.ts
@@ -1,7 +1,9 @@
 import type { Socket } from 'socket.io';
 import type { AuthService } from '../auth/auth.service';
 import {
+  AUTH_CLAIMS_UPDATED_EVENT,
   DASHBOARD_ENTITY_UPDATED_EVENT,
+  type AuthClaimsUpdatedPayload,
   type DashboardEntityUpdatedPayload,
 } from './dashboard-events.types';
 import { DashboardGateway } from './dashboard.gateway';
@@ -75,7 +77,9 @@ describe('DashboardGateway', () => {
       'Bearer jwt-token',
     );
     expect(client.join).toHaveBeenCalledWith('tenant_tenant-a');
+    expect(client.join).toHaveBeenCalledWith('user_user-1');
     expect(client.data.tenantId).toBe('tenant-a');
+    expect(client.data.userId).toBe('user-1');
     expect(client.disconnect).not.toHaveBeenCalled();
   });
 
@@ -97,5 +101,21 @@ describe('DashboardGateway', () => {
     expect(emit).toHaveBeenCalledWith(DASHBOARD_ENTITY_UPDATED_EVENT, payload);
     const emittedPayload = emit.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(emittedPayload.tenantId).toBeUndefined();
+  });
+
+  it('emits claims refresh events only to the affected user room', () => {
+    const emit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit });
+    gateway.server = { to } as unknown as DashboardGateway['server'];
+
+    const payload: AuthClaimsUpdatedPayload = {
+      reason: 'membership-updated',
+      timestamp: new Date().toISOString(),
+    };
+
+    gateway.emitClaimsUpdated('user-1', payload);
+
+    expect(to).toHaveBeenCalledWith('user_user-1');
+    expect(emit).toHaveBeenCalledWith(AUTH_CLAIMS_UPDATED_EVENT, payload);
   });
 });

--- a/apps/core-api/src/dashboard-realtime/dashboard.gateway.spec.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard.gateway.spec.ts
@@ -6,7 +6,22 @@ import {
   type AuthClaimsUpdatedPayload,
   type DashboardEntityUpdatedPayload,
 } from './dashboard-events.types';
-import { DashboardGateway } from './dashboard.gateway';
+import { DashboardGateway, resolveCorsOrigins } from './dashboard.gateway';
+
+describe('resolveCorsOrigins', () => {
+  it('falls back to localhost dev origins when FRONTEND_URL is unset outside production', () => {
+    expect(resolveCorsOrigins(undefined, 'development')).toEqual([
+      'http://localhost:5173',
+      'http://127.0.0.1:5173',
+    ]);
+  });
+
+  it('uses configured origins when FRONTEND_URL is provided', () => {
+    expect(
+      resolveCorsOrigins('http://localhost:5173,https://app.example.com', 'development'),
+    ).toEqual(['http://localhost:5173', 'https://app.example.com']);
+  });
+});
 
 type MockSocket = {
   id: string;

--- a/apps/core-api/src/dashboard-realtime/dashboard.gateway.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard.gateway.ts
@@ -8,6 +8,8 @@ import { Server, Socket } from 'socket.io';
 import { Public } from '../common/decorators/public.decorator';
 import { AuthService } from '../auth/auth.service';
 import {
+  AUTH_CLAIMS_UPDATED_EVENT,
+  AuthClaimsUpdatedPayload,
   DASHBOARD_ENTITY_UPDATED_EVENT,
   DashboardEntityUpdatedPayload,
 } from './dashboard-events.types';
@@ -77,6 +79,7 @@ const allowedOrigins = resolveCorsOrigins();
 export class DashboardGateway implements OnGatewayConnection {
   private readonly logger = new Logger(DashboardGateway.name);
   private static readonly TENANT_ROOM_PREFIX = 'tenant_';
+  private static readonly USER_ROOM_PREFIX = 'user_';
 
   constructor(
     @Inject(forwardRef(() => AuthService))
@@ -106,11 +109,14 @@ export class DashboardGateway implements OnGatewayConnection {
         : `Bearer ${normalizedToken}`;
       const user = await this.authService.authenticateBearerToken(authHeader);
 
-      const room = `${DashboardGateway.TENANT_ROOM_PREFIX}${user.tenantId}`;
+      const tenantRoom = `${DashboardGateway.TENANT_ROOM_PREFIX}${user.tenantId}`;
+      const userRoom = `${DashboardGateway.USER_ROOM_PREFIX}${user.userId}`;
       client.data.tenantId = user.tenantId;
-      await client.join(room);
+      client.data.userId = user.userId;
+      await client.join(tenantRoom);
+      await client.join(userRoom);
       this.logger.debug(
-        `Client authenticated and joined room: ${room} (Socket ID: ${client.id})`,
+        `Client authenticated and joined rooms: ${tenantRoom}, ${userRoom} (Socket ID: ${client.id})`,
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -138,6 +144,21 @@ export class DashboardGateway implements OnGatewayConnection {
       .emit(DASHBOARD_ENTITY_UPDATED_EVENT, payload);
     this.logger.debug(
       `Emitted ${DASHBOARD_ENTITY_UPDATED_EVENT} to room ${room}: ${payload.type}/${payload.action} ${payload.entityId ?? ''}`.trim(),
+    );
+  }
+
+  emitClaimsUpdated(userId: string, payload: AuthClaimsUpdatedPayload): void {
+    if (!this.server) {
+      this.logger.debug(
+        `Skipped emitting ${AUTH_CLAIMS_UPDATED_EVENT}: ${payload.reason} (No server connected)`.trim(),
+      );
+      return;
+    }
+
+    const room = `${DashboardGateway.USER_ROOM_PREFIX}${userId}`;
+    this.server.to(room).emit(AUTH_CLAIMS_UPDATED_EVENT, payload);
+    this.logger.debug(
+      `Emitted ${AUTH_CLAIMS_UPDATED_EVENT} to room ${room}: ${payload.reason}`.trim(),
     );
   }
 }

--- a/apps/core-api/src/dashboard-realtime/dashboard.gateway.ts
+++ b/apps/core-api/src/dashboard-realtime/dashboard.gateway.ts
@@ -16,22 +16,30 @@ import {
 import type { IncomingHttpHeaders } from 'node:http';
 
 const setupLogger = new Logger('DashboardGatewaySetup');
+const DEVELOPMENT_DEFAULT_ORIGINS = [
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+];
 
-function resolveCorsOrigins(): string[] {
-  const configuredOrigins = process.env.FRONTEND_URL?.split(',')
+export function resolveCorsOrigins(
+  frontendUrl = process.env.FRONTEND_URL,
+  nodeEnv = process.env.NODE_ENV,
+): string[] {
+  const configuredOrigins = frontendUrl?.split(',')
     .map((origin) => origin.trim())
     .filter(Boolean);
 
   if (!configuredOrigins || configuredOrigins.length === 0) {
-    if (process.env.NODE_ENV === 'production') {
+    if (nodeEnv === 'production') {
       throw new Error(
         'CRITICAL: Starting the server without FRONTEND_URL is a critical misconfiguration. It must contain the allowed frontend origin(s) for the dashboard-realtime gateway.',
       );
     }
+
     setupLogger.warn(
-      'WARNING: CORS origins are empty because FRONTEND_URL is not set. No browser origins will be allowed to connect via WebSocket.',
+      `WARNING: CORS origins are empty because FRONTEND_URL is not set. Falling back to development origins: ${DEVELOPMENT_DEFAULT_ORIGINS.join(', ')}`,
     );
-    return [];
+    return DEVELOPMENT_DEFAULT_ORIGINS;
   }
 
   return configuredOrigins;

--- a/apps/core-api/src/platform-admin/dto/platform-tenant.dto.ts
+++ b/apps/core-api/src/platform-admin/dto/platform-tenant.dto.ts
@@ -1,0 +1,154 @@
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  Max,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TenantPlan } from '@prisma/client';
+
+function trimIfString(value: unknown): unknown {
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+function parseOptionalNumber(value: unknown): unknown {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  return Number(value);
+}
+
+function parseOptionalBoolean(value: unknown): unknown {
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  return value;
+}
+
+export class ListPlatformTenantsQueryDto {
+  @ApiPropertyOptional({ description: 'Search by tenant name or slug' })
+  @IsOptional()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Include inactive tenants when true' })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalBoolean(value as unknown))
+  @IsBoolean()
+  includeInactive?: boolean;
+
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalNumber(value as unknown))
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalNumber(value as unknown))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class CreatePlatformTenantDto {
+  @ApiProperty()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ description: 'Lowercase slug used for tenant routing and lookup' })
+  @Transform(({ value }) => trimIfString(value as unknown))
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  slug!: string;
+
+  @ApiProperty({ enum: TenantPlan, enumName: 'TenantPlan' })
+  @IsEnum(TenantPlan)
+  plan!: TenantPlan;
+}
+
+export class UpdatePlatformTenantDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  slug?: string;
+
+  @ApiPropertyOptional({ enum: TenantPlan, enumName: 'TenantPlan' })
+  @IsOptional()
+  @IsEnum(TenantPlan)
+  plan?: TenantPlan;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}
+
+export class PlatformTenantResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  slug!: string;
+
+  @ApiProperty({ enum: TenantPlan, enumName: 'TenantPlan' })
+  plan!: TenantPlan;
+
+  @ApiProperty()
+  isActive!: boolean;
+
+  @ApiProperty()
+  memberCount!: number;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}
+
+export class PlatformTenantListMetaDto {
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  page!: number;
+
+  @ApiProperty()
+  limit!: number;
+
+  @ApiProperty()
+  totalPages!: number;
+}
+
+export class PlatformTenantListResponseDto {
+  @ApiProperty({ type: [PlatformTenantResponseDto] })
+  data!: PlatformTenantResponseDto[];
+
+  @ApiProperty({ type: PlatformTenantListMetaDto })
+  meta!: PlatformTenantListMetaDto;
+}

--- a/apps/core-api/src/platform-admin/platform-admin.controller.ts
+++ b/apps/core-api/src/platform-admin/platform-admin.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { SuperAdminGuard } from '../auth/super-admin.guard';
+import { AllowPlatformAdmin } from '../common/decorators/allow-platform-admin.decorator';
+import {
+  CreatePlatformTenantDto,
+  ListPlatformTenantsQueryDto,
+  PlatformTenantListResponseDto,
+  PlatformTenantResponseDto,
+  UpdatePlatformTenantDto,
+} from './dto/platform-tenant.dto';
+import { PlatformAdminService } from './platform-admin.service';
+
+@ApiTags('platform-tenants')
+@AllowPlatformAdmin()
+@UseGuards(SuperAdminGuard)
+@Controller('platform/tenants')
+export class PlatformAdminController {
+  constructor(private readonly platformAdminService: PlatformAdminService) {}
+
+  @Get()
+  @ApiOkResponse({ type: PlatformTenantListResponseDto })
+  findAll(@Query() query: ListPlatformTenantsQueryDto) {
+    return this.platformAdminService.findAll(query);
+  }
+
+  @Post()
+  @ApiCreatedResponse({ type: PlatformTenantResponseDto })
+  create(@Body() dto: CreatePlatformTenantDto) {
+    return this.platformAdminService.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOkResponse({ type: PlatformTenantResponseDto })
+  update(@Param('id') id: string, @Body() dto: UpdatePlatformTenantDto) {
+    return this.platformAdminService.update(id, dto);
+  }
+}

--- a/apps/core-api/src/platform-admin/platform-admin.module.ts
+++ b/apps/core-api/src/platform-admin/platform-admin.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { PlatformAdminController } from './platform-admin.controller';
+import { PlatformAdminService } from './platform-admin.service';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [PlatformAdminController],
+  providers: [PlatformAdminService],
+  exports: [PlatformAdminService],
+})
+export class PlatformAdminModule {}

--- a/apps/core-api/src/platform-admin/platform-admin.service.spec.ts
+++ b/apps/core-api/src/platform-admin/platform-admin.service.spec.ts
@@ -1,0 +1,128 @@
+import { TenantPlan } from '@prisma/client';
+import { SystemPrismaService } from '../prisma/system-prisma.service';
+import { PlatformAdminService } from './platform-admin.service';
+
+const mockSystemPrisma = {
+  tenant: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+    update: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+describe('PlatformAdminService', () => {
+  let service: PlatformAdminService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PlatformAdminService(
+      mockSystemPrisma as unknown as SystemPrismaService,
+    );
+  });
+
+  it('lists tenants with membership counts in a paginated response', async () => {
+    mockSystemPrisma.tenant.findMany.mockResolvedValue([
+      {
+        id: 'tenant-1',
+        name: 'Default Workshop',
+        slug: 'default-workshop',
+        plan: TenantPlan.STANDARD,
+        is_active: true,
+        created_at: new Date('2026-04-23T10:00:00.000Z'),
+        updated_at: new Date('2026-04-23T11:00:00.000Z'),
+        _count: {
+          memberships: 3,
+        },
+      },
+    ]);
+    mockSystemPrisma.tenant.count.mockResolvedValue(1);
+
+    const result = await service.findAll({ page: 1, limit: 25 });
+
+    expect(mockSystemPrisma.tenant.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          _count: {
+            select: { memberships: true },
+          },
+        },
+      }),
+    );
+    expect(result).toEqual({
+      data: [
+        {
+          id: 'tenant-1',
+          name: 'Default Workshop',
+          slug: 'default-workshop',
+          plan: TenantPlan.STANDARD,
+          isActive: true,
+          memberCount: 3,
+          createdAt: new Date('2026-04-23T10:00:00.000Z'),
+          updatedAt: new Date('2026-04-23T11:00:00.000Z'),
+        },
+      ],
+      meta: {
+        total: 1,
+        page: 1,
+        limit: 25,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('creates a tenant and its default finance settings in one transaction', async () => {
+    const tenantCreate = jest.fn().mockResolvedValue({
+      id: 'tenant-2',
+      name: 'North Branch',
+      slug: 'north-branch',
+      plan: TenantPlan.PREMIUM,
+      is_active: true,
+      created_at: new Date('2026-04-23T12:00:00.000Z'),
+      updated_at: new Date('2026-04-23T12:00:00.000Z'),
+      _count: { memberships: 0 },
+    });
+    const financeSettingsCreate = jest.fn().mockResolvedValue(undefined);
+
+    mockSystemPrisma.$transaction.mockImplementation(async (callback) =>
+      callback({
+        tenant: { create: tenantCreate },
+        financeSettings: { create: financeSettingsCreate },
+      }),
+    );
+
+    const result = await service.create({
+      name: 'North Branch',
+      slug: 'north-branch',
+      plan: TenantPlan.PREMIUM,
+    });
+
+    expect(tenantCreate).toHaveBeenCalledWith({
+      data: {
+        name: 'North Branch',
+        slug: 'north-branch',
+        plan: TenantPlan.PREMIUM,
+      },
+      include: {
+        _count: {
+          select: { memberships: true },
+        },
+      },
+    });
+    expect(financeSettingsCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tenant_id: 'tenant-2',
+        fiscal_year_start_month: 1,
+        next_invoice_number: 1001,
+        next_sales_order_number: 1001,
+        next_workshop_order_number: 1,
+      }),
+    });
+    expect(result).toMatchObject({
+      id: 'tenant-2',
+      slug: 'north-branch',
+      plan: TenantPlan.PREMIUM,
+      memberCount: 0,
+    });
+  });
+});

--- a/apps/core-api/src/platform-admin/platform-admin.service.ts
+++ b/apps/core-api/src/platform-admin/platform-admin.service.ts
@@ -1,0 +1,167 @@
+import {
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import type { Prisma as PrismaTypes } from '@prisma/client';
+import {
+  CreatePlatformTenantDto,
+  ListPlatformTenantsQueryDto,
+  UpdatePlatformTenantDto,
+} from './dto/platform-tenant.dto';
+import { SystemPrismaService } from '../prisma/system-prisma.service';
+
+type PlatformTenantRecord = PrismaTypes.TenantGetPayload<{
+  include: {
+    _count: {
+      select: { memberships: true };
+    };
+  };
+}>;
+
+@Injectable()
+export class PlatformAdminService {
+  constructor(private readonly systemPrisma: SystemPrismaService) {}
+
+  async findAll(query: ListPlatformTenantsQueryDto) {
+    const page = Math.max(1, query.page ?? 1);
+    const limit = Math.min(100, Math.max(1, query.limit ?? 25));
+    const skip = (page - 1) * limit;
+    const where = this.buildTenantWhere(query);
+
+    const [tenants, total] = await Promise.all([
+      this.systemPrisma.tenant.findMany({
+        where,
+        include: {
+          _count: {
+            select: { memberships: true },
+          },
+        },
+        orderBy: [{ created_at: 'asc' }],
+        skip,
+        take: limit,
+      }),
+      this.systemPrisma.tenant.count({ where }),
+    ]);
+
+    return {
+      data: tenants.map((tenant) => this.mapTenant(tenant)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  async create(dto: CreatePlatformTenantDto) {
+    try {
+      const tenant = await this.systemPrisma.$transaction(async (tx) => {
+        const createdTenant = await tx.tenant.create({
+          data: {
+            name: dto.name.trim(),
+            slug: dto.slug.trim().toLowerCase(),
+            plan: dto.plan,
+          },
+          include: {
+            _count: {
+              select: { memberships: true },
+            },
+          },
+        });
+
+        await tx.financeSettings.create({
+          data: this.buildDefaultFinanceSettings(createdTenant.id),
+        });
+
+        return createdTenant;
+      });
+
+      return this.mapTenant(tenant);
+    } catch (error) {
+      throw this.mapPersistenceError(error);
+    }
+  }
+
+  async update(id: string, dto: UpdatePlatformTenantDto) {
+    try {
+      const updatedTenant = await this.systemPrisma.tenant.update({
+        where: { id },
+        data: {
+          ...(dto.name !== undefined && { name: dto.name.trim() }),
+          ...(dto.slug !== undefined && { slug: dto.slug.trim().toLowerCase() }),
+          ...(dto.plan !== undefined && { plan: dto.plan }),
+          ...(dto.isActive !== undefined && { is_active: dto.isActive }),
+        },
+        include: {
+          _count: {
+            select: { memberships: true },
+          },
+        },
+      });
+
+      return this.mapTenant(updatedTenant);
+    } catch (error) {
+      throw this.mapPersistenceError(error);
+    }
+  }
+
+  private buildTenantWhere(
+    query: ListPlatformTenantsQueryDto,
+  ): PrismaTypes.TenantWhereInput {
+    const search = query.search?.trim();
+
+    return {
+      ...(query.includeInactive ? {} : { is_active: true }),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { slug: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+  }
+
+  private buildDefaultFinanceSettings(tenantId: string) {
+    const currentYear = new Date().getFullYear();
+
+    return {
+      tenant_id: tenantId,
+      fiscal_year_start_month: 1,
+      lock_date: null,
+      next_invoice_number: 1001,
+      invoice_prefix: `RE-${currentYear}-`,
+      next_sales_order_number: 1001,
+      sales_order_prefix: `SO-${currentYear}-`,
+      next_workshop_order_number: 1,
+      workshop_order_prefix: `WO-${currentYear}-`,
+    };
+  }
+
+  private mapTenant(tenant: PlatformTenantRecord) {
+    return {
+      id: tenant.id,
+      name: tenant.name,
+      slug: tenant.slug,
+      plan: tenant.plan,
+      isActive: tenant.is_active,
+      memberCount: tenant._count.memberships,
+      createdAt: tenant.created_at,
+      updatedAt: tenant.updated_at,
+    };
+  }
+
+  private mapPersistenceError(error: unknown): Error {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    ) {
+      return new ConflictException('Tenant name or slug already exists.');
+    }
+
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/apps/core-api/src/prisma/prisma.module.ts
+++ b/apps/core-api/src/prisma/prisma.module.ts
@@ -2,11 +2,12 @@ import { Global, Module, forwardRef } from '@nestjs/common';
 import { TenantContextService } from '../common/services/tenant-context.service';
 import { DashboardRealtimeModule } from '../dashboard-realtime/dashboard-realtime.module';
 import { PrismaService } from './prisma.service';
+import { SystemPrismaService } from './system-prisma.service';
 
 @Global()
 @Module({
   imports: [forwardRef(() => DashboardRealtimeModule)],
-  providers: [PrismaService, TenantContextService],
-  exports: [PrismaService, TenantContextService],
+  providers: [PrismaService, SystemPrismaService, TenantContextService],
+  exports: [PrismaService, SystemPrismaService, TenantContextService],
 })
 export class PrismaModule {}

--- a/apps/core-api/src/prisma/system-prisma.service.spec.ts
+++ b/apps/core-api/src/prisma/system-prisma.service.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { SystemPrismaService } from './system-prisma.service';
+
+describe('SystemPrismaService', () => {
+  it('queries platform admins without requiring tenant context', () => {
+    expect(SystemPrismaService).toBeDefined();
+  });
+
+  it('exposes a privileged Prisma client for cross-tenant reads', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      SystemPrismaService.prototype,
+      'client',
+    );
+
+    expect(descriptor).toBeDefined();
+  });
+});

--- a/apps/core-api/src/prisma/system-prisma.service.ts
+++ b/apps/core-api/src/prisma/system-prisma.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+import { Pool } from 'pg';
+
+@Injectable()
+export class SystemPrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(SystemPrismaService.name);
+  private readonly pool: Pool;
+
+  constructor() {
+    const connectionString = process.env.DATABASE_URL;
+    const pool = new Pool({ connectionString });
+    const adapter = new PrismaPg(pool);
+
+    super({
+      adapter,
+      log: ['info', 'warn', 'error'],
+    });
+
+    this.pool = pool;
+  }
+
+  get client(): PrismaClient {
+    return this;
+  }
+
+  async onModuleInit() {
+    if (
+      process.env.SKIP_PRISMA_CONNECT === 'true' ||
+      process.env.SKIP_PRISMA_CONNECT === '1'
+    ) {
+      this.logger.warn(
+        'Skipping system Prisma database connection (SKIP_PRISMA_CONNECT set).',
+      );
+      return;
+    }
+
+    await this.connectWithRetry();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+    await this.pool.end();
+  }
+
+  private async connectWithRetry(retries = 5, delay = 2000) {
+    for (let attempt = 0; attempt < retries; attempt += 1) {
+      try {
+        await this.$connect();
+        this.logger.log('Successfully connected to the database via Adapter.');
+        return;
+      } catch (error) {
+        this.logger.error(
+          `Failed to connect to database (Attempt ${attempt + 1}/${retries}). Retrying in ${delay / 1000}s...`,
+          error,
+        );
+
+        if (attempt === retries - 1) {
+          this.logger.error('All connection attempts failed. Exiting...');
+          throw error;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+}

--- a/apps/core-api/src/prisma/tenant-isolation.extension.spec.ts
+++ b/apps/core-api/src/prisma/tenant-isolation.extension.spec.ts
@@ -1,4 +1,5 @@
 import { InternalServerErrorException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { applyTenantIsolation } from './tenant-isolation.extension';
 import { TenantContextStorage } from '../common/services/tenant-context.storage';
 
@@ -26,12 +27,29 @@ function call(
 }
 
 describe('applyTenantIsolation', () => {
-  describe('GLOBAL_MODELS (Tenant only)', () => {
+  describe('GLOBAL_MODELS', () => {
     it('passes through Tenant queries without injecting tenant_id', async () => {
       const query = jest.fn().mockResolvedValue([]);
       const args = { where: { slug: 'acme' } };
 
       await runWithTenant(() => call('Tenant', 'findMany', args, query));
+
+      expect(query).toHaveBeenCalledWith(args);
+      expect(query.mock.calls[0][0]).not.toHaveProperty('where.tenant_id');
+    });
+
+    it('passes through MasterPart queries without injecting tenant_id', async () => {
+      const query = jest.fn().mockResolvedValue([]);
+      const args = {
+        where: {
+          supplier_part_number: {
+            contains: 'test',
+            mode: 'insensitive',
+          },
+        },
+      };
+
+      await runWithTenant(() => call('MasterPart', 'findMany', args, query));
 
       expect(query).toHaveBeenCalledWith(args);
       expect(query.mock.calls[0][0]).not.toHaveProperty('where.tenant_id');
@@ -110,6 +128,73 @@ describe('applyTenantIsolation', () => {
 
       expect(query).toHaveBeenCalledWith({
         where: { status: 'DRAFT', tenant_id: TENANT_ID },
+      });
+    });
+  });
+
+  describe('update() — must verify tenant ownership', () => {
+    it('executes tenant-scoped unique updates without resolving a delegate', async () => {
+      const query = jest.fn().mockResolvedValue({ id: 'settings-1' });
+      const getExtensionContextSpy = jest
+        .spyOn(Prisma, 'getExtensionContext')
+        .mockReturnValue({} as never);
+
+      try {
+        await runWithTenant(() =>
+          applyTenantIsolation.call(
+            {},
+            'FinanceSettings',
+            'update',
+            {
+              where: { tenant_id: 'wrong-tenant' },
+              data: { workshop_order_prefix: 'WO-2026-' },
+            },
+            query,
+          ),
+        );
+      } finally {
+        getExtensionContextSpy.mockRestore();
+      }
+
+      expect(query).toHaveBeenCalledWith({
+        where: { tenant_id: TENANT_ID },
+        data: { workshop_order_prefix: 'WO-2026-' },
+      });
+    });
+
+    it('falls back to PascalCase model delegates when lower-camel delegates are unavailable', async () => {
+      const query = jest.fn().mockResolvedValue({ id: 'settings-1' });
+      const findFirst = jest.fn().mockResolvedValue({ id: 'settings-1' });
+      const getExtensionContextSpy = jest
+        .spyOn(Prisma, 'getExtensionContext')
+        .mockReturnValue({
+          FinanceSettings: { findFirst },
+        } as never);
+
+      try {
+        await runWithTenant(() =>
+          applyTenantIsolation.call(
+            {},
+            'FinanceSettings',
+            'update',
+            {
+              where: { id: 'settings-1' },
+              data: { workshop_order_prefix: 'WO-2026-' },
+            },
+            query,
+          ),
+        );
+      } finally {
+        getExtensionContextSpy.mockRestore();
+      }
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { id: 'settings-1' },
+        select: { id: true },
+      });
+      expect(query).toHaveBeenCalledWith({
+        where: { id: 'settings-1' },
+        data: { workshop_order_prefix: 'WO-2026-' },
       });
     });
   });

--- a/apps/core-api/src/prisma/tenant-isolation.extension.ts
+++ b/apps/core-api/src/prisma/tenant-isolation.extension.ts
@@ -5,9 +5,15 @@ import { toPrismaDelegateKey } from './prisma-delegate';
 
 /**
  * Models that do NOT carry a tenant_id column and must bypass tenant isolation.
- * Only the root Tenant entity itself is global.
+ * These are currently global/shared reference tables.
  */
-const GLOBAL_MODELS = new Set(['Tenant']);
+const GLOBAL_MODELS = new Set([
+  'Tenant',
+  'MasterPart',
+  'PartFitment',
+  'LocalInventory',
+  'LaborFitment',
+]);
 
 /**
  * Operations where tenant_id is injected into args.where.
@@ -51,11 +57,10 @@ function normalizeRecord(value: unknown): Record<string, unknown> {
   return { ...(value as Record<string, unknown>) };
 }
 
-function scopeUpsertWhere(
-  model: string,
+function injectTenantIntoWhere(
   where: Record<string, unknown> | undefined,
   tenantId: string,
-): Record<string, unknown> {
+): { scopedWhere: Record<string, unknown>; injected: boolean } {
   const scopedWhere = normalizeRecord(where);
   let injected = false;
 
@@ -76,6 +81,16 @@ function scopeUpsertWhere(
       injected = true;
     }
   }
+
+  return { scopedWhere, injected };
+}
+
+function scopeUpsertWhere(
+  model: string,
+  where: Record<string, unknown> | undefined,
+  tenantId: string,
+): Record<string, unknown> {
+  const { scopedWhere, injected } = injectTenantIntoWhere(where, tenantId);
 
   if (!injected) {
     throw new Error(
@@ -133,16 +148,27 @@ export function applyTenantIsolation(
     // Targeted single-row mutations: pre-check against the current tenant and
     // then execute the write with the caller's unique selector.
     if (operation === 'update' || operation === 'delete') {
-      const where = normalizeRecord(nextArgs.where);
+      const { scopedWhere, injected } = injectTenantIntoWhere(
+        nextArgs.where as Record<string, unknown> | undefined,
+        tenantId,
+      );
+      const where = scopedWhere;
+
       if (Object.keys(where).length === 0) {
         throw new Error(
           `[TenantIsolation] ${operation}() on model '${model}' requires a where clause.`,
         );
       }
 
+      if (injected) {
+        nextArgs.where = where;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+        return query(nextArgs);
+      }
+
       const ctx = Prisma.getExtensionContext(this) as Record<string, unknown>;
       const delegateKey = toPrismaDelegateKey(model);
-      const modelDelegate = ctx[delegateKey] as
+      const modelDelegate = (ctx[delegateKey] ?? ctx[model]) as
         | {
             findFirst?: (findArgs: {
               where: Record<string, unknown>;

--- a/apps/core-api/src/tenant-member/dto/tenant-member.dto.ts
+++ b/apps/core-api/src/tenant-member/dto/tenant-member.dto.ts
@@ -1,0 +1,134 @@
+import { Transform } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TenantMemberRole } from '@prisma/client';
+
+function trimIfString(value: unknown): unknown {
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+function parseOptionalBoolean(value: unknown): unknown {
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  return value;
+}
+
+function parseOptionalNumber(value: unknown): unknown {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  return Number(value);
+}
+
+export class InviteTenantMemberDto {
+  @ApiProperty()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ enum: TenantMemberRole, enumName: 'TenantMemberRole' })
+  @IsEnum(TenantMemberRole)
+  role!: TenantMemberRole;
+}
+
+export class UpdateTenantMemberDto {
+  @ApiPropertyOptional({ enum: TenantMemberRole, enumName: 'TenantMemberRole' })
+  @IsOptional()
+  @IsEnum(TenantMemberRole)
+  role?: TenantMemberRole;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}
+
+export class ListTenantMembersQueryDto {
+  @ApiPropertyOptional({ description: 'Search by email or user name' })
+  @IsOptional()
+  @Transform(({ value }) => trimIfString(value as unknown))
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Include inactive memberships when true' })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalBoolean(value as unknown))
+  includeInactive?: boolean;
+
+  @ApiPropertyOptional({ description: 'Page number (1-based)', minimum: 1 })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalNumber(value as unknown))
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Transform(({ value }) => parseOptionalNumber(value as unknown))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}
+
+export class TenantMemberResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  tenantId!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  userId!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiPropertyOptional()
+  firstName?: string | null;
+
+  @ApiPropertyOptional()
+  lastName?: string | null;
+
+  @ApiProperty({ enum: TenantMemberRole, enumName: 'TenantMemberRole' })
+  role!: TenantMemberRole;
+
+  @ApiProperty()
+  isActive!: boolean;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}
+
+export class TenantMembersListMetaDto {
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  page!: number;
+
+  @ApiProperty()
+  limit!: number;
+
+  @ApiProperty()
+  totalPages!: number;
+}
+
+export class TenantMembersListResponseDto {
+  @ApiProperty({ type: [TenantMemberResponseDto] })
+  data!: TenantMemberResponseDto[];
+
+  @ApiProperty({ type: TenantMembersListMetaDto })
+  meta!: TenantMembersListMetaDto;
+}

--- a/apps/core-api/src/tenant-member/tenant-member.controller.ts
+++ b/apps/core-api/src/tenant-member/tenant-member.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  InviteTenantMemberDto,
+  ListTenantMembersQueryDto,
+  TenantMemberResponseDto,
+  TenantMembersListResponseDto,
+  UpdateTenantMemberDto,
+} from './dto/tenant-member.dto';
+import { TenantMemberService } from './tenant-member.service';
+
+@ApiTags('tenant-members')
+@Controller('tenant-members')
+export class TenantMemberController {
+  constructor(private readonly tenantMemberService: TenantMemberService) {}
+
+  @Get()
+  @ApiOkResponse({ type: TenantMembersListResponseDto })
+  findAll(@Query() query: ListTenantMembersQueryDto) {
+    return this.tenantMemberService.findAll(query);
+  }
+
+  @Post('invite')
+  @ApiCreatedResponse({ type: TenantMemberResponseDto })
+  invite(@Body() dto: InviteTenantMemberDto) {
+    return this.tenantMemberService.invite(dto);
+  }
+
+  @Patch(':id')
+  @ApiOkResponse({ type: TenantMemberResponseDto })
+  update(@Param('id') id: string, @Body() dto: UpdateTenantMemberDto) {
+    return this.tenantMemberService.update(id, dto);
+  }
+}

--- a/apps/core-api/src/tenant-member/tenant-member.module.ts
+++ b/apps/core-api/src/tenant-member/tenant-member.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { TenantMemberController } from './tenant-member.controller';
+import { TenantMemberService } from './tenant-member.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TenantMemberController],
+  providers: [TenantMemberService],
+  exports: [TenantMemberService],
+})
+export class TenantMemberModule {}

--- a/apps/core-api/src/tenant-member/tenant-member.service.spec.ts
+++ b/apps/core-api/src/tenant-member/tenant-member.service.spec.ts
@@ -1,0 +1,315 @@
+import { ForbiddenException } from '@nestjs/common';
+import { TenantMemberRole } from '@prisma/client';
+import { DashboardRealtimeService } from '../dashboard-realtime/dashboard-realtime.service';
+import { TenantContextService } from '../common/services/tenant-context.service';
+import { SystemPrismaService } from '../prisma/system-prisma.service';
+import { TenantMemberService } from './tenant-member.service';
+
+const mockSystemPrisma = {
+  tenantMember: {
+    findMany: jest.fn(),
+    count: jest.fn(),
+    upsert: jest.fn(),
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  },
+  user: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+const mockTenantContext = {
+  getRequiredTenantId: jest.fn().mockReturnValue('tenant-a'),
+  getAuthenticatedUser: jest.fn().mockReturnValue({
+    userId: 'admin-user',
+    email: 'admin@autocore.com',
+    tenantId: 'tenant-a',
+    role: 'ADMIN',
+  }),
+};
+
+describe('TenantMemberService', () => {
+  let service: TenantMemberService;
+  let mockDashboardRealtime: {
+    emitClaimsUpdated: jest.Mock;
+  };
+  let mockFirebaseAuth: {
+    getUserByEmail: jest.Mock;
+    createUser: jest.Mock;
+    getUser: jest.Mock;
+    setCustomUserClaims: jest.Mock;
+    revokeRefreshTokens: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockDashboardRealtime = {
+      emitClaimsUpdated: jest.fn(),
+    };
+
+    service = new TenantMemberService(
+      mockSystemPrisma as unknown as SystemPrismaService,
+      mockTenantContext as unknown as TenantContextService,
+      mockDashboardRealtime as unknown as DashboardRealtimeService,
+    );
+
+    mockFirebaseAuth = {
+      getUserByEmail: jest.fn(),
+      createUser: jest.fn(),
+      getUser: jest.fn(),
+      setCustomUserClaims: jest.fn(),
+      revokeRefreshTokens: jest.fn(),
+    };
+
+    jest
+      .spyOn(service as never, 'getFirebaseAuth')
+      .mockReturnValue(mockFirebaseAuth as never);
+  });
+
+  it('lists tenant members with related user data in a paginated response', async () => {
+    mockSystemPrisma.tenantMember.findMany.mockResolvedValue([
+      {
+        id: 'membership-1',
+        tenant_id: 'tenant-a',
+        user_id: 'user-1',
+        role: TenantMemberRole.ADMIN,
+        is_active: true,
+        createdAt: new Date('2026-04-23T10:00:00.000Z'),
+        updatedAt: new Date('2026-04-23T11:00:00.000Z'),
+        user: {
+          id: 'user-1',
+          email: 'admin@autocore.com',
+          firstName: 'Auto',
+          lastName: 'Admin',
+        },
+      },
+    ]);
+    mockSystemPrisma.tenantMember.count.mockResolvedValue(1);
+
+    const result = await service.findAll({ page: 1, limit: 25 });
+
+    expect(mockSystemPrisma.tenantMember.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenant_id: 'tenant-a', is_active: true },
+        include: { user: true },
+      }),
+    );
+    expect(result).toEqual({
+      data: [
+        {
+          id: 'membership-1',
+          tenantId: 'tenant-a',
+          userId: 'user-1',
+          email: 'admin@autocore.com',
+          firstName: 'Auto',
+          lastName: 'Admin',
+          role: TenantMemberRole.ADMIN,
+          isActive: true,
+          createdAt: new Date('2026-04-23T10:00:00.000Z'),
+          updatedAt: new Date('2026-04-23T11:00:00.000Z'),
+        },
+      ],
+      meta: {
+        total: 1,
+        page: 1,
+        limit: 25,
+        totalPages: 1,
+      },
+    });
+  });
+
+  it('invites a tenant member, provisioning the Firebase user when it does not yet exist', async () => {
+    mockFirebaseAuth.getUserByEmail.mockRejectedValue({
+      code: 'auth/user-not-found',
+    });
+    mockFirebaseAuth.createUser.mockResolvedValue({
+      uid: 'firebase-uid-1',
+      email: 'tech@autocore.com',
+    });
+    mockSystemPrisma.user.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        firebaseUid: 'firebase-uid-1',
+        email: 'tech@autocore.com',
+        active_tenant_id: 'tenant-a',
+        platformAdmin: null,
+        memberships: [
+          {
+            tenant_id: 'tenant-a',
+            role: TenantMemberRole.TECH,
+            is_active: true,
+          },
+        ],
+      });
+    mockSystemPrisma.user.create.mockResolvedValue({
+      id: 'user-1',
+      active_tenant_id: null,
+    });
+    mockSystemPrisma.user.update.mockResolvedValue({
+      id: 'user-1',
+      active_tenant_id: 'tenant-a',
+    });
+    mockSystemPrisma.tenantMember.upsert.mockResolvedValue({
+      id: 'membership-1',
+      tenant_id: 'tenant-a',
+      user_id: 'user-1',
+      role: TenantMemberRole.TECH,
+      is_active: true,
+      createdAt: new Date('2026-04-23T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-23T10:00:00.000Z'),
+      user: {
+        id: 'user-1',
+        email: 'tech@autocore.com',
+        firstName: null,
+        lastName: null,
+      },
+    });
+    mockFirebaseAuth.getUser.mockResolvedValue({
+      uid: 'firebase-uid-1',
+      customClaims: { existing: 'claim' },
+    });
+    mockFirebaseAuth.setCustomUserClaims.mockResolvedValue(undefined);
+
+    const result = await service.invite({
+      email: 'tech@autocore.com',
+      role: TenantMemberRole.TECH,
+    });
+
+    expect(mockFirebaseAuth.createUser).toHaveBeenCalledWith({
+      email: 'tech@autocore.com',
+    });
+    expect(mockSystemPrisma.tenantMember.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenant_id_user_id: {
+            tenant_id: 'tenant-a',
+            user_id: 'user-1',
+          },
+        },
+      }),
+    );
+    expect(mockFirebaseAuth.setCustomUserClaims).toHaveBeenCalledWith(
+      'firebase-uid-1',
+      {
+        existing: 'claim',
+        tenantId: 'tenant-a',
+        role: TenantMemberRole.TECH,
+      },
+    );
+    expect(mockDashboardRealtime.emitClaimsUpdated).toHaveBeenCalledWith(
+      'user-1',
+    );
+    expect(result).toMatchObject({
+      id: 'membership-1',
+      tenantId: 'tenant-a',
+      userId: 'user-1',
+      email: 'tech@autocore.com',
+      role: TenantMemberRole.TECH,
+      isActive: true,
+    });
+  });
+
+  it('updates a membership, revokes refresh tokens for security-sensitive changes, and emits claims refresh', async () => {
+    mockSystemPrisma.tenantMember.findFirst.mockResolvedValue({
+      id: 'membership-1',
+      tenant_id: 'tenant-a',
+      user_id: 'user-1',
+      role: TenantMemberRole.ADMIN,
+      is_active: true,
+      createdAt: new Date('2026-04-23T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-23T10:00:00.000Z'),
+      user: {
+        id: 'user-1',
+        email: 'admin@autocore.com',
+        firstName: 'Auto',
+        lastName: 'Admin',
+      },
+    });
+    mockSystemPrisma.tenantMember.update.mockResolvedValue({
+      id: 'membership-1',
+      tenant_id: 'tenant-a',
+      user_id: 'user-1',
+      role: TenantMemberRole.TECH,
+      is_active: false,
+      createdAt: new Date('2026-04-23T10:00:00.000Z'),
+      updatedAt: new Date('2026-04-23T11:00:00.000Z'),
+      user: {
+        id: 'user-1',
+        email: 'admin@autocore.com',
+        firstName: 'Auto',
+        lastName: 'Admin',
+      },
+    });
+    mockSystemPrisma.user.findFirst
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        firebaseUid: 'firebase-uid-1',
+        email: 'admin@autocore.com',
+        active_tenant_id: null,
+        platformAdmin: null,
+        memberships: [],
+      })
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        firebaseUid: 'firebase-uid-1',
+      });
+    mockFirebaseAuth.getUser.mockResolvedValue({
+      uid: 'firebase-uid-1',
+      customClaims: {
+        tenantId: 'tenant-a',
+        role: TenantMemberRole.ADMIN,
+      },
+    });
+    mockFirebaseAuth.setCustomUserClaims.mockResolvedValue(undefined);
+    mockFirebaseAuth.revokeRefreshTokens.mockResolvedValue(undefined);
+
+    const result = await service.update('membership-1', {
+      role: TenantMemberRole.TECH,
+      isActive: false,
+    });
+
+    expect(mockSystemPrisma.tenantMember.update).toHaveBeenCalledWith({
+      where: { id: 'membership-1' },
+      data: {
+        role: TenantMemberRole.TECH,
+        is_active: false,
+      },
+      include: { user: true },
+    });
+    expect(mockFirebaseAuth.setCustomUserClaims).toHaveBeenCalledWith(
+      'firebase-uid-1',
+      {},
+    );
+    expect(mockFirebaseAuth.revokeRefreshTokens).toHaveBeenCalledWith(
+      'firebase-uid-1',
+    );
+    expect(mockDashboardRealtime.emitClaimsUpdated).toHaveBeenCalledWith(
+      'user-1',
+    );
+    expect(result).toMatchObject({
+      id: 'membership-1',
+      role: TenantMemberRole.TECH,
+      isActive: false,
+    });
+  });
+
+  it('rejects membership management for non-admin tenant users', async () => {
+    mockTenantContext.getAuthenticatedUser.mockReturnValue({
+      userId: 'tech-user',
+      email: 'tech@autocore.com',
+      tenantId: 'tenant-a',
+      role: 'TECH',
+    });
+
+    await expect(
+      service.invite({
+        email: 'sales@autocore.com',
+        role: TenantMemberRole.SALES,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/apps/core-api/src/tenant-member/tenant-member.service.ts
+++ b/apps/core-api/src/tenant-member/tenant-member.service.ts
@@ -1,0 +1,343 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+import type { UserRecord } from 'firebase-admin/auth';
+import { getFirebaseAdminAuth } from '../auth/firebase-admin';
+import { TenantContextService } from '../common/services/tenant-context.service';
+import { DashboardRealtimeService } from '../dashboard-realtime/dashboard-realtime.service';
+import { SystemPrismaService } from '../prisma/system-prisma.service';
+import {
+  InviteTenantMemberDto,
+  ListTenantMembersQueryDto,
+  UpdateTenantMemberDto,
+} from './dto/tenant-member.dto';
+
+type TenantMemberListRecord = Prisma.TenantMemberGetPayload<{
+  include: { user: true };
+}>;
+
+type UserProjectionRecord = Prisma.UserGetPayload<{
+  include: {
+    platformAdmin: true;
+    memberships: true;
+  };
+}>;
+
+@Injectable()
+export class TenantMemberService {
+  constructor(
+    private readonly systemPrisma: SystemPrismaService,
+    private readonly tenantContext: TenantContextService,
+    private readonly dashboardRealtime: DashboardRealtimeService,
+  ) {}
+
+  async findAll(query: ListTenantMembersQueryDto) {
+    this.assertTenantAdminAccess();
+
+    const tenantId = this.tenantContext.getRequiredTenantId();
+    const page = Math.max(1, query.page ?? 1);
+    const limit = Math.min(100, Math.max(1, query.limit ?? 25));
+    const skip = (page - 1) * limit;
+    const where = this.buildTenantMemberWhere(tenantId, query);
+
+    const [memberships, total] = await Promise.all([
+      this.systemPrisma.tenantMember.findMany({
+        where,
+        include: { user: true },
+        orderBy: [{ createdAt: 'asc' }],
+        skip,
+        take: limit,
+      }),
+      this.systemPrisma.tenantMember.count({ where }),
+    ]);
+
+    return {
+      data: memberships.map((membership) => this.mapTenantMember(membership)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+    };
+  }
+
+  async invite(dto: InviteTenantMemberDto) {
+    this.assertTenantAdminAccess();
+
+    const tenantId = this.tenantContext.getRequiredTenantId();
+    const normalizedEmail = dto.email.trim().toLowerCase();
+    const firebaseUser = await this.resolveFirebaseUser(normalizedEmail);
+    const resolvedEmail = (firebaseUser.email ?? normalizedEmail)
+      .trim()
+      .toLowerCase();
+
+    const existingUser = await this.systemPrisma.user.findFirst({
+      where: {
+        OR: [
+          { firebaseUid: firebaseUser.uid },
+          { email: resolvedEmail },
+        ],
+      },
+    });
+
+    let userId: string;
+    let hasActiveTenant = false;
+
+    if (existingUser) {
+      userId = existingUser.id;
+      hasActiveTenant = Boolean(existingUser.active_tenant_id);
+
+      await this.systemPrisma.user.update({
+        where: { id: existingUser.id },
+        data: {
+          firebaseUid: firebaseUser.uid,
+          email: resolvedEmail,
+        },
+      });
+    } else {
+      const createdUser = await this.systemPrisma.user.create({
+        data: {
+          firebaseUid: firebaseUser.uid,
+          email: resolvedEmail,
+        },
+      });
+
+      userId = createdUser.id;
+      hasActiveTenant = Boolean(createdUser.active_tenant_id);
+    }
+
+    if (!hasActiveTenant) {
+      await this.systemPrisma.user.update({
+        where: { id: userId },
+        data: { active_tenant_id: tenantId },
+      });
+    }
+
+    const membership = await this.systemPrisma.tenantMember.upsert({
+      where: {
+        tenant_id_user_id: {
+          tenant_id: tenantId,
+          user_id: userId,
+        },
+      },
+      update: {
+        role: dto.role,
+        is_active: true,
+      },
+      create: {
+        tenant_id: tenantId,
+        user_id: userId,
+        role: dto.role,
+        is_active: true,
+      },
+      include: { user: true },
+    });
+
+    await this.syncUserClaims(userId);
+    this.dashboardRealtime.emitClaimsUpdated(userId);
+
+    return this.mapTenantMember(membership);
+  }
+
+  async update(id: string, dto: UpdateTenantMemberDto) {
+    this.assertTenantAdminAccess();
+
+    const tenantId = this.tenantContext.getRequiredTenantId();
+    const existingMembership = await this.systemPrisma.tenantMember.findFirst({
+      where: {
+        id,
+        tenant_id: tenantId,
+      },
+      include: { user: true },
+    });
+
+    if (!existingMembership) {
+      throw new BadRequestException(`Tenant member ${id} not found.`);
+    }
+
+    const updatedMembership = await this.systemPrisma.tenantMember.update({
+      where: { id },
+      data: {
+        ...(dto.role !== undefined && { role: dto.role }),
+        ...(dto.isActive !== undefined && { is_active: dto.isActive }),
+      },
+      include: { user: true },
+    });
+
+    const securitySensitiveChange =
+      (dto.role !== undefined && dto.role !== existingMembership.role) ||
+      dto.isActive === false;
+
+    await this.syncUserClaims(updatedMembership.user_id);
+
+    if (securitySensitiveChange) {
+      const user = await this.systemPrisma.user.findFirst({
+        where: { id: updatedMembership.user_id },
+        select: { firebaseUid: true },
+      });
+
+      if (user?.firebaseUid) {
+        await this.getFirebaseAuth().revokeRefreshTokens(user.firebaseUid);
+      }
+    }
+
+    this.dashboardRealtime.emitClaimsUpdated(updatedMembership.user_id);
+
+    return this.mapTenantMember(updatedMembership);
+  }
+
+  protected getFirebaseAuth() {
+    return getFirebaseAdminAuth();
+  }
+
+  private async resolveFirebaseUser(email: string): Promise<UserRecord> {
+    const firebaseAuth = this.getFirebaseAuth();
+
+    try {
+      return await firebaseAuth.getUserByEmail(email);
+    } catch (error) {
+      if (this.getFirebaseErrorCode(error) === 'auth/user-not-found') {
+        return firebaseAuth.createUser({ email });
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BadRequestException(
+        `Failed to resolve Firebase user for ${email}: ${message}`,
+      );
+    }
+  }
+
+  private async syncUserClaims(userId: string): Promise<void> {
+    const user = (await this.systemPrisma.user.findFirst({
+      where: { id: userId },
+      include: {
+        platformAdmin: true,
+        memberships: {
+          where: {
+            is_active: true,
+            tenant: { is_active: true },
+          },
+          orderBy: [{ createdAt: 'asc' }],
+        },
+      },
+    })) as UserProjectionRecord | null;
+
+    if (!user) {
+      throw new BadRequestException(
+        `Unable to project claims for user ${userId}.`,
+      );
+    }
+
+    const activeMembership =
+      user.memberships.find(
+        (membership) => membership.tenant_id === user.active_tenant_id,
+      ) ?? user.memberships[0] ?? null;
+
+    if ((user.active_tenant_id ?? null) !== (activeMembership?.tenant_id ?? null)) {
+      await this.systemPrisma.user.update({
+        where: { id: user.id },
+        data: { active_tenant_id: activeMembership?.tenant_id ?? null },
+      });
+    }
+
+    const firebaseAuth = this.getFirebaseAuth();
+    const firebaseUser = await firebaseAuth.getUser(user.firebaseUid);
+    const nextClaims = {
+      ...(firebaseUser.customClaims ?? {}),
+    } as Record<string, unknown>;
+
+    delete nextClaims.tenantId;
+    delete nextClaims.role;
+    delete nextClaims.platformRole;
+
+    if (activeMembership) {
+      nextClaims.tenantId = activeMembership.tenant_id;
+      nextClaims.role = activeMembership.role;
+    }
+
+    if (user.platformAdmin?.is_active) {
+      nextClaims.platformRole = user.platformAdmin.role;
+    }
+
+    await firebaseAuth.setCustomUserClaims(user.firebaseUid, nextClaims);
+  }
+
+  private buildTenantMemberWhere(
+    tenantId: string,
+    query: ListTenantMembersQueryDto,
+  ): Prisma.TenantMemberWhereInput {
+    const search = query.search?.trim();
+
+    return {
+      tenant_id: tenantId,
+      ...(query.includeInactive ? {} : { is_active: true }),
+      ...(search
+        ? {
+            OR: [
+              {
+                user: {
+                  is: {
+                    email: { contains: search, mode: 'insensitive' },
+                  },
+                },
+              },
+              {
+                user: {
+                  is: {
+                    firstName: { contains: search, mode: 'insensitive' },
+                  },
+                },
+              },
+              {
+                user: {
+                  is: {
+                    lastName: { contains: search, mode: 'insensitive' },
+                  },
+                },
+              },
+            ],
+          }
+        : {}),
+    };
+  }
+
+  private assertTenantAdminAccess(): void {
+    const user = this.tenantContext.getAuthenticatedUser();
+
+    if (!user || (user.role !== 'ADMIN' && user.role !== 'OWNER')) {
+      throw new ForbiddenException('Tenant admin access is required.');
+    }
+  }
+
+  private mapTenantMember(membership: TenantMemberListRecord) {
+    return {
+      id: membership.id,
+      tenantId: membership.tenant_id,
+      userId: membership.user_id,
+      email: membership.user.email,
+      firstName: membership.user.firstName,
+      lastName: membership.user.lastName,
+      role: membership.role,
+      isActive: membership.is_active,
+      createdAt: membership.createdAt,
+      updatedAt: membership.updatedAt,
+    };
+  }
+
+  private getFirebaseErrorCode(error: unknown): string | undefined {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      typeof (error as { code?: unknown }).code === 'string'
+    ) {
+      return (error as { code: string }).code;
+    }
+
+    return undefined;
+  }
+}

--- a/apps/core-api/test/auth.e2e-spec.ts
+++ b/apps/core-api/test/auth.e2e-spec.ts
@@ -9,6 +9,7 @@ import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
 import { SuperAdminGuard } from '../src/auth/super-admin.guard';
 import { AllowPlatformAdmin } from '../src/common/decorators/allow-platform-admin.decorator';
 import { PrismaService } from '../src/prisma/prisma.service';
+import { SystemPrismaService } from '../src/prisma/system-prisma.service';
 
 @Controller('protected')
 class ProtectedController {
@@ -38,6 +39,12 @@ describe('Bearer auth (e2e)', () => {
     },
   };
 
+  const systemPrismaMock = {
+    user: {
+      findFirst: jest.fn(),
+    },
+  };
+
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
 
@@ -53,6 +60,8 @@ describe('Bearer auth (e2e)', () => {
     })
       .overrideProvider(PrismaService)
       .useValue(prismaMock)
+      .overrideProvider(SystemPrismaService)
+      .useValue(systemPrismaMock)
       .compile();
 
     app = moduleFixture.createNestApplication();
@@ -67,6 +76,7 @@ describe('Bearer auth (e2e)', () => {
 
   beforeEach(() => {
     prismaMock.tenant.findFirst.mockReset();
+    systemPrismaMock.user.findFirst.mockReset();
   });
 
   it('rejects requests without bearer auth', async () => {
@@ -133,5 +143,42 @@ describe('Bearer auth (e2e)', () => {
       .get('/protected')
       .set('Authorization', `Bearer ${token}`)
       .expect(401);
+  });
+
+  it('projects tenant claims from the database when token claims are missing', async () => {
+    prismaMock.tenant.findFirst.mockResolvedValue({
+      id: 'tenant-active',
+      is_active: true,
+    });
+
+    systemPrismaMock.user.findFirst.mockResolvedValue({
+      id: 'user-1',
+      firebaseUid: 'e2e-user-id',
+      email: 'testauto@auto.core.at',
+      active_tenant_id: 'tenant-active',
+      platformAdmin: null,
+      memberships: [
+        {
+          tenant_id: 'tenant-active',
+          role: 'ADMIN',
+          is_active: true,
+          tenant: {
+            id: 'tenant-active',
+            is_active: true,
+          },
+        },
+      ],
+    });
+
+    const token = authService.createTestToken({
+      email: 'testauto@auto.core.at',
+      tenantId: undefined,
+      role: undefined,
+    } as never);
+
+    await request(app.getHttpServer())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200, { ok: true });
   });
 });

--- a/apps/core-api/test/auth.e2e-spec.ts
+++ b/apps/core-api/test/auth.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
@@ -6,6 +6,8 @@ import request from 'supertest';
 import { AuthModule } from '../src/auth/auth.module';
 import { AuthService } from '../src/auth/auth.service';
 import { JwtAuthGuard } from '../src/auth/jwt-auth.guard';
+import { SuperAdminGuard } from '../src/auth/super-admin.guard';
+import { AllowPlatformAdmin } from '../src/common/decorators/allow-platform-admin.decorator';
 import { PrismaService } from '../src/prisma/prisma.service';
 
 @Controller('protected')
@@ -13,6 +15,16 @@ class ProtectedController {
   @Get()
   getProtected() {
     return { ok: true };
+  }
+}
+
+@Controller('platform/probe')
+class PlatformProbeController {
+  @AllowPlatformAdmin()
+  @Get()
+  @UseGuards(SuperAdminGuard)
+  getPlatformProtected() {
+    return { ok: true, scope: 'platform' };
   }
 }
 
@@ -31,7 +43,7 @@ describe('Bearer auth (e2e)', () => {
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AuthModule],
-      controllers: [ProtectedController],
+      controllers: [ProtectedController, PlatformProbeController],
       providers: [
         {
           provide: APP_GUARD,
@@ -95,5 +107,31 @@ describe('Bearer auth (e2e)', () => {
       .get('/protected')
       .set('Authorization', `Bearer ${token}`)
       .expect(403);
+  });
+
+  it('accepts platform-admin tokens on routes marked for platform access without tenantId', async () => {
+    const token = authService.createTestToken({
+      tenantId: undefined,
+      role: undefined,
+      platformRole: 'SUPER_ADMIN',
+    } as never);
+
+    await request(app.getHttpServer())
+      .get('/platform/probe')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200, { ok: true, scope: 'platform' });
+  });
+
+  it('still rejects normal tenant routes without tenantId and role claims', async () => {
+    const token = authService.createTestToken({
+      tenantId: undefined,
+      role: undefined,
+      platformRole: 'SUPER_ADMIN',
+    } as never);
+
+    await request(app.getHttpServer())
+      .get('/protected')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
   });
 });

--- a/apps/core-web/package-lock.json
+++ b/apps/core-web/package-lock.json
@@ -34,6 +34,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-error-boundary": "^6.1.1",
         "react-hook-form": "^7.72.1",
         "react-router-dom": "^7.13.0",
         "recharts": "^3.8.1",
@@ -7174,6 +7175,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+      "integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/apps/core-web/package.json
+++ b/apps/core-web/package.json
@@ -41,6 +41,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-error-boundary": "^6.1.1",
     "react-hook-form": "^7.72.1",
     "react-router-dom": "^7.13.0",
     "recharts": "^3.8.1",

--- a/apps/core-web/src/App.tsx
+++ b/apps/core-web/src/App.tsx
@@ -10,33 +10,37 @@ import { DashboardWidgetsProvider } from '@/features/dashboard-widgets/Dashboard
 import { RealtimeDashboardSyncProvider } from '@/features/realtime/RealtimeDashboardSyncProvider'
 import { SavedViewsProvider } from '@/features/saved-views/SavedViewsProvider'
 import { generateId } from '@/lib/id'
-import LoginPage from '@/pages/LoginPage'
-import InventoryList from './pages/InventoryList'
-import InventoryLedgerPage from './pages/inventory/InventoryLedgerPage'
-import VendorList from './pages/vendors/VendorList'
-import VendorDetail from './pages/vendors/VendorDetail'
-import PurchaseOrderList from './pages/purchase-orders/PurchaseOrderList'
-import PurchaseOrderCreate from './pages/purchase-orders/PurchaseOrderCreate'
-import PurchaseOrderDetail from './pages/purchase-orders/PurchaseOrderDetail'
-import InvoiceCreatePage from './pages/sales/InvoiceCreatePage'
-import InvoiceDetailPage from './pages/sales/InvoiceDetailPage'
-import PurchaseInvoiceCreatePage from './pages/purchase-invoices/PurchaseInvoiceCreatePage'
-import PurchaseBillsPage from './pages/purchase-bills/PurchaseBillsPage'
-import PurchaseBillDetailPage from './pages/purchase-bills/PurchaseBillDetailPage'
-import PurchaseBillCreatePage from './pages/purchase-bills/PurchaseBillCreatePage'
-import SettingsPage from './pages/SettingsPage'
-import DashboardPage from './pages/DashboardPage'
-import { IntakeDashboard } from './pages/workshop/IntakeDashboard'
-import WorkshopOrderDetails from './pages/workshop/WorkshopOrderDetails'
-import WorkshopOrderList from './pages/workshop/WorkshopOrderList'
-import WorkshopPickList from './pages/workshop/WorkshopPickList'
-import CustomerList from './pages/customers/CustomerList'
-import CustomerDetail from './pages/customers/CustomerDetail'
-import VehicleDetail from './pages/vehicles/VehicleDetail'
-import VehicleList from './pages/vehicles/VehicleList'
-import SalesOrderList from './pages/sales-orders/SalesOrderList'
-import SalesOrderCreate from './pages/sales-orders/SalesOrderCreate'
-import SalesOrderDetail from './pages/sales-orders/SalesOrderDetail'
+import { GlobalErrorBoundary } from '@/components/GlobalErrorBoundary'
+import { PageLoader } from '@/components/ui/PageLoader'
+
+const LoginPage = React.lazy(() => import('@/pages/LoginPage'))
+const InventoryList = React.lazy(() => import('./pages/InventoryList'))
+const InventoryLedgerPage = React.lazy(() => import('./pages/inventory/InventoryLedgerPage'))
+const VendorList = React.lazy(() => import('./pages/vendors/VendorList'))
+const VendorDetail = React.lazy(() => import('./pages/vendors/VendorDetail'))
+const PurchaseOrderList = React.lazy(() => import('./pages/purchase-orders/PurchaseOrderList'))
+const PurchaseOrderCreate = React.lazy(() => import('./pages/purchase-orders/PurchaseOrderCreate'))
+const PurchaseOrderDetail = React.lazy(() => import('./pages/purchase-orders/PurchaseOrderDetail'))
+const InvoiceCreatePage = React.lazy(() => import('./pages/sales/InvoiceCreatePage'))
+const InvoiceDetailPage = React.lazy(() => import('./pages/sales/InvoiceDetailPage'))
+const PurchaseInvoiceCreatePage = React.lazy(() => import('./pages/purchase-invoices/PurchaseInvoiceCreatePage'))
+const PurchaseBillsPage = React.lazy(() => import('./pages/purchase-bills/PurchaseBillsPage'))
+const PurchaseBillDetailPage = React.lazy(() => import('./pages/purchase-bills/PurchaseBillDetailPage'))
+const PurchaseBillCreatePage = React.lazy(() => import('./pages/purchase-bills/PurchaseBillCreatePage'))
+const SettingsPage = React.lazy(() => import('./pages/SettingsPage'))
+const DashboardPage = React.lazy(() => import('./pages/DashboardPage'))
+const PlatformTenantsPage = React.lazy(() => import('./pages/platform/PlatformTenantsPage'))
+const IntakeDashboard = React.lazy(() => import('./pages/workshop/IntakeDashboard').then(m => ({ default: m.IntakeDashboard })))
+const WorkshopOrderDetails = React.lazy(() => import('./pages/workshop/WorkshopOrderDetails'))
+const WorkshopOrderList = React.lazy(() => import('./pages/workshop/WorkshopOrderList'))
+const WorkshopPickList = React.lazy(() => import('./pages/workshop/WorkshopPickList'))
+const CustomerList = React.lazy(() => import('./pages/customers/CustomerList'))
+const CustomerDetail = React.lazy(() => import('./pages/customers/CustomerDetail'))
+const VehicleDetail = React.lazy(() => import('./pages/vehicles/VehicleDetail'))
+const VehicleList = React.lazy(() => import('./pages/vehicles/VehicleList'))
+const SalesOrderList = React.lazy(() => import('./pages/sales-orders/SalesOrderList'))
+const SalesOrderCreate = React.lazy(() => import('./pages/sales-orders/SalesOrderCreate'))
+const SalesOrderDetail = React.lazy(() => import('./pages/sales-orders/SalesOrderDetail'))
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = 'acp:sidebar-collapsed'
 
@@ -52,35 +56,38 @@ function AppRoutes() {
           animate={{ opacity: 1, y: 0, transition: { duration: 0.2, ease: 'easeOut' } }}
           exit={{ opacity: 0, y: -6, transition: { duration: 0.16, ease: 'easeIn' } }}
         >
-          <Routes location={location}>
-            <Route path="/" element={<Navigate to="/inventory" replace />} />
-            <Route path="/inventory" element={<InventoryList />} />
-            <Route path="/inventory/:itemId/ledger" element={<InventoryLedgerPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/customers" element={<CustomerList />} />
-            <Route path="/customers/:id" element={<CustomerDetail />} />
-            <Route path="/vehicles" element={<VehicleList />} />
-            <Route path="/vehicles/:id" element={<VehicleDetail />} />
-            <Route path="/sales-orders" element={<SalesOrderList />} />
-            <Route path="/sales-orders/new" element={<SalesOrderCreate />} />
-            <Route path="/sales-orders/:id" element={<SalesOrderDetail />} />
-            <Route path="/vendors" element={<VendorList />} />
-            <Route path="/vendors/:id" element={<VendorDetail />} />
-            <Route path="/purchase-orders" element={<PurchaseOrderList />} />
-            <Route path="/purchase-orders/new" element={<PurchaseOrderCreate />} />
-            <Route path="/purchase-orders/:id" element={<PurchaseOrderDetail />} />
-            <Route path="/purchase-bills" element={<PurchaseBillsPage />} />
-            <Route path="/purchase-bills/new" element={<PurchaseBillCreatePage />} />
-            <Route path="/purchase-bills/:id" element={<PurchaseBillDetailPage />} />
-            <Route path="/sales/invoices/new" element={<InvoiceCreatePage />} />
-            <Route path="/sales/invoices/:id" element={<InvoiceDetailPage />} />
-            <Route path="/purchase-invoices/new" element={<PurchaseInvoiceCreatePage />} />
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/workshop/intake" element={<IntakeDashboard />} />
-            <Route path="/workshop/orders" element={<WorkshopOrderList />} />
-            <Route path="/workshop/pick-list" element={<WorkshopPickList />} />
-            <Route path="/workshop/orders/:id" element={<WorkshopOrderDetails />} />
-          </Routes>
+          <React.Suspense fallback={<PageLoader />}>
+            <Routes location={location}>
+              <Route path="/" element={<Navigate to="/inventory" replace />} />
+              <Route path="/inventory" element={<InventoryList />} />
+              <Route path="/inventory/:itemId/ledger" element={<InventoryLedgerPage />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/customers" element={<CustomerList />} />
+              <Route path="/customers/:id" element={<CustomerDetail />} />
+              <Route path="/vehicles" element={<VehicleList />} />
+              <Route path="/vehicles/:id" element={<VehicleDetail />} />
+              <Route path="/sales-orders" element={<SalesOrderList />} />
+              <Route path="/sales-orders/new" element={<SalesOrderCreate />} />
+              <Route path="/sales-orders/:id" element={<SalesOrderDetail />} />
+              <Route path="/vendors" element={<VendorList />} />
+              <Route path="/vendors/:id" element={<VendorDetail />} />
+              <Route path="/purchase-orders" element={<PurchaseOrderList />} />
+              <Route path="/purchase-orders/new" element={<PurchaseOrderCreate />} />
+              <Route path="/purchase-orders/:id" element={<PurchaseOrderDetail />} />
+              <Route path="/purchase-bills" element={<PurchaseBillsPage />} />
+              <Route path="/purchase-bills/new" element={<PurchaseBillCreatePage />} />
+              <Route path="/purchase-bills/:id" element={<PurchaseBillDetailPage />} />
+              <Route path="/sales/invoices/new" element={<InvoiceCreatePage />} />
+              <Route path="/sales/invoices/:id" element={<InvoiceDetailPage />} />
+              <Route path="/purchase-invoices/new" element={<PurchaseInvoiceCreatePage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/platform/tenants" element={<PlatformTenantsPage />} />
+              <Route path="/workshop/intake" element={<IntakeDashboard />} />
+              <Route path="/workshop/orders" element={<WorkshopOrderList />} />
+              <Route path="/workshop/pick-list" element={<WorkshopPickList />} />
+              <Route path="/workshop/orders/:id" element={<WorkshopOrderDetails />} />
+            </Routes>
+          </React.Suspense>
         </motion.div>
       </AnimatePresence>
     </LayoutGroup>
@@ -102,7 +109,9 @@ function AppMain({ sidebarCollapsed }: AppMainProps) {
       tabIndex={-1}
     >
       <div className={isWorkshopOrderDetails ? 'w-full py-8 px-0' : 'w-full py-8 px-4'}>
-        <AppRoutes />
+        <GlobalErrorBoundary>
+          <AppRoutes />
+        </GlobalErrorBoundary>
       </div>
       <Toaster />
     </main>
@@ -112,10 +121,11 @@ function AppMain({ sidebarCollapsed }: AppMainProps) {
 type AppShellProps = {
   userId?: string
   userEmail: string | null
+  platformRole: string | null
   onSignOut: () => void
 }
 
-function AppShell({ userId, userEmail, onSignOut }: AppShellProps) {
+function AppShell({ userId, userEmail, platformRole, onSignOut }: AppShellProps) {
   const [deviceId] = React.useState(() => {
     if (typeof window === 'undefined') return 'server'
     const stored = window.localStorage.getItem('deviceId')
@@ -162,6 +172,7 @@ function AppShell({ userId, userEmail, onSignOut }: AppShellProps) {
 
             <AppSidebar
               userEmail={userEmail}
+              platformRole={platformRole}
               collapsed={sidebarCollapsed}
               onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
               onOpenSearch={() => setSearchOpen(true)}
@@ -178,19 +189,28 @@ function AppShell({ userId, userEmail, onSignOut }: AppShellProps) {
 }
 
 function App() {
-  const { user, loading, signOutUser } = useAuth()
+  const { user, claims, loading, signOutUser } = useAuth()
 
   if (loading) {
     return <div className="min-h-screen flex items-center justify-center bg-slate-100 text-sm text-slate-500">Loading…</div>
   }
 
   if (!user) {
-    return <LoginPage />
+    return (
+      <React.Suspense fallback={<PageLoader />}>
+        <LoginPage />
+      </React.Suspense>
+    )
   }
 
   return (
     <Router>
-      <AppShell userEmail={user.email ?? null} onSignOut={() => void signOutUser()} />
+      <AppShell
+        userId={user.uid}
+        userEmail={user.email ?? null}
+        platformRole={claims?.platformRole ?? null}
+        onSignOut={() => void signOutUser()}
+      />
     </Router>
   )
 }

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -996,6 +996,86 @@ export interface paths {
         patch: operations["BayController_update"];
         trace?: never;
     };
+    "/api/platform/tenants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["PlatformAdminController_findAll"];
+        put?: never;
+        post: operations["PlatformAdminController_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/platform/tenants/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["PlatformAdminController_update"];
+        trace?: never;
+    };
+    "/api/tenant-members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["TenantMemberController_findAll"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tenant-members/invite": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["TenantMemberController_invite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tenant-members/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch: operations["TenantMemberController_update"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1677,6 +1757,80 @@ export interface components {
             id: string;
             isActive?: boolean;
             deleted?: boolean;
+        };
+        /** @enum {string} */
+        TenantPlan: "STANDARD" | "PREMIUM" | "ENTERPRISE";
+        PlatformTenantResponseDto: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            slug: string;
+            plan: components["schemas"]["TenantPlan"];
+            isActive: boolean;
+            memberCount: number;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        PlatformTenantListMetaDto: {
+            total: number;
+            page: number;
+            limit: number;
+            totalPages: number;
+        };
+        PlatformTenantListResponseDto: {
+            data: components["schemas"]["PlatformTenantResponseDto"][];
+            meta: components["schemas"]["PlatformTenantListMetaDto"];
+        };
+        CreatePlatformTenantDto: {
+            name: string;
+            /** @description Lowercase slug used for tenant routing and lookup */
+            slug: string;
+            plan: components["schemas"]["TenantPlan"];
+        };
+        UpdatePlatformTenantDto: {
+            name?: string;
+            slug?: string;
+            plan?: components["schemas"]["TenantPlan"];
+            isActive?: boolean;
+        };
+        /** @enum {string} */
+        TenantMemberRole: "OWNER" | "ADMIN" | "TECH" | "SALES";
+        TenantMemberResponseDto: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            tenantId: string;
+            /** Format: uuid */
+            userId: string;
+            email: string;
+            firstName?: Record<string, never>;
+            lastName?: Record<string, never>;
+            role: components["schemas"]["TenantMemberRole"];
+            isActive: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        TenantMembersListMetaDto: {
+            total: number;
+            page: number;
+            limit: number;
+            totalPages: number;
+        };
+        TenantMembersListResponseDto: {
+            data: components["schemas"]["TenantMemberResponseDto"][];
+            meta: components["schemas"]["TenantMembersListMetaDto"];
+        };
+        InviteTenantMemberDto: {
+            email: string;
+            role: components["schemas"]["TenantMemberRole"];
+        };
+        UpdateTenantMemberDto: {
+            role?: components["schemas"]["TenantMemberRole"];
+            isActive?: boolean;
         };
     };
     responses: never;
@@ -4102,6 +4256,155 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    PlatformAdminController_findAll: {
+        parameters: {
+            query?: {
+                /** @description Search by tenant name or slug */
+                search?: string;
+                /** @description Include inactive tenants when true */
+                includeInactive?: boolean;
+                page?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantListResponseDto"];
+                };
+            };
+        };
+    };
+    PlatformAdminController_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePlatformTenantDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponseDto"];
+                };
+            };
+        };
+    };
+    PlatformAdminController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePlatformTenantDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponseDto"];
+                };
+            };
+        };
+    };
+    TenantMemberController_findAll: {
+        parameters: {
+            query?: {
+                /** @description Search by email or user name */
+                search?: string;
+                /** @description Include inactive memberships when true */
+                includeInactive?: boolean;
+                /** @description Page number (1-based) */
+                page?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantMembersListResponseDto"];
+                };
+            };
+        };
+    };
+    TenantMemberController_invite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InviteTenantMemberDto"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantMemberResponseDto"];
+                };
+            };
+        };
+    };
+    TenantMemberController_update: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTenantMemberDto"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantMemberResponseDto"];
+                };
             };
         };
     };

--- a/apps/core-web/src/api/platform-tenants.ts
+++ b/apps/core-web/src/api/platform-tenants.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { components } from './generated/openapi'
+import { fetchWithAuth } from './client'
+
+export type TenantPlan = components['schemas']['TenantPlan']
+export type PlatformTenant = components['schemas']['PlatformTenantResponseDto']
+export type PlatformTenantsListResponse = components['schemas']['PlatformTenantListResponseDto']
+export type CreatePlatformTenantPayload = components['schemas']['CreatePlatformTenantDto']
+export type UpdatePlatformTenantPayload = components['schemas']['UpdatePlatformTenantDto']
+
+export type ListPlatformTenantsOptions = {
+  search?: string
+  includeInactive?: boolean
+  page?: number
+  limit?: number
+}
+
+export const platformTenantKeys = {
+  all: ['platform-tenants'] as const,
+  list: (options?: ListPlatformTenantsOptions) => [...platformTenantKeys.all, 'list', options] as const,
+  detail: (id: string) => [...platformTenantKeys.all, 'detail', id] as const,
+}
+
+async function getErrorMessage(response: Response, fallbackMessage: string) {
+  const payload = await response.json().catch(() => undefined) as { message?: string } | undefined
+  return payload?.message || fallbackMessage
+}
+
+export function usePlatformTenants(options?: ListPlatformTenantsOptions) {
+  return useQuery<PlatformTenantsListResponse>({
+    queryKey: platformTenantKeys.list(options),
+    queryFn: async () => {
+      const params = new URLSearchParams()
+
+      if (options?.search) {
+        params.append('search', options.search)
+      }
+
+      if (options?.includeInactive !== undefined) {
+        params.append('includeInactive', String(options.includeInactive))
+      }
+
+      if (options?.page !== undefined) {
+        params.append('page', String(options.page))
+      }
+
+      if (options?.limit !== undefined) {
+        params.append('limit', String(options.limit))
+      }
+
+      const query = params.toString()
+      const response = await fetchWithAuth(query ? `/api/platform/tenants?${query}` : '/api/platform/tenants')
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to fetch tenants'))
+      }
+
+      return response.json()
+    },
+  })
+}
+
+export function useCreatePlatformTenant() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: CreatePlatformTenantPayload) => {
+      const response = await fetchWithAuth('/api/platform/tenants', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to create tenant'))
+      }
+
+      return response.json() as Promise<PlatformTenant>
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: platformTenantKeys.all })
+    },
+  })
+}
+
+export function useUpdatePlatformTenant() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdatePlatformTenantPayload }) => {
+      const response = await fetchWithAuth(`/api/platform/tenants/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to update tenant'))
+      }
+
+      return response.json() as Promise<PlatformTenant>
+    },
+    onSuccess: (tenant) => {
+      queryClient.invalidateQueries({ queryKey: platformTenantKeys.all })
+      queryClient.invalidateQueries({ queryKey: platformTenantKeys.detail(tenant.id) })
+    },
+  })
+}

--- a/apps/core-web/src/api/tenant-members.ts
+++ b/apps/core-web/src/api/tenant-members.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { components } from './generated/openapi'
+import { fetchWithAuth } from './client'
+
+export type TenantMemberRole = components['schemas']['TenantMemberRole']
+export type TenantMember = components['schemas']['TenantMemberResponseDto']
+export type TenantMembersListResponse = components['schemas']['TenantMembersListResponseDto']
+export type InviteTenantMemberPayload = components['schemas']['InviteTenantMemberDto']
+export type UpdateTenantMemberPayload = components['schemas']['UpdateTenantMemberDto']
+
+export type ListTenantMembersOptions = {
+  search?: string
+  includeInactive?: boolean
+  page?: number
+  limit?: number
+}
+
+export const tenantMemberKeys = {
+  all: ['tenant-members'] as const,
+  list: (options?: ListTenantMembersOptions) => [...tenantMemberKeys.all, 'list', options] as const,
+  detail: (id: string) => [...tenantMemberKeys.all, 'detail', id] as const,
+}
+
+async function getErrorMessage(response: Response, fallbackMessage: string) {
+  const payload = await response.json().catch(() => undefined) as { message?: string } | undefined
+  return payload?.message || fallbackMessage
+}
+
+export function useTenantMembers(options?: ListTenantMembersOptions) {
+  return useQuery<TenantMembersListResponse>({
+    queryKey: tenantMemberKeys.list(options),
+    queryFn: async () => {
+      const params = new URLSearchParams()
+
+      if (options?.search) {
+        params.append('search', options.search)
+      }
+
+      if (options?.includeInactive !== undefined) {
+        params.append('includeInactive', String(options.includeInactive))
+      }
+
+      if (options?.page !== undefined) {
+        params.append('page', String(options.page))
+      }
+
+      if (options?.limit !== undefined) {
+        params.append('limit', String(options.limit))
+      }
+
+      const query = params.toString()
+      const response = await fetchWithAuth(query ? `/api/tenant-members?${query}` : '/api/tenant-members')
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to fetch tenant members'))
+      }
+
+      return response.json()
+    },
+  })
+}
+
+export function useInviteTenantMember() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (payload: InviteTenantMemberPayload) => {
+      const response = await fetchWithAuth('/api/tenant-members/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to invite team member'))
+      }
+
+      return response.json() as Promise<TenantMember>
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantMemberKeys.all })
+    },
+  })
+}
+
+export function useUpdateTenantMember() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdateTenantMemberPayload }) => {
+      const response = await fetchWithAuth(`/api/tenant-members/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+
+      if (!response.ok) {
+        throw new Error(await getErrorMessage(response, 'Failed to update tenant member'))
+      }
+
+      return response.json() as Promise<TenantMember>
+    },
+    onSuccess: (membership) => {
+      queryClient.invalidateQueries({ queryKey: tenantMemberKeys.all })
+      queryClient.invalidateQueries({ queryKey: tenantMemberKeys.detail(membership.id) })
+    },
+  })
+}

--- a/apps/core-web/src/api/workshop.test.tsx
+++ b/apps/core-web/src/api/workshop.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { useWorkshopPickList } from './workshop'
+import { useCreateWorkshopOrder, useWorkshopPickList } from './workshop'
 import { fetchWithAuth } from './client'
 import type { WorkshopOrder } from './types'
 import type { ReactNode } from 'react'
@@ -14,6 +14,9 @@ function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
+        retry: false,
+      },
+      mutations: {
         retry: false,
       },
     },
@@ -65,9 +68,10 @@ function createWorkshopOrder(overrides: Partial<WorkshopOrder> = {}): WorkshopOr
   }
 }
 
-function createJsonResponse(body: unknown): Response {
+function createJsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
-    ok: true,
+    ok,
+    status,
     json: async () => body,
   } as Response
 }
@@ -122,5 +126,28 @@ describe('useWorkshopPickList', () => {
     expect(fetchWithAuth).toHaveBeenCalledTimes(2)
     expect(result.current.data?.data.map((order) => order.id)).toEqual(['eligible-order'])
     expect(result.current.data?.meta.total).toBe(1)
+  })
+
+  it('surfaces backend error messages when creating workshop orders', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      createJsonResponse({ message: 'Finance settings update failed' }, false, 500),
+    )
+
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCreateWorkshopOrder(), { wrapper })
+
+    await expect(result.current.mutateAsync({
+      customerId: 'customer-1',
+      vehicleId: 'vehicle-1',
+      odometer: 0,
+      fuelLevel: 50,
+    })).rejects.toMatchObject({
+      message: 'Finance settings update failed',
+      status: 500,
+    })
   })
 })

--- a/apps/core-web/src/api/workshop.ts
+++ b/apps/core-web/src/api/workshop.ts
@@ -332,7 +332,7 @@ export const useCreateWorkshopOrder = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
-      if (!response.ok) throw new Error('Failed to create workshop order')
+      if (!response.ok) throw await parseErrorResponse(response, 'Failed to create workshop order')
       const json = await response.json()
       return normalizeOrder(json)
     },

--- a/apps/core-web/src/auth/AuthProvider.tsx
+++ b/apps/core-web/src/auth/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {
   GoogleAuthProvider,
-  onAuthStateChanged,
+  onIdTokenChanged,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut,
@@ -25,8 +25,21 @@ function assertAllowedUser(user: User) {
   }
 }
 
+type AuthTokenResult = {
+  claims: Record<string, unknown>
+}
+
+type AuthenticatedUser = {
+  uid: string
+  email: string | null
+  displayName: string | null
+  getIdToken: (forceRefresh?: boolean) => Promise<string>
+  getIdTokenResult: (forceRefresh?: boolean) => Promise<AuthTokenResult>
+}
+
 type AuthContextValue = {
-  user: User | null
+  user: AuthenticatedUser | null
+  claims: AuthClaims | null
   loading: boolean
   isConfigured: boolean
   signIn: (email: string, password: string) => Promise<void>
@@ -34,10 +47,17 @@ type AuthContextValue = {
   signOutUser: () => Promise<void>
 }
 
+type AuthClaims = {
+  tenantId?: string
+  role?: string
+  platformRole?: string
+}
+
 const AuthContext = React.createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = React.useState<User | null>(null)
+  const [user, setUser] = React.useState<AuthenticatedUser | null>(null)
+  const [claims, setClaims] = React.useState<AuthClaims | null>(null)
   const [loading, setLoading] = React.useState(true)
 
   React.useEffect(() => {
@@ -47,22 +67,50 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email: 'testauto@auto.core.at',
         displayName: 'E2E Tester',
         getIdToken: async () => 'e2e-test-token',
-      } as User)
+        getIdTokenResult: async () => ({
+          claims: {
+            tenantId: 'e2e-tenant-id',
+            role: 'ADMIN',
+          },
+        }),
+      })
+      setClaims({ tenantId: 'e2e-tenant-id', role: 'ADMIN' })
       setLoading(false)
       return
     }
 
     if (!firebaseAuth) {
+      setClaims(null)
       setLoading(false)
       return
     }
 
-    const unsubscribe = onAuthStateChanged(firebaseAuth, (nextUser) => {
-      setUser(nextUser)
-      setLoading(false)
+    let active = true
+
+    const unsubscribe = onIdTokenChanged(firebaseAuth, (nextUser) => {
+      void (async () => {
+        if (!active) return
+
+        setUser(nextUser)
+
+        if (!nextUser) {
+          setClaims(null)
+          setLoading(false)
+          return
+        }
+
+        const tokenResult = await nextUser.getIdTokenResult()
+        if (!active) return
+
+        setClaims(extractAuthClaims(tokenResult.claims))
+        setLoading(false)
+      })()
     })
 
-    return unsubscribe
+    return () => {
+      active = false
+      unsubscribe()
+    }
   }, [])
 
   const signIn = React.useCallback(async (email: string, password: string) => {
@@ -106,12 +154,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const value = React.useMemo<AuthContextValue>(() => ({
     user,
+    claims,
     loading,
     isConfigured: !firebaseConfigMissing,
     signIn,
     signInWithGoogle,
     signOutUser,
-  }), [user, loading, signIn, signInWithGoogle, signOutUser])
+  }), [user, claims, loading, signIn, signInWithGoogle, signOutUser])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
@@ -124,4 +173,13 @@ export function useAuth() {
   }
 
   return context
+}
+
+function extractAuthClaims(rawClaims: Record<string, unknown>): AuthClaims {
+  return {
+    tenantId: typeof rawClaims.tenantId === 'string' ? rawClaims.tenantId : undefined,
+    role: typeof rawClaims.role === 'string' ? rawClaims.role : undefined,
+    platformRole:
+      typeof rawClaims.platformRole === 'string' ? rawClaims.platformRole : undefined,
+  }
 }

--- a/apps/core-web/src/components/GlobalErrorBoundary.tsx
+++ b/apps/core-web/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import type { FallbackProps } from 'react-error-boundary'
+import { AlertCircle, RefreshCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+function ErrorFallback({ error }: FallbackProps) {
+  const err = error as any
+  const isChunkLoadError = 
+    err?.name === 'ChunkLoadError' || 
+    err?.message?.includes('Failed to fetch dynamically imported module') ||
+    err?.message?.includes('Importing a module script failed')
+
+  return (
+    <div className="flex min-h-[50vh] w-full items-center justify-center p-4">
+      <Card className="w-full max-w-md border-slate-200 shadow-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600">
+            <AlertCircle className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-xl font-bold tracking-tight text-slate-900">
+            {isChunkLoadError ? 'Update Required' : 'Unexpected Error'}
+          </CardTitle>
+          <CardDescription className="text-slate-500">
+            {isChunkLoadError 
+              ? 'The application was updated or encountered a network interruption. A reload is required to continue.'
+              : 'The application encountered an unexpected error. Please try reloading to recover.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg bg-slate-50 p-3 text-xs font-mono text-slate-600 overflow-auto max-h-32 border border-slate-200">
+            {err?.message || 'Unknown error occurred'}
+          </div>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <Button 
+            onClick={() => {
+              // Perform a hard reload to clear stale manifests and cache
+              window.location.reload()
+            }}
+            className="w-full gap-2 bg-slate-950 hover:bg-slate-800"
+          >
+            <RefreshCcw className="h-4 w-4" />
+            Reload Application
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}
+
+interface GlobalErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+export function GlobalErrorBoundary({ children }: GlobalErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      onReset={() => {
+        // This is called when resetErrorBoundary is invoked
+        window.location.reload()
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/apps/core-web/src/components/data-table/DataTable.test.tsx
+++ b/apps/core-web/src/components/data-table/DataTable.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react'
-import { vi, describe, it, expect } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DataTable } from './DataTable'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
 describe('DataTable Characterization', () => {
   const columns = [
@@ -10,13 +15,14 @@ describe('DataTable Characterization', () => {
     },
   ]
   const data = [{ name: 'Test Item' }]
+  const mockSetColumnFilters = vi.fn()
   const mockSetGlobalFilter = vi.fn()
 
   const defaultProps = {
     columns,
     data,
     columnFilters: [],
-    setColumnFilters: vi.fn(),
+    setColumnFilters: mockSetColumnFilters,
     sorting: [],
     setSorting: vi.fn(),
     pagination: { pageIndex: 0, pageSize: 10 },
@@ -27,17 +33,18 @@ describe('DataTable Characterization', () => {
     searchPlaceholder: 'Search items...',
   }
 
-  it('calls setGlobalFilter when search input changes', () => {
+  it('calls setColumnFilters when column search input changes', () => {
     render(<DataTable {...defaultProps} />)
-    
+
     const input = screen.getByPlaceholderText('Search items...')
     fireEvent.change(input, { target: { value: 'test' } })
-    
-    expect(mockSetGlobalFilter).toHaveBeenCalled()
+
+    expect(mockSetColumnFilters).toHaveBeenCalled()
+    expect(mockSetGlobalFilter).not.toHaveBeenCalled()
   })
 
   it('renders data correctly', () => {
     render(<DataTable {...defaultProps} />)
-    expect(screen.getByText('Test Item')).toBeInTheDocument()
+    expect(screen.getAllByText('Test Item')).toHaveLength(1)
   })
 })

--- a/apps/core-web/src/components/navigation/AppSidebar.tsx
+++ b/apps/core-web/src/components/navigation/AppSidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink, useLocation, useNavigate } from 'react-router-dom'
 import type { LucideIcon } from 'lucide-react'
 import {
+  Building2,
   Car,
   ChevronsLeft,
   ChevronsRight,
@@ -23,6 +24,7 @@ import { useSavedViews } from '@/features/saved-views/SavedViewsProvider'
 
 type SidebarAccessContext = {
   userEmail: string | null
+  platformRole: string | null
 }
 
 type SidebarModule = {
@@ -42,6 +44,14 @@ const coreModules: SidebarModule[] = [
     icon: LayoutDashboard,
     isVisible: () => true,
     isActive: (pathname) => pathname === '/' || pathname.startsWith('/dashboard'),
+  },
+  {
+    id: 'platform-tenants',
+    label: 'Tenants',
+    to: '/platform/tenants',
+    icon: Building2,
+    isVisible: (context) => context.platformRole === 'SUPER_ADMIN',
+    isActive: (pathname) => pathname.startsWith('/platform/tenants'),
   },
   {
     id: 'customers',
@@ -119,6 +129,7 @@ const coreModules: SidebarModule[] = [
 
 type AppSidebarProps = {
   userEmail: string | null
+  platformRole: string | null
   collapsed: boolean
   onToggleCollapsed: () => void
   onOpenSearch: () => void
@@ -137,6 +148,7 @@ function normalizePathWithQuery(pathname: string, search: string): string {
 
 export function AppSidebar({
   userEmail,
+  platformRole,
   collapsed,
   onToggleCollapsed,
   onOpenSearch,
@@ -146,7 +158,7 @@ export function AppSidebar({
   const navigate = useNavigate()
   const { savedViews, removeSavedView } = useSavedViews()
 
-  const visibleModules = coreModules.filter((module) => module.isVisible({ userEmail }))
+  const visibleModules = coreModules.filter((module) => module.isVisible({ userEmail, platformRole }))
   const currentPathWithQuery = normalizePathWithQuery(location.pathname, location.search)
 
   return (

--- a/apps/core-web/src/components/settings/TeamSettingsTab.test.tsx
+++ b/apps/core-web/src/components/settings/TeamSettingsTab.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { useTenantMembers } from '@/api/tenant-members'
+import { TeamSettingsTab } from './TeamSettingsTab'
+
+const tenantMembersResult = {
+  data: {
+    data: [],
+    meta: { total: 0, page: 1, limit: 100, totalPages: 1 },
+  },
+  error: null,
+  isLoading: false,
+  refetch: vi.fn(),
+}
+
+vi.mock('@/api/tenant-members', () => ({
+  useTenantMembers: vi.fn(() => tenantMembersResult),
+  useInviteTenantMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateTenantMember: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+describe('TeamSettingsTab', () => {
+  it('renders title and top-right + Member action', () => {
+    render(
+      <MemoryRouter>
+        <TeamSettingsTab />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Team')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '+ Member' })).toBeInTheDocument()
+    expect(vi.mocked(useTenantMembers)).toHaveBeenCalledWith({
+      includeInactive: true,
+      limit: 100,
+    })
+  })
+})

--- a/apps/core-web/src/components/settings/TeamSettingsTab.tsx
+++ b/apps/core-web/src/components/settings/TeamSettingsTab.tsx
@@ -1,0 +1,354 @@
+import * as React from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { z } from 'zod'
+import { toast } from 'sonner'
+
+import {
+  type TenantMember,
+  type TenantMemberRole,
+  useInviteTenantMember,
+  useTenantMembers,
+  useUpdateTenantMember,
+} from '@/api/tenant-members'
+import { DataTable } from '@/components/data-table/DataTable'
+import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header'
+import { InlineEdit } from '@/components/inline-edit/InlineEdit'
+import { StatusBadge } from '@/components/status/StatusBadge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { useDataTableQuery } from '@/hooks/useDataTableQuery'
+import { getErrorMessage } from '@/lib/error-utils'
+
+const TEAM_ROLE_OPTIONS = ['OWNER', 'ADMIN', 'TECH', 'SALES'] as const
+const TEAM_ROLE_SCHEMA = z.enum(TEAM_ROLE_OPTIONS)
+
+type InviteMemberFormState = {
+  email: string
+  role: TenantMemberRole
+}
+
+const defaultInviteMemberFormState: InviteMemberFormState = {
+  email: '',
+  role: 'TECH',
+}
+
+function normalizeSearch(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function getDisplayName(member: TenantMember) {
+  const fullName = [member.firstName, member.lastName].filter(Boolean).join(' ').trim()
+  return fullName || member.email
+}
+
+function matchesMemberSearch(member: TenantMember, term: string) {
+  if (!term) return true
+
+  const haystack = [
+    member.email,
+    member.firstName ?? '',
+    member.lastName ?? '',
+    getDisplayName(member),
+    member.role,
+    member.isActive ? 'active' : 'inactive',
+  ]
+
+  return haystack.some((entry) => entry.toLowerCase().includes(term))
+}
+
+function sortMembers(
+  members: TenantMember[],
+  sortField?: string,
+  sortDirection: 'asc' | 'desc' = 'asc',
+) {
+  if (!sortField) return members
+
+  const direction = sortDirection === 'desc' ? -1 : 1
+
+  return [...members].sort((left, right) => {
+    if (sortField === 'email') {
+      return direction * left.email.localeCompare(right.email)
+    }
+
+    if (sortField === 'role') {
+      return direction * left.role.localeCompare(right.role)
+    }
+
+    if (sortField === 'isActive') {
+      return direction * (Number(left.isActive) - Number(right.isActive))
+    }
+
+    if (sortField === 'name') {
+      return direction * getDisplayName(left).localeCompare(getDisplayName(right))
+    }
+
+    return 0
+  })
+}
+
+export function TeamSettingsTab() {
+  const { queryParams, setPagination, ...tableState } = useDataTableQuery({ defaultPageSize: 10 })
+  const { data: responseData, error, isLoading, refetch } = useTenantMembers({
+    includeInactive: true,
+    limit: 100,
+  })
+  const inviteMutation = useInviteTenantMember()
+  const updateMutation = useUpdateTenantMember()
+
+  const [inviteOpen, setInviteOpen] = React.useState(false)
+  const [inviteFormState, setInviteFormState] = React.useState<InviteMemberFormState>(defaultInviteMemberFormState)
+  const [selectedMember, setSelectedMember] = React.useState<TenantMember | null>(null)
+  const [sheetOpen, setSheetOpen] = React.useState(false)
+
+  const members = React.useMemo(() => responseData?.data ?? [], [responseData?.data])
+
+  const filteredMembers = React.useMemo(() => {
+    const term = normalizeSearch(queryParams.search ?? '')
+    return members.filter((member) => matchesMemberSearch(member, term))
+  }, [members, queryParams.search])
+
+  const sortedMembers = React.useMemo(
+    () => sortMembers(filteredMembers, queryParams.sortField, queryParams.sortDirection),
+    [filteredMembers, queryParams.sortDirection, queryParams.sortField],
+  )
+
+  const pageSize = queryParams.pageSize
+  const pageCount = Math.max(1, Math.ceil(sortedMembers.length / pageSize))
+  const currentPage = Math.min(queryParams.page, pageCount)
+
+  React.useEffect(() => {
+    if (queryParams.page <= pageCount) return
+
+    setPagination((previous) => ({
+      ...previous,
+      pageIndex: pageCount - 1,
+    }))
+  }, [pageCount, queryParams.page, setPagination])
+
+  const pageStart = (currentPage - 1) * pageSize
+  const pagedMembers = sortedMembers.slice(pageStart, pageStart + pageSize)
+
+  const handleInvite = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    try {
+      await inviteMutation.mutateAsync({
+        email: inviteFormState.email.trim().toLowerCase(),
+        role: inviteFormState.role,
+      })
+      toast.success('Member invited')
+      setInviteFormState(defaultInviteMemberFormState)
+      setInviteOpen(false)
+    } catch (inviteError: unknown) {
+      toast.error(getErrorMessage(inviteError, 'Failed to invite team member'))
+    }
+  }
+
+  const handleToggleActive = async (member: TenantMember) => {
+    try {
+      const updatedMember = await updateMutation.mutateAsync({
+        id: member.id,
+        data: { isActive: !member.isActive },
+      })
+
+      toast.success(updatedMember.isActive ? 'Member reactivated' : 'Member deactivated')
+      setSelectedMember(updatedMember)
+    } catch (updateError: unknown) {
+      toast.error(getErrorMessage(updateError, 'Failed to update member status'))
+    }
+  }
+
+  const columns = React.useMemo<ColumnDef<TenantMember>[]>(
+    () => [
+      {
+        id: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        cell: ({ row }) => (
+          <div>
+            <div className='font-medium'>{getDisplayName(row.original)}</div>
+            <div className='text-xs text-slate-500'>{row.original.email}</div>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'role',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Role' />,
+      },
+      {
+        accessorKey: 'isActive',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        cell: ({ row }) => (
+          <StatusBadge status={row.original.isActive ? 'ACTIVE' : 'INACTIVE'} />
+        ),
+      },
+    ],
+    [],
+  )
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h3 className='text-lg font-medium'>Team</h3>
+          <p className='text-sm text-slate-500'>Invite tenant users and manage their membership roles.</p>
+        </div>
+        <Button onClick={() => setInviteOpen(true)}>
+          + Member
+        </Button>
+      </div>
+
+      {error ? (
+        <div className='rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700'>
+          <div className='flex items-center justify-between gap-4'>
+            <span>{getErrorMessage(error, 'Failed to load team members')}</span>
+            <Button variant='outline' size='sm' onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <DataTable
+        columns={columns}
+        data={pagedMembers}
+        pageCount={pageCount}
+        isLoading={isLoading}
+        searchPlaceholder='Search team members...'
+        setPagination={setPagination}
+        onRowClick={(member) => {
+          setSelectedMember(member)
+          setSheetOpen(true)
+        }}
+        {...tableState}
+      />
+
+      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Invite Member</DialogTitle>
+            <DialogDescription>
+              Create or reactivate a tenant membership and synchronize the user claims immediately.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleInvite} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='team-invite-email'>Email</Label>
+              <Input
+                id='team-invite-email'
+                type='email'
+                value={inviteFormState.email}
+                onChange={(event) => setInviteFormState((previous) => ({
+                  ...previous,
+                  email: event.target.value,
+                }))}
+                placeholder='tech@autocore.com'
+                required
+              />
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='team-invite-role'>Role</Label>
+              <Select
+                value={inviteFormState.role}
+                onValueChange={(nextRole) => setInviteFormState((previous) => ({
+                  ...previous,
+                  role: nextRole as TenantMemberRole,
+                }))}
+              >
+                <SelectTrigger id='team-invite-role'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TEAM_ROLE_OPTIONS.map((role) => (
+                    <SelectItem key={role} value={role}>
+                      {role}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <DialogFooter>
+              <Button type='submit' disabled={inviteMutation.isPending}>
+                Invite Member
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side='right' className='w-full sm:max-w-xl'>
+          <SheetHeader className='mb-6'>
+            <SheetTitle>Member Details</SheetTitle>
+            <SheetDescription>
+              Update a role or deactivate access. Security-sensitive changes force a claims refresh.
+            </SheetDescription>
+          </SheetHeader>
+
+          {selectedMember ? (
+            <div className='space-y-6'>
+              <div className='space-y-1'>
+                <p className='text-sm font-medium text-slate-900'>{getDisplayName(selectedMember)}</p>
+                <p className='text-sm text-slate-500'>{selectedMember.email}</p>
+              </div>
+
+              <div className='space-y-2'>
+                <Label>Role</Label>
+                <InlineEdit
+                  value={selectedMember.role}
+                  schema={TEAM_ROLE_SCHEMA}
+                  ariaLabel='Tenant member role'
+                  onSave={async (nextRole) => {
+                    const normalizedRole = nextRole.trim().toUpperCase() as TenantMemberRole
+                    const updatedMember = await updateMutation.mutateAsync({
+                      id: selectedMember.id,
+                      data: { role: normalizedRole },
+                    })
+                    setSelectedMember(updatedMember)
+                    toast.success('Member role updated')
+                  }}
+                />
+                <p className='text-xs text-slate-500'>Allowed values: OWNER, ADMIN, TECH, SALES.</p>
+              </div>
+
+              <div className='space-y-2'>
+                <Label>Status</Label>
+                <StatusBadge status={selectedMember.isActive ? 'ACTIVE' : 'INACTIVE'} />
+              </div>
+
+              <SheetFooter>
+                <Button
+                  variant={selectedMember.isActive ? 'destructive' : 'default'}
+                  onClick={() => void handleToggleActive(selectedMember)}
+                  disabled={updateMutation.isPending}
+                >
+                  {selectedMember.isActive ? 'Deactivate Member' : 'Reactivate Member'}
+                </Button>
+              </SheetFooter>
+            </div>
+          ) : null}
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}

--- a/apps/core-web/src/components/ui/PageLoader.tsx
+++ b/apps/core-web/src/components/ui/PageLoader.tsx
@@ -1,0 +1,38 @@
+import { motion } from 'framer-motion'
+
+export function PageLoader() {
+  return (
+    <div className="flex min-h-[50vh] w-full flex-col items-center justify-center space-y-4">
+      <motion.div
+        initial={{ opacity: 0.5, scale: 0.95 }}
+        animate={{ 
+          opacity: [0.5, 1, 0.5],
+          scale: [0.95, 1, 0.95]
+        }}
+        transition={{
+          duration: 2,
+          repeat: Infinity,
+          ease: "easeInOut"
+        }}
+        className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-950 text-xl font-bold tracking-tighter text-white shadow-xl"
+      >
+        ACP
+      </motion.div>
+      <div className="flex flex-col items-center space-y-1">
+        <p className="text-sm font-medium text-slate-600">Loading module...</p>
+        <div className="h-1 w-24 overflow-hidden rounded-full bg-slate-200">
+          <motion.div
+            initial={{ x: "-100%" }}
+            animate={{ x: "100%" }}
+            transition={{
+              duration: 1.5,
+              repeat: Infinity,
+              ease: "linear"
+            }}
+            className="h-full w-1/2 bg-slate-950"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/core-web/src/components/workshop/WorkshopOrderIntakeDialog.test.tsx
+++ b/apps/core-web/src/components/workshop/WorkshopOrderIntakeDialog.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as workshopApi from '@/api/workshop'
+import { toast } from 'sonner'
+import { WorkshopOrderIntakeDialog } from './WorkshopOrderIntakeDialog'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@/api/workshop')
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+describe('WorkshopOrderIntakeDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    ;(workshopApi.useWorkshopSearch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        data: {
+          vehicles: [
+            {
+              id: 'vehicle-1',
+              tenant_id: 'tenant-1',
+              make: 'Volkswagen',
+              model: 'Golf VII',
+              year: 2018,
+              vin: 'VWZZZ12345678901',
+              plate: 'W-12345AB',
+              customer: {
+                id: 'customer-1',
+                first_name: 'Max',
+                last_name: 'Mustermann',
+                type: 'PRIVATE',
+              },
+            },
+          ],
+          customers: [],
+        },
+        meta: {
+          total: 1,
+          page: 1,
+          limit: 100,
+          totalPages: 1,
+        },
+      },
+      isLoading: false,
+    })
+
+    ;(workshopApi.useRegisterIntake as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })
+
+    ;(workshopApi.useCreateWorkshopOrder as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      mutateAsync: vi.fn().mockRejectedValue(new Error('Finance settings update failed')),
+      isPending: false,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows the backend error message when workshop order creation fails', async () => {
+    render(<WorkshopOrderIntakeDialog open onOpenChange={vi.fn()} />)
+
+    expect(
+      screen.getByText('Search for an existing vehicle or register a new vehicle before creating the workshop order.'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /2018 Volkswagen Golf VII/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Finance settings update failed')
+    })
+  })
+})

--- a/apps/core-web/src/components/workshop/WorkshopOrderIntakeDialog.tsx
+++ b/apps/core-web/src/components/workshop/WorkshopOrderIntakeDialog.tsx
@@ -4,7 +4,13 @@ import { useCreateWorkshopOrder, useRegisterIntake, useWorkshopSearch } from '@/
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
@@ -135,13 +141,13 @@ export function WorkshopOrderIntakeDialog({ open, onOpenChange }: WorkshopOrderI
           return
         }
 
-      const order = await createOrder.mutateAsync({
-        customerId: selectedVehicle.customer.id,
-        vehicleId: selectedVehicle.id,
-        odometer: Number(odometer),
-        fuelLevel: Number(fuelLevel),
-        reportedIssue: notes || undefined,
-      })
+        const order = await createOrder.mutateAsync({
+          customerId: selectedVehicle.customer.id,
+          vehicleId: selectedVehicle.id,
+          odometer: Number(odometer),
+          fuelLevel: Number(fuelLevel),
+          reportedIssue: notes || undefined,
+        })
 
         toast.success('Workshop order created')
         handleDialogOpenChange(false)
@@ -187,8 +193,8 @@ export function WorkshopOrderIntakeDialog({ open, onOpenChange }: WorkshopOrderI
       toast.success('Workshop order created')
       handleDialogOpenChange(false)
       navigate(`/workshop/orders/${order.id}`)
-    } catch {
-      toast.error('Failed to create workshop order')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create workshop order')
     }
   }
 
@@ -197,6 +203,9 @@ export function WorkshopOrderIntakeDialog({ open, onOpenChange }: WorkshopOrderI
       <DialogContent className="sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>Create Workshop Order</DialogTitle>
+          <DialogDescription>
+            Search for an existing vehicle or register a new vehicle before creating the workshop order.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.test.tsx
+++ b/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.test.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, render, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { RealtimeDashboardSyncProvider } from './RealtimeDashboardSyncProvider'
+import {
+  RealtimeDashboardSyncProvider,
+  resolveRealtimeConnection,
+} from './RealtimeDashboardSyncProvider'
 import { AUTH_CLAIMS_UPDATED_EVENT } from './types'
 
 const mocks = vi.hoisted(() => {
@@ -81,6 +84,30 @@ describe('RealtimeDashboardSyncProvider', () => {
     vi.clearAllMocks()
   })
 
+  it('uses the dedicated dev socket proxy path when only the browser origin is available', () => {
+    expect(
+      resolveRealtimeConnection({
+        apiBaseUrl: '',
+        currentOrigin: 'http://localhost:5173',
+      }),
+    ).toEqual({
+      url: 'http://localhost:5173/dashboard-realtime',
+      path: '/socket.io',
+    })
+  })
+
+  it('uses the backend socket path when an API base URL is configured', () => {
+    expect(
+      resolveRealtimeConnection({
+        apiBaseUrl: 'http://127.0.0.1:3000',
+        currentOrigin: 'http://localhost:5173',
+      }),
+    ).toEqual({
+      url: 'http://127.0.0.1:3000/dashboard-realtime',
+      path: '/api/socket.io',
+    })
+  })
+
   it('refreshes claims and invalidates active queries when auth claims change', async () => {
     const queryClient = createQueryClient()
     const invalidateQueries = vi
@@ -94,6 +121,7 @@ describe('RealtimeDashboardSyncProvider', () => {
         'http://127.0.0.1:3000/dashboard-realtime',
         expect.objectContaining({
           auth: { token: 'initial-token' },
+          path: '/api/socket.io',
         }),
       )
     })

--- a/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.test.tsx
+++ b/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RealtimeDashboardSyncProvider } from './RealtimeDashboardSyncProvider'
+import { AUTH_CLAIMS_UPDATED_EVENT } from './types'
+
+const mocks = vi.hoisted(() => {
+  const socket = {
+    on: vi.fn(),
+    off: vi.fn(),
+    disconnect: vi.fn(),
+  }
+
+  return {
+    io: vi.fn(() => socket),
+    socket,
+    useAuth: vi.fn(),
+    currentUser: {
+      getIdToken: vi.fn(),
+    },
+  }
+})
+
+vi.mock('socket.io-client', () => ({
+  io: mocks.io,
+}))
+
+vi.mock('@/api/client', () => ({
+  API_BASE_URL: 'http://127.0.0.1:3000',
+}))
+
+vi.mock('@/auth/AuthProvider', () => ({
+  useAuth: mocks.useAuth,
+}))
+
+vi.mock('@/lib/firebase', () => ({
+  firebaseAuth: {
+    currentUser: mocks.currentUser,
+  },
+  firebaseConfigMissing: false,
+}))
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <RealtimeDashboardSyncProvider>{children}</RealtimeDashboardSyncProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('RealtimeDashboardSyncProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    const user = {
+      uid: 'user-1',
+      email: 'admin@autocore.com',
+      displayName: 'Admin',
+      getIdToken: vi.fn().mockResolvedValue('initial-token'),
+      getIdTokenResult: vi.fn(),
+    }
+
+    mocks.currentUser.getIdToken.mockResolvedValue('refreshed-token')
+    mocks.useAuth.mockReturnValue({
+      user,
+      signOutUser: vi.fn().mockResolvedValue(undefined),
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('refreshes claims and invalidates active queries when auth claims change', async () => {
+    const queryClient = createQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue(undefined)
+
+    render(<div />, { wrapper: createWrapper(queryClient) })
+
+    await waitFor(() => {
+      expect(mocks.io).toHaveBeenCalledWith(
+        'http://127.0.0.1:3000/dashboard-realtime',
+        expect.objectContaining({
+          auth: { token: 'initial-token' },
+        }),
+      )
+    })
+
+    const claimsUpdatedHandler = mocks.socket.on.mock.calls.find(
+      ([eventName]) => eventName === AUTH_CLAIMS_UPDATED_EVENT,
+    )?.[1] as ((payload: unknown) => void) | undefined
+
+    expect(claimsUpdatedHandler).toBeDefined()
+
+    await act(async () => {
+      claimsUpdatedHandler?.({
+        reason: 'membership-updated',
+        timestamp: '2026-04-23T15:00:00.000Z',
+      })
+    })
+
+    await waitFor(() => {
+      expect(mocks.currentUser.getIdToken).toHaveBeenCalledWith(true)
+      expect(invalidateQueries).toHaveBeenCalledWith({ refetchType: 'active' })
+    })
+  })
+})

--- a/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.tsx
+++ b/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.tsx
@@ -3,10 +3,14 @@ import { useQueryClient } from '@tanstack/react-query'
 import { io } from 'socket.io-client'
 import type { Socket } from 'socket.io-client'
 import { API_BASE_URL } from '@/api/client'
+import { useAuth } from '@/auth/AuthProvider'
 import { getDashboardSourceKeysForEntityType, isEntityUpdatedPayload } from '@/features/realtime/dashboard-entity-map'
-import { ENTITY_UPDATED_EVENT } from '@/features/realtime/types'
+import {
+  AUTH_CLAIMS_UPDATED_EVENT,
+  ENTITY_UPDATED_EVENT,
+  isClaimsUpdatedPayload,
+} from '@/features/realtime/types'
 import { firebaseAuth } from '@/lib/firebase'
-import { onAuthStateChanged } from 'firebase/auth'
 
 function resolveRealtimeBaseUrl(): string | undefined {
   if (API_BASE_URL) return API_BASE_URL
@@ -21,19 +25,33 @@ type RealtimeDashboardSyncProviderProps = {
 
 export function RealtimeDashboardSyncProvider({ children }: RealtimeDashboardSyncProviderProps) {
   const queryClient = useQueryClient()
+  const { signOutUser, user } = useAuth()
   const [token, setToken] = React.useState<string | null>(null)
 
   React.useEffect(() => {
-    if (!firebaseAuth) return
-    return onAuthStateChanged(firebaseAuth, async (user) => {
-      if (user) {
-        const idToken = await user.getIdToken()
+    let active = true
+
+    if (!user) {
+      setToken(null)
+      return () => {
+        active = false
+      }
+    }
+
+    void user.getIdToken().then((idToken) => {
+      if (active) {
         setToken(idToken)
-      } else {
+      }
+    }).catch(() => {
+      if (active) {
         setToken(null)
       }
     })
-  }, [])
+
+    return () => {
+      active = false
+    }
+  }, [user])
 
   React.useEffect(() => {
     const baseUrl = resolveRealtimeBaseUrl()
@@ -58,13 +76,33 @@ export function RealtimeDashboardSyncProvider({ children }: RealtimeDashboardSyn
       }
     }
 
+    const onClaimsUpdated = (payload: unknown) => {
+      if (!isClaimsUpdatedPayload(payload)) return
+
+      void (async () => {
+        const currentUser = firebaseAuth?.currentUser
+        if (!currentUser) return
+
+        try {
+          const refreshedToken = await currentUser.getIdToken(true)
+          setToken(refreshedToken)
+          await queryClient.invalidateQueries({ refetchType: 'active' })
+        } catch (error) {
+          console.error('Failed to refresh claims after realtime auth update event.', error)
+          await signOutUser()
+        }
+      })()
+    }
+
     socket.on(ENTITY_UPDATED_EVENT, onEntityUpdated)
+    socket.on(AUTH_CLAIMS_UPDATED_EVENT, onClaimsUpdated)
 
     return () => {
       socket.off(ENTITY_UPDATED_EVENT, onEntityUpdated)
+      socket.off(AUTH_CLAIMS_UPDATED_EVENT, onClaimsUpdated)
       socket.disconnect()
     }
-  }, [queryClient, token])
+  }, [queryClient, signOutUser, token])
 
   return <>{children}</>
 }

--- a/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.tsx
+++ b/apps/core-web/src/features/realtime/RealtimeDashboardSyncProvider.tsx
@@ -12,9 +12,36 @@ import {
 } from '@/features/realtime/types'
 import { firebaseAuth } from '@/lib/firebase'
 
-function resolveRealtimeBaseUrl(): string | undefined {
-  if (API_BASE_URL) return API_BASE_URL
-  if (typeof window !== 'undefined' && window.location.origin) return window.location.origin
+type RealtimeConnection = {
+  url: string
+  path: string
+}
+
+type ResolveRealtimeConnectionOptions = {
+  apiBaseUrl?: string
+  currentOrigin?: string
+  isDev?: boolean
+}
+
+export function resolveRealtimeConnection({
+  apiBaseUrl = API_BASE_URL,
+  currentOrigin = typeof window !== 'undefined' ? window.location.origin : undefined,
+  isDev = import.meta.env.DEV,
+}: ResolveRealtimeConnectionOptions = {}): RealtimeConnection | undefined {
+  if (apiBaseUrl) {
+    return {
+      url: `${apiBaseUrl}/dashboard-realtime`,
+      path: '/api/socket.io',
+    }
+  }
+
+  if (currentOrigin) {
+    return {
+      url: `${currentOrigin}/dashboard-realtime`,
+      path: isDev ? '/socket.io' : '/api/socket.io',
+    }
+  }
+
   console.warn('Unable to resolve realtime base URL: neither API_BASE_URL nor window.location.origin are available.')
   return undefined
 }
@@ -54,11 +81,11 @@ export function RealtimeDashboardSyncProvider({ children }: RealtimeDashboardSyn
   }, [user])
 
   React.useEffect(() => {
-    const baseUrl = resolveRealtimeBaseUrl()
-    if (!baseUrl || !token) return
+    const connection = resolveRealtimeConnection()
+    if (!connection || !token) return
 
-    const socket: Socket = io(`${baseUrl}/dashboard-realtime`, {
-      path: '/api/socket.io',
+    const socket: Socket = io(connection.url, {
+      path: connection.path,
       transports: ['websocket', 'polling'],
       withCredentials: true,
       auth: { token },

--- a/apps/core-web/src/features/realtime/types.ts
+++ b/apps/core-web/src/features/realtime/types.ts
@@ -1,4 +1,5 @@
 export const ENTITY_UPDATED_EVENT = 'entity_updated'
+export const AUTH_CLAIMS_UPDATED_EVENT = 'auth:claims_updated'
 
 export type RealtimeEntityType =
   | 'PURCHASE_ORDER'
@@ -17,4 +18,17 @@ export interface EntityUpdatedPayload {
   action: RealtimeEntityAction
   entityId?: string
   timestamp: string
+}
+
+export interface ClaimsUpdatedPayload {
+  reason: 'membership-updated'
+  timestamp: string
+}
+
+export function isClaimsUpdatedPayload(payload: unknown): payload is ClaimsUpdatedPayload {
+  if (!payload || typeof payload !== 'object') return false
+
+  const value = payload as Partial<ClaimsUpdatedPayload>
+
+  return value.reason === 'membership-updated' && typeof value.timestamp === 'string'
 }

--- a/apps/core-web/src/pages/SettingsPage.test.tsx
+++ b/apps/core-web/src/pages/SettingsPage.test.tsx
@@ -151,6 +151,14 @@ vi.mock('@/api/locations', () => ({
   useDeleteLocation: () => deleteLocationResult,
 }))
 
+vi.mock('@/auth/AuthProvider', () => ({
+  useAuth: () => ({
+    claims: {
+      role: 'ADMIN',
+    },
+  }),
+}))
+
 vi.mock('@/components/RevenueGroupTable', () => ({
   RevenueGroupTable: () => <div>Revenue groups table</div>,
 }))
@@ -179,6 +187,10 @@ vi.mock('@/components/settings/BaySettingsTab', () => ({
   BaySettingsTab: () => <div>Bays tab content</div>,
 }))
 
+vi.mock('@/components/settings/TeamSettingsTab', () => ({
+  TeamSettingsTab: () => <div>Team tab content</div>,
+}))
+
 function LocationProbe() {
   const location = useLocation()
   return <div data-testid='location-search'>{location.search}</div>
@@ -204,6 +216,7 @@ describe('SettingsPage tab integration', () => {
 
     expect(screen.getByRole('tab', { name: 'Employees' })).toBeVisible()
     expect(screen.getByRole('tab', { name: 'Bays' })).toBeVisible()
+    expect(screen.getByRole('tab', { name: 'Team' })).toBeVisible()
     expect(screen.getByText('Employees tab content')).toBeVisible()
     expect(screen.getByTestId('location-search')).toHaveTextContent('?tab=employees')
 

--- a/apps/core-web/src/pages/SettingsPage.tsx
+++ b/apps/core-web/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns"
 import { Loader2, Save, AlertTriangle } from "lucide-react"
 import { toast } from "sonner"
 
+import { useAuth } from "@/auth/AuthProvider"
 import { useFinanceSettings, useUpdateFinanceSettings, useRevenueGroups } from "@/api/useFinance"
 import { useBrands } from "@/api/brands"
 import { useLocationTree, useCreateLocation, useDeleteLocation, type StorageLocation, type LocationType } from "@/api/locations"
@@ -31,6 +32,7 @@ import { AddBrandDialog } from "@/components/AddBrandDialog"
 import { LaborCategoriesTab } from "@/components/labor/LaborCategoriesTab"
 import { EmployeeSettingsTab } from "@/components/settings/EmployeeSettingsTab"
 import { BaySettingsTab } from "@/components/settings/BaySettingsTab"
+import { TeamSettingsTab } from "@/components/settings/TeamSettingsTab"
 import { cn } from "@/lib/utils"
 import { getErrorMessage } from "@/lib/error-utils"
 import type { Brand } from "@/api/types"
@@ -259,13 +261,16 @@ function StorageLocationsTab() {
 }
 
 // ─── Main Settings Page ────────────────────────────────────────────────────
-const VALID_TABS = ["finance", "revenue-groups", "brands", "locations", "employees", "bays", "labor"] as const
+const VALID_TABS = ["finance", "revenue-groups", "brands", "locations", "employees", "bays", "labor", "team"] as const
 type SettingsTab = typeof VALID_TABS[number]
 
 export default function SettingsPage() {
+    const { claims } = useAuth()
     const [searchParams, setSearchParams] = useSearchParams()
     const rawTab = searchParams.get("tab")
-    const activeTab: SettingsTab = VALID_TABS.includes(rawTab as SettingsTab) ? (rawTab as SettingsTab) : "finance"
+    const canManageTeam = claims?.role === 'ADMIN' || claims?.role === 'OWNER'
+    const requestedTab = VALID_TABS.includes(rawTab as SettingsTab) ? (rawTab as SettingsTab) : "finance"
+    const activeTab: SettingsTab = requestedTab === 'team' && !canManageTeam ? 'finance' : requestedTab
 
     // ── Finance state ──
     const { data: settings, isLoading } = useFinanceSettings()
@@ -336,7 +341,7 @@ export default function SettingsPage() {
             </div>
 
             <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
-                <TabsList className="grid w-full grid-cols-7 max-w-[1100px]">
+                <TabsList className={cn("grid w-full max-w-[1100px]", canManageTeam ? 'grid-cols-8' : 'grid-cols-7')}>
                     <TabsTrigger value="finance">Finance</TabsTrigger>
                     <TabsTrigger value="revenue-groups">Revenue Groups</TabsTrigger>
                     <TabsTrigger value="brands">Brands</TabsTrigger>
@@ -344,6 +349,7 @@ export default function SettingsPage() {
                     <TabsTrigger value="employees">Employees</TabsTrigger>
                     <TabsTrigger value="bays">Bays</TabsTrigger>
                     <TabsTrigger value="labor">Labor</TabsTrigger>
+                    {canManageTeam ? <TabsTrigger value="team">Team</TabsTrigger> : null}
                 </TabsList>
 
                 {/* ── Finance Tab ── */}
@@ -464,6 +470,13 @@ export default function SettingsPage() {
                 <TabsContent value="labor" className="space-y-6">
                     <LaborCategoriesTab />
                 </TabsContent>
+
+                {/* ── Team Tab ── */}
+                {canManageTeam ? (
+                    <TabsContent value="team" className="space-y-6">
+                        <TeamSettingsTab />
+                    </TabsContent>
+                ) : null}
             </Tabs>
 
             {/* Lock Date Alert Dialog */}

--- a/apps/core-web/src/pages/platform/PlatformTenantsPage.test.tsx
+++ b/apps/core-web/src/pages/platform/PlatformTenantsPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { usePlatformTenants } from '@/api/platform-tenants'
+import { useAuth } from '@/auth/AuthProvider'
+import PlatformTenantsPage from './PlatformTenantsPage'
+
+const platformTenantsResult = {
+  data: {
+    data: [
+      {
+        id: 'tenant-1',
+        name: 'North Branch',
+        slug: 'north-branch',
+        plan: 'PREMIUM',
+        isActive: true,
+        memberCount: 7,
+        createdAt: '2026-04-23T10:00:00.000Z',
+        updatedAt: '2026-04-23T10:00:00.000Z',
+      },
+    ],
+    meta: { total: 1, page: 1, limit: 100, totalPages: 1 },
+  },
+  error: null,
+  isLoading: false,
+  refetch: vi.fn(),
+}
+
+vi.mock('@/auth/AuthProvider', () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock('@/api/platform-tenants', () => ({
+  usePlatformTenants: vi.fn(() => platformTenantsResult),
+  useCreatePlatformTenant: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdatePlatformTenant: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+describe('PlatformTenantsPage', () => {
+  it('renders title, data, and top-right + Tenant action for super admins', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      claims: { platformRole: 'SUPER_ADMIN' },
+    } as ReturnType<typeof useAuth>)
+
+    render(
+      <MemoryRouter initialEntries={['/platform/tenants']}>
+        <Routes>
+          <Route path='/platform/tenants' element={<PlatformTenantsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Tenants')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '+ Tenant' })).toBeInTheDocument()
+    expect(screen.getByText('North Branch')).toBeInTheDocument()
+    expect(vi.mocked(usePlatformTenants)).toHaveBeenCalledWith({
+      includeInactive: true,
+      limit: 100,
+    })
+  })
+
+  it('redirects non-super-admin users to the dashboard', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      claims: { role: 'ADMIN' },
+    } as ReturnType<typeof useAuth>)
+
+    render(
+      <MemoryRouter initialEntries={['/platform/tenants']}>
+        <Routes>
+          <Route path='/platform/tenants' element={<PlatformTenantsPage />} />
+          <Route path='/dashboard' element={<div>Dashboard destination</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Dashboard destination')).toBeInTheDocument()
+  })
+})

--- a/apps/core-web/src/pages/platform/PlatformTenantsPage.tsx
+++ b/apps/core-web/src/pages/platform/PlatformTenantsPage.tsx
@@ -1,0 +1,435 @@
+import * as React from 'react'
+import { Navigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { toast } from 'sonner'
+
+import { useAuth } from '@/auth/AuthProvider'
+import {
+  type PlatformTenant,
+  type TenantPlan,
+  useCreatePlatformTenant,
+  usePlatformTenants,
+  useUpdatePlatformTenant,
+} from '@/api/platform-tenants'
+import { DataTable } from '@/components/data-table/DataTable'
+import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header'
+import { StatusBadge } from '@/components/status/StatusBadge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { useDataTableQuery } from '@/hooks/useDataTableQuery'
+import { getErrorMessage } from '@/lib/error-utils'
+
+const TENANT_PLAN_OPTIONS = ['STANDARD', 'PREMIUM', 'ENTERPRISE'] as const
+
+type TenantFormState = {
+  name: string
+  slug: string
+  plan: TenantPlan
+  isActive: 'ACTIVE' | 'INACTIVE'
+}
+
+const defaultTenantFormState: TenantFormState = {
+  name: '',
+  slug: '',
+  plan: 'STANDARD',
+  isActive: 'ACTIVE',
+}
+
+function normalizeSearch(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function matchesTenantSearch(tenant: PlatformTenant, term: string) {
+  if (!term) return true
+
+  const haystack = [
+    tenant.name,
+    tenant.slug,
+    tenant.plan,
+    String(tenant.memberCount),
+    tenant.isActive ? 'active' : 'inactive',
+  ]
+
+  return haystack.some((entry) => entry.toLowerCase().includes(term))
+}
+
+function sortTenants(
+  tenants: PlatformTenant[],
+  sortField?: string,
+  sortDirection: 'asc' | 'desc' = 'asc',
+) {
+  if (!sortField) return tenants
+
+  const direction = sortDirection === 'desc' ? -1 : 1
+
+  return [...tenants].sort((left, right) => {
+    if (sortField === 'name') {
+      return direction * left.name.localeCompare(right.name)
+    }
+
+    if (sortField === 'slug') {
+      return direction * left.slug.localeCompare(right.slug)
+    }
+
+    if (sortField === 'plan') {
+      return direction * left.plan.localeCompare(right.plan)
+    }
+
+    if (sortField === 'memberCount') {
+      return direction * (left.memberCount - right.memberCount)
+    }
+
+    if (sortField === 'isActive') {
+      return direction * (Number(left.isActive) - Number(right.isActive))
+    }
+
+    return 0
+  })
+}
+
+function toEditFormState(tenant: PlatformTenant): TenantFormState {
+  return {
+    name: tenant.name,
+    slug: tenant.slug,
+    plan: tenant.plan,
+    isActive: tenant.isActive ? 'ACTIVE' : 'INACTIVE',
+  }
+}
+
+export default function PlatformTenantsPage() {
+  const { claims } = useAuth()
+  const { queryParams, setPagination, ...tableState } = useDataTableQuery({ defaultPageSize: 10 })
+  const { data: responseData, error, isLoading, refetch } = usePlatformTenants({
+    includeInactive: true,
+    limit: 100,
+  })
+  const createMutation = useCreatePlatformTenant()
+  const updateMutation = useUpdatePlatformTenant()
+
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [createFormState, setCreateFormState] = React.useState<TenantFormState>(defaultTenantFormState)
+  const [selectedTenant, setSelectedTenant] = React.useState<PlatformTenant | null>(null)
+  const [editFormState, setEditFormState] = React.useState<TenantFormState>(defaultTenantFormState)
+  const [sheetOpen, setSheetOpen] = React.useState(false)
+
+  const tenants = React.useMemo(() => responseData?.data ?? [], [responseData?.data])
+
+  const filteredTenants = React.useMemo(() => {
+    const term = normalizeSearch(queryParams.search ?? '')
+    return tenants.filter((tenant) => matchesTenantSearch(tenant, term))
+  }, [tenants, queryParams.search])
+
+  const sortedTenants = React.useMemo(
+    () => sortTenants(filteredTenants, queryParams.sortField, queryParams.sortDirection),
+    [filteredTenants, queryParams.sortDirection, queryParams.sortField],
+  )
+
+  const pageSize = queryParams.pageSize
+  const pageCount = Math.max(1, Math.ceil(sortedTenants.length / pageSize))
+  const currentPage = Math.min(queryParams.page, pageCount)
+
+  React.useEffect(() => {
+    if (queryParams.page <= pageCount) return
+
+    setPagination((previous) => ({
+      ...previous,
+      pageIndex: pageCount - 1,
+    }))
+  }, [pageCount, queryParams.page, setPagination])
+
+  const pageStart = (currentPage - 1) * pageSize
+  const pagedTenants = sortedTenants.slice(pageStart, pageStart + pageSize)
+
+  if (claims?.platformRole !== 'SUPER_ADMIN') {
+    return <Navigate to='/dashboard' replace />
+  }
+
+  const columns = React.useMemo<ColumnDef<PlatformTenant>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
+        cell: ({ row }) => (
+          <div>
+            <div className='font-medium'>{row.original.name}</div>
+            <div className='text-xs text-slate-500'>{row.original.slug}</div>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'plan',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Plan' />,
+      },
+      {
+        accessorKey: 'memberCount',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Members' />,
+      },
+      {
+        accessorKey: 'isActive',
+        header: ({ column }) => <DataTableColumnHeader column={column} title='Status' />,
+        cell: ({ row }) => (
+          <StatusBadge status={row.original.isActive ? 'ACTIVE' : 'INACTIVE'} />
+        ),
+      },
+    ],
+    [],
+  )
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    try {
+      await createMutation.mutateAsync({
+        name: createFormState.name.trim(),
+        slug: createFormState.slug.trim().toLowerCase(),
+        plan: createFormState.plan,
+      })
+      toast.success('Tenant created')
+      setCreateFormState(defaultTenantFormState)
+      setCreateOpen(false)
+    } catch (createError: unknown) {
+      toast.error(getErrorMessage(createError, 'Failed to create tenant'))
+    }
+  }
+
+  const handleSaveTenant = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!selectedTenant) return
+
+    try {
+      const updatedTenant = await updateMutation.mutateAsync({
+        id: selectedTenant.id,
+        data: {
+          name: editFormState.name.trim(),
+          slug: editFormState.slug.trim().toLowerCase(),
+          plan: editFormState.plan,
+          isActive: editFormState.isActive === 'ACTIVE',
+        },
+      })
+
+      toast.success('Tenant updated')
+      setSelectedTenant(updatedTenant)
+      setEditFormState(toEditFormState(updatedTenant))
+    } catch (updateError: unknown) {
+      toast.error(getErrorMessage(updateError, 'Failed to update tenant'))
+    }
+  }
+
+  return (
+    <div className='w-full max-w-7xl mx-auto p-6 space-y-6'>
+      <div className='flex items-center justify-between mb-8'>
+        <div>
+          <h1 className='text-2xl font-semibold tracking-tight'>Tenants</h1>
+          <p className='text-slate-500'>Manage platform tenants, plans, and onboarding state.</p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          + Tenant
+        </Button>
+      </div>
+
+      {error ? (
+        <div className='rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700'>
+          <div className='flex items-center justify-between gap-4'>
+            <span>{getErrorMessage(error, 'Failed to load tenants')}</span>
+            <Button variant='outline' size='sm' onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <DataTable
+        columns={columns}
+        data={pagedTenants}
+        pageCount={pageCount}
+        isLoading={isLoading}
+        searchPlaceholder='Search tenants...'
+        setPagination={setPagination}
+        onRowClick={(tenant) => {
+          setSelectedTenant(tenant)
+          setEditFormState(toEditFormState(tenant))
+          setSheetOpen(true)
+        }}
+        {...tableState}
+      />
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Tenant</DialogTitle>
+            <DialogDescription>
+              This creates the tenant foundation and its default finance settings.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleCreate} className='space-y-4'>
+            <div className='space-y-2'>
+              <Label htmlFor='tenant-name'>Name</Label>
+              <Input
+                id='tenant-name'
+                value={createFormState.name}
+                onChange={(event) => setCreateFormState((previous) => ({
+                  ...previous,
+                  name: event.target.value,
+                }))}
+                required
+              />
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='tenant-slug'>Slug</Label>
+              <Input
+                id='tenant-slug'
+                value={createFormState.slug}
+                onChange={(event) => setCreateFormState((previous) => ({
+                  ...previous,
+                  slug: event.target.value,
+                }))}
+                placeholder='north-branch'
+                required
+              />
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='tenant-plan'>Plan</Label>
+              <Select
+                value={createFormState.plan}
+                onValueChange={(nextPlan) => setCreateFormState((previous) => ({
+                  ...previous,
+                  plan: nextPlan as TenantPlan,
+                }))}
+              >
+                <SelectTrigger id='tenant-plan'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TENANT_PLAN_OPTIONS.map((plan) => (
+                    <SelectItem key={plan} value={plan}>
+                      {plan}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <DialogFooter>
+              <Button type='submit' disabled={createMutation.isPending}>
+                Create Tenant
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side='right' className='w-full sm:max-w-xl'>
+          <SheetHeader className='mb-6'>
+            <SheetTitle>Tenant Details</SheetTitle>
+            <SheetDescription>
+              Update platform metadata and activation state for this tenant.
+            </SheetDescription>
+          </SheetHeader>
+
+          {selectedTenant ? (
+            <form onSubmit={handleSaveTenant} className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='tenant-edit-name'>Name</Label>
+                <Input
+                  id='tenant-edit-name'
+                  value={editFormState.name}
+                  onChange={(event) => setEditFormState((previous) => ({
+                    ...previous,
+                    name: event.target.value,
+                  }))}
+                  required
+                />
+              </div>
+
+              <div className='space-y-2'>
+                <Label htmlFor='tenant-edit-slug'>Slug</Label>
+                <Input
+                  id='tenant-edit-slug'
+                  value={editFormState.slug}
+                  onChange={(event) => setEditFormState((previous) => ({
+                    ...previous,
+                    slug: event.target.value,
+                  }))}
+                  required
+                />
+              </div>
+
+              <div className='space-y-2'>
+                <Label htmlFor='tenant-edit-plan'>Plan</Label>
+                <Select
+                  value={editFormState.plan}
+                  onValueChange={(nextPlan) => setEditFormState((previous) => ({
+                    ...previous,
+                    plan: nextPlan as TenantPlan,
+                  }))}
+                >
+                  <SelectTrigger id='tenant-edit-plan'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TENANT_PLAN_OPTIONS.map((plan) => (
+                      <SelectItem key={plan} value={plan}>
+                        {plan}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className='space-y-2'>
+                <Label htmlFor='tenant-edit-status'>Status</Label>
+                <Select
+                  value={editFormState.isActive}
+                  onValueChange={(nextStatus) => setEditFormState((previous) => ({
+                    ...previous,
+                    isActive: nextStatus as 'ACTIVE' | 'INACTIVE',
+                  }))}
+                >
+                  <SelectTrigger id='tenant-edit-status'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value='ACTIVE'>Active</SelectItem>
+                    <SelectItem value='INACTIVE'>Inactive</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className='rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600'>
+                Current members: {selectedTenant.memberCount}
+              </div>
+
+              <SheetFooter>
+                <Button type='submit' disabled={updateMutation.isPending}>
+                  Save Tenant
+                </Button>
+              </SheetFooter>
+            </form>
+          ) : null}
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}

--- a/apps/core-web/vite.config.ts
+++ b/apps/core-web/vite.config.ts
@@ -11,6 +11,7 @@ const hasSentryUploadCredentials = Boolean(
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, '')
+  const apiProxyTarget = env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:3000'
 
   return {
     plugins: [
@@ -41,8 +42,13 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
+        '/socket.io': {
+          target: apiProxyTarget,
+          ws: true,
+          rewrite: (socketPath) => socketPath.replace(/^\/socket\.io/, '/api/socket.io'),
+        },
         '/api': {
-          target: env.VITE_API_PROXY_TARGET || 'http://127.0.0.1:3000',
+          target: apiProxyTarget,
           changeOrigin: true,
           ws: true,
         },

--- a/apps/core-web/vite.config.ts
+++ b/apps/core-web/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
     ],
     build: {
       sourcemap: 'hidden',
+      chunkSizeWarningLimit: 750,
     },
     resolve: {
       alias: {

--- a/docs/deletion-policy.md
+++ b/docs/deletion-policy.md
@@ -31,6 +31,9 @@ This document defines when deletion is allowed in Auto Core Platform.
 | InvoiceItem | No direct delete | Managed by parent `Invoice` lifecycle. |
 | PurchaseInvoice | No | Financial document; use status lifecycle (`DRAFT`, `POSTED`, `PAID`). |
 | PurchaseInvoiceLine | No direct delete | Managed by parent `PurchaseInvoice` lifecycle. |
+| User | No direct delete | Identity record persists for auditability; deactivate memberships instead of deleting the user. |
+| TenantMember | Conditional (soft-disable preferred) | Set `is_active = false` first; hard delete only when no audit or access-history requirement remains. |
+| PlatformAdmin | No direct delete | Remove elevated claims and deactivate the record instead of deleting it. |
 | Employee | Conditional (future API) | DB FK is `ON DELETE SET NULL` from `WorkshopOrder.mechanic_id`; if delete API is added, default to deactivation (`is_active = false`) and allow hard delete only under explicit business rules. |
 | Bay | Conditional (future API) | DB FK is `ON DELETE SET NULL` from `WorkshopOrder.bay_id`; if delete API is added, default to deactivation (`is_active = false`) and allow hard delete only under explicit business rules. |
 | WorkshopOrder | Conditional (future API) | Prefer cancel/archive flow; if delete is added, limit to pre-work intake states only. |

--- a/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
+++ b/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
@@ -181,6 +181,7 @@ This real-time claims refresh path is mandatory for role downgrades, membership 
 **Administrative modules introduced by this decision:**
 
 - `PlatformAdminModule` for internal `Tenant` CRUD, protected by a `SuperAdminGuard` backed by a platform-level claim. If a short-lived bootstrap fallback is ever required before that claim exists, it must use an environment-configured admin-email allowlist with a documented expiration date and removal criterion before release; hardcoded identities are forbidden.
+- Bootstrapping the first platform administrator, or creating a persistent platform-admin record outside the normal authenticated admin flow, must happen through a dedicated deployment-scoped Prisma seed / CLI script that runs with direct production environment access and uses Firebase Admin plus Prisma directly. This capability must not be exposed as an HTTP endpoint.
 - `TenantMemberModule` for invite, list, update, and deactivate membership workflows.
 - `POST /tenant-members/invite` resolves or provisions the Firebase user, writes the `User`, writes the `TenantMember`, and synchronizes custom claims.
 - `PATCH /tenant-members/:id` (or equivalent role / activation endpoint) must synchronize claims, revoke Firebase refresh tokens for security-sensitive changes, and emit `auth:claims_updated` to the affected user's private socket room immediately after the membership mutation succeeds.
@@ -399,6 +400,8 @@ Introduce the relational and administrative foundation required to manage tenant
 2. **Backend API Development (NestJS)**
   - Create `PlatformAdminModule` with internal `Tenant` CRUD endpoints.
   - Protect tenant CRUD routes with `SuperAdminGuard` using a system-level claim. If a bootstrap fallback is needed temporarily, it must use an environment-configured allowlist of platform-admin emails with an explicit expiration date and removal criterion.
+  - The initial platform-admin bootstrap path must bypass HTTP entirely. Provide a dedicated Prisma seed / CLI command (for example `npm --prefix apps/core-api run db:seed:platform-admin -- --email=founder@autocore.com`) that is run only from a trusted deployment or operations context with direct database credentials.
+  - The seed / CLI bootstrap writes any persistent platform-admin record required by the design, uses Prisma directly, calls Firebase Admin to synchronize the corresponding claims, and is never invokable by an end-user request.
   - Create `TenantMemberModule` with `POST /tenant-members/invite` and supporting list/update endpoints.
   - `TenantMember` mutations (invite, role change, deactivate, reactivate, tenant reassignment) must trigger the same side effect chain in order: persist PostgreSQL state, synchronize Firebase Custom Claims, revoke Firebase refresh tokens when the change is security-sensitive, then emit `auth:claims_updated` to the affected user's private socket room.
   - Invite workflow:
@@ -434,6 +437,7 @@ Introduce the relational and administrative foundation required to manage tenant
 
 - [ ] Prisma migrations run successfully without data loss.
 - [ ] NestJS successfully synchronizes a membership change in PostgreSQL to Firebase Custom Claims.
+- [ ] Initial platform-admin bootstrap is performed only through a deployment-scoped Prisma seed / CLI path, not through a public HTTP endpoint.
 - [ ] Security-sensitive membership changes revoke Firebase refresh tokens after claims are synchronized.
 - [ ] `TenantMember` role / activation changes emit `auth:claims_updated` to the affected user's private socket room.
 - [ ] A connected frontend session silently forces a token refresh, updates the auth context, and invalidates TanStack Query caches when `auth:claims_updated` is received.

--- a/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
+++ b/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
@@ -167,14 +167,20 @@ The `tenantId` claim is still extracted and validated by `JwtAuthGuard` on every
 
 1. Backend writes `User` and `TenantMember` state to PostgreSQL.
 2. Backend immediately calls the Firebase Admin SDK to update the user's custom claims, e.g. `{ tenantId: "xyz", role: "ADMIN" }`.
-3. Client obtains a refreshed Firebase ID token on the next token refresh or sign-in.
-4. Existing `auth.service.ts` logic continues to trust the token claims for request-time authorization without an extra membership database lookup.
+3. Backend emits `auth:claims_updated` to the affected user's private Socket.io room (for example `user_<userId>` or `user_<firebaseUid>`), not to the whole tenant room.
+4. The React 19 frontend listens for `auth:claims_updated` and silently forces a Firebase token refresh via `currentUser.getIdToken(true)`.
+5. After the forced refresh, the frontend updates the global auth context and invalidates TanStack Query caches so role-sensitive screens re-resolve immediately.
+6. If the forced refresh fails or the refreshed token no longer carries an active `tenantId` / `role` pair, the frontend clears auth state and signs the user out of privileged screens.
+7. Existing `auth.service.ts` logic continues to trust the token claims for request-time authorization without an extra membership database lookup.
+
+This real-time claims refresh path is mandatory for role downgrades, membership deactivation, tenant removal, and any other `TenantMember` mutation that changes effective access.
 
 **Administrative modules introduced by this decision:**
 
 - `PlatformAdminModule` for internal `Tenant` CRUD, protected by a `SuperAdminGuard` backed by a platform-level claim or a temporary hardcoded admin-email allowlist.
 - `TenantMemberModule` for invite, list, update, and deactivate membership workflows.
 - `POST /tenant-members/invite` resolves or provisions the Firebase user, writes the `User`, writes the `TenantMember`, and synchronizes custom claims.
+- `PATCH /tenant-members/:id` (or equivalent role / activation endpoint) must synchronize claims and emit `auth:claims_updated` to the affected user's private socket room immediately after the membership mutation succeeds.
 - Frontend admin routes:
   - `/platform/tenants` for Super Admin tenant management.
   - `/settings/team` for tenant-scoped team management.
@@ -330,7 +336,7 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 
 | Existing ADR | Impact |
 |---|---|
-| **ADR-0001** — Prisma `$extends` Real-Time Sync | The tenant isolation extension is chained before the real-time extension. **WebSocket event scoping is resolved via Socket.io Rooms.** On authenticated socket connection the gateway executes `client.join('tenant_' + jwt.tenantId)`. The `createDashboardRealtimeExtension` reads `tenantId` from the ALS context (already populated by `TenantMiddleware`) and emits to the room: `this.server.to('tenant_' + tenantId).emit('entityUpdated', payload)` instead of the current global `this.server.emit(...)`. Real-time events in the WebSocket payload do not carry `tenant_id` — tenancy is enforced by room membership at the socket layer. |
+| **ADR-0001** — Prisma `$extends` Real-Time Sync | The tenant isolation extension is chained before the real-time extension. **WebSocket event scoping is resolved via Socket.io Rooms.** On authenticated socket connection the gateway executes both `client.join('tenant_' + jwt.tenantId)` for tenant-scoped entity events and `client.join('user_' + jwt.sub)` (or equivalent Firebase UID room) for private auth refresh events. The `createDashboardRealtimeExtension` reads `tenantId` from the ALS context (already populated by `TenantMiddleware`) and emits to the room: `this.server.to('tenant_' + tenantId).emit('entityUpdated', payload)` instead of the current global `this.server.emit(...)`. Separately, membership-changing application services emit `auth:claims_updated` only to the affected user room so the frontend can force `getIdToken(true)`, refresh auth state, and invalidate TanStack Query caches without broadcasting auth churn tenant-wide. Real-time events in the WebSocket payload do not carry `tenant_id` — tenancy is enforced by room membership at the socket layer. |
 | **ADR-0002** — Ledger-Based Inventory | `InventoryTransaction` gains `tenant_id`. The ledger pattern (append-only, never direct `InventoryStock` mutation) is unchanged. Ledger reads and writes are automatically scoped by the isolation extension. |
 | **ADR-0003** — Fiscal Lock Date | `FinanceSettings` becomes a per-tenant singleton. The lock-date check must be loaded with `findFirst({ where: { tenant_id: ctx } })`. The isolation extension handles this automatically. |
 | **ADR-0004** — Invoice Snapshotting | Snapshot fields (`revenue_group_name`, `unit_price`) are tenant-agnostic values stored on immutable `InvoiceItem` rows. No changes required beyond the `tenant_id` column addition. |
@@ -351,6 +357,7 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 - **Audit trail is tenant-scoped by default.** `InventoryTransaction`, `InvoiceSequence`, and all append-only tables carry `tenant_id`, so per-tenant historical reports are trivially filterable.
 - **Relational user management becomes possible.** `User` and `TenantMember` allow efficient DataTable-backed features such as team directories, invite flows, and tenant membership administration.
 - **Request-time auth remains fast.** Existing middleware continues to read `tenantId` and `role` from the JWT without an additional database lookup on every request.
+- **Connected sessions self-heal after access changes.** Targeted `auth:claims_updated` events force token refresh, auth-context reconciliation, and query invalidation without requiring a full reload.
 - **Platform administration becomes tractable.** Super Admin workflows such as tenant CRUD and subscription-facing management now have a relational foundation.
 
 ### Negative
@@ -361,7 +368,7 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 - **WebSocket tenant isolation — resolved via Socket.io Rooms.** On socket connection, the NestJS gateway calls `client.join('tenant_' + jwt.tenantId)`. The `createDashboardRealtimeExtension` is updated to emit `this.server.to('tenant_' + tenantId).emit(...)` instead of broadcasting globally. `tenantId` is sourced from the ALS context, which is already populated by `TenantMiddleware` for the duration of the originating HTTP request that triggered the mutation. No changes are required to event payloads.
 - **Testing complexity.** Integration tests must seed a `Tenant` row and establish an ALS context before any Prisma operation. Test helpers must be updated to inject a default `tenantId`.
 - **Dual-write synchronization complexity.** Membership changes now touch both PostgreSQL and Firebase Custom Claims. Failure handling, retries, and token refresh semantics must be defined carefully.
-- **Token staleness becomes a product concern.** After a role or membership change, users may carry an old token until refresh or re-authentication. UI and backend workflows must account for this delay.
+- **Token staleness is reduced, not eliminated.** Connected sessions can be forced to refresh through `auth:claims_updated`, but disconnected clients still depend on the normal token refresh or expiry cycle. Forced-refresh failure is therefore a first-class sign-out and access-loss path, not an exceptional edge case.
 - **User lifecycle becomes broader than authentication.** Placeholder invitees, deactivated memberships, and cross-tenant membership history now require explicit domain handling instead of being delegated entirely to Firebase.
 
 ### Neutral
@@ -377,7 +384,7 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 
 ### Objective
 
-Introduce the relational and administrative foundation required to manage tenants and tenant members as first-class SaaS concepts while preserving the current fast JWT-based request pipeline.
+Introduce the relational and administrative foundation required to manage tenants and tenant members as first-class SaaS concepts while preserving the current fast JWT-based request pipeline, collapsing stale-token windows for connected clients, and keeping admin UX inside the platform's established page and sheet patterns.
 
 ### Execution Steps
 
@@ -390,30 +397,50 @@ Introduce the relational and administrative foundation required to manage tenant
   - Create `PlatformAdminModule` with internal `Tenant` CRUD endpoints.
   - Protect tenant CRUD routes with `SuperAdminGuard` using a system-level claim or a temporary hardcoded allowlist of platform-admin emails.
   - Create `TenantMemberModule` with `POST /tenant-members/invite` and supporting list/update endpoints.
+  - `TenantMember` mutations (invite, role change, deactivate, reactivate, tenant reassignment) must trigger the same three-step side effect chain in order: persist PostgreSQL state, synchronize Firebase Custom Claims, then emit `auth:claims_updated` to the affected user's private socket room.
   - Invite workflow:
     - Check whether the user exists by email.
     - If not, provision the Firebase identity required to obtain a `firebaseUid`, create the `User` row, and trigger a Firebase invite/reset-link flow.
     - Create the `TenantMember` record.
     - Immediately synchronize Firebase Custom Claims to reflect the user's active `tenantId` and `role`.
+  - List endpoints must be written to avoid N+1 queries by default:
+    - Tenant member queries load related users in one read, e.g. `prisma.tenantMember.findMany({ include: { user: true } })`.
+    - Tenant listing endpoints use relation counts / aggregate queries for member totals instead of looping over tenants and issuing per-row count queries.
+  - Bulk invite workflows must avoid serial `await` loops:
+    - Build Firebase Admin SDK calls as an array of promises and resolve them concurrently as one batch.
+    - Persist the corresponding `User` / `TenantMember` rows with `createMany` or concurrent Prisma writes inside a transaction.
 
 3. **Frontend UI Implementation (React 19 / Vite)**
   - Add `/platform/tenants` for Super Admins.
-  - Use the shared `DataTable` for tenant listing.
+  - Use the shared `DataTable` for tenant listing with in-table `Skeleton` loaders for loading states and an inline error state with retry inside the table shell.
   - Place `+ Tenant` in the top-right header area.
-  - Open a shadcn `Sheet` on row click for tenant editing with debounced auto-save (750ms).
+  - Clicking `+ Tenant` opens a shadcn `Dialog` or `Sheet`; no full-page create route is allowed.
+  - Clicking an existing tenant row opens a detail `Sheet` for editing; no full-page edit route is allowed.
+  - Tenant queries use strict TanStack Query v5 key factories only; inline array keys are forbidden.
   - Add `/settings/team` for tenant admins.
-  - Use the shared `DataTable` for `TenantMember` listing.
-  - Place `+ Member` in the top-right header area and open an invite modal.
-  - Use TanStack Query v5 with strict query key factories, e.g. `tenantMemberKeys.list({ tenantId })`.
+  - Use the shared `DataTable` for `TenantMember` listing with in-table `Skeleton` loaders for loading states and an inline error state with retry inside the table shell.
+  - Place `+ Member` in the top-right header area.
+  - Clicking `+ Member` opens a shadcn `Dialog` or `Sheet`; no full-page invite route is allowed.
+  - Clicking an existing team row opens a detail `Sheet`.
+  - Role changes in the team detail sheet use the shared `InlineEdit` field-level save-on-blur pattern and call a `PATCH` membership endpoint that immediately triggers the claims refresh sequence above.
+  - The frontend auth layer listens for `auth:claims_updated`, forces `currentUser.getIdToken(true)`, refreshes the global auth context, and invalidates TanStack Query caches.
+  - If the refreshed token no longer authorizes the current route, the UI signs the user out and exits the privileged screen gracefully instead of leaving stale data visible.
+  - Use TanStack Query v5 with strict query key factories, e.g. `tenantMemberKeys.list({ tenantId })`; inline array keys are forbidden.
 
 ### Acceptance Criteria
 
 - [ ] Prisma migrations run successfully without data loss.
 - [ ] NestJS successfully synchronizes a membership change in PostgreSQL to Firebase Custom Claims.
+- [ ] `TenantMember` role / activation changes emit `auth:claims_updated` to the affected user's private socket room.
+- [ ] A connected frontend session silently forces a token refresh, updates the auth context, and invalidates TanStack Query caches when `auth:claims_updated` is received.
 - [ ] Existing `auth.service.ts` request middleware continues to function without modification by reading the synchronized claims.
-- [ ] Frontend query usage follows TanStack Query v5 key-factory discipline.
+- [ ] Frontend query usage follows TanStack Query v5 key-factory discipline; no inline array query keys are introduced.
 - [ ] Primary list pages use the standardized shared `DataTable` component.
+- [ ] Page action buttons remain exclusively in the top-right header area.
+- [ ] Team role edits use the shared `InlineEdit` save-on-blur pattern rather than a full-page edit flow.
 - [ ] Database access uses bulk-fetch / pre-fetch-and-map patterns; no `await` calls inside loops when resolving tenant member data.
+- [ ] N+1 query prevention is verified on the backend by using `include: { user: true }` for tenant members and aggregate / relation-count queries for tenant summaries.
+- [ ] DataTable-driven admin screens render loading states with `Skeleton` rows and keep error states inside the table shell with an inline retry path.
 
 ---
 

--- a/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
+++ b/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
@@ -152,14 +152,16 @@ A single `User` may hold memberships in multiple tenants in PostgreSQL. However,
 
 ```json
 {
-  "sub": "user-cuid",
+  "sub": "firebase-uid-9f3c2b7a",
   "email": "ali@thunder-auto.com",
-  "tenantId": "tenant-cuid",
+  "tenantId": "550e8400-e29b-41d4-a716-446655440000",
   "role": "ADMIN",
   "iat": 1744000000,
   "exp": 1744086400
 }
 ```
+
+In the current backend, `sub` maps to Firebase `decoded.uid` rather than the relational `User.id`. `tenantId` remains the PostgreSQL tenant UUID carried in the custom claims payload.
 
 The `tenantId` claim is still extracted and validated by `JwtAuthGuard` on every authenticated request. It is **never sourced from the request body or query parameters** — only from the signed JWT payload, preventing tenant spoofing.
 
@@ -167,20 +169,21 @@ The `tenantId` claim is still extracted and validated by `JwtAuthGuard` on every
 
 1. Backend writes `User` and `TenantMember` state to PostgreSQL.
 2. Backend immediately calls the Firebase Admin SDK to update the user's custom claims, e.g. `{ tenantId: "xyz", role: "ADMIN" }`.
-3. Backend emits `auth:claims_updated` to the affected user's private Socket.io room (for example `user_<userId>` or `user_<firebaseUid>`), not to the whole tenant room.
-4. The React 19 frontend listens for `auth:claims_updated` and silently forces a Firebase token refresh via `currentUser.getIdToken(true)`.
-5. After the forced refresh, the frontend updates the global auth context and invalidates TanStack Query caches so role-sensitive screens re-resolve immediately.
-6. If the forced refresh fails or the refreshed token no longer carries an active `tenantId` / `role` pair, the frontend clears auth state and signs the user out of privileged screens.
-7. Existing `auth.service.ts` logic continues to trust the token claims for request-time authorization without an extra membership database lookup.
+3. For security-sensitive membership changes such as role downgrades, tenant removal, or membership deactivation, the backend also revokes the user's Firebase refresh tokens after the claim sync succeeds. This does not invalidate an already-issued ID token by itself, but it prevents missed-socket or offline clients from minting fresh privileged tokens later.
+4. Backend emits `auth:claims_updated` to the affected user's private Socket.io room (for example `user_<firebaseUid>`), not to the whole tenant room.
+5. The React 19 frontend listens for `auth:claims_updated` and silently forces a Firebase token refresh via `currentUser.getIdToken(true)`.
+6. After the forced refresh, the frontend updates the global auth context and invalidates TanStack Query caches so role-sensitive screens re-resolve immediately.
+7. If the forced refresh fails or the refreshed token no longer carries an active `tenantId` / `role` pair, the frontend clears auth state and signs the user out of privileged screens.
+8. Existing `auth.service.ts` logic continues to trust the token claims for request-time authorization without an extra membership database lookup.
 
-This real-time claims refresh path is mandatory for role downgrades, membership deactivation, tenant removal, and any other `TenantMember` mutation that changes effective access.
+This real-time claims refresh path is mandatory for role downgrades, membership deactivation, tenant removal, and any other `TenantMember` mutation that changes effective access. Refresh-token revocation is a complementary control for sensitive changes, not a substitute for the targeted socket refresh path.
 
 **Administrative modules introduced by this decision:**
 
-- `PlatformAdminModule` for internal `Tenant` CRUD, protected by a `SuperAdminGuard` backed by a platform-level claim or a temporary hardcoded admin-email allowlist.
+- `PlatformAdminModule` for internal `Tenant` CRUD, protected by a `SuperAdminGuard` backed by a platform-level claim. If a short-lived bootstrap fallback is ever required before that claim exists, it must use an environment-configured admin-email allowlist with a documented expiration date and removal criterion before release; hardcoded identities are forbidden.
 - `TenantMemberModule` for invite, list, update, and deactivate membership workflows.
 - `POST /tenant-members/invite` resolves or provisions the Firebase user, writes the `User`, writes the `TenantMember`, and synchronizes custom claims.
-- `PATCH /tenant-members/:id` (or equivalent role / activation endpoint) must synchronize claims and emit `auth:claims_updated` to the affected user's private socket room immediately after the membership mutation succeeds.
+- `PATCH /tenant-members/:id` (or equivalent role / activation endpoint) must synchronize claims, revoke Firebase refresh tokens for security-sensitive changes, and emit `auth:claims_updated` to the affected user's private socket room immediately after the membership mutation succeeds.
 - Frontend admin routes:
   - `/platform/tenants` for Super Admin tenant management.
   - `/settings/team` for tenant-scoped team management.
@@ -367,7 +370,7 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 - **Raw query prohibition.** Any RLS bypass (e.g., cross-tenant admin reporting) requires out-of-band tooling (e.g., a privileged internal service with a non-extended Prisma client) that is not covered by this ADR and must undergo separate architectural review before use.
 - **WebSocket tenant isolation — resolved via Socket.io Rooms.** On socket connection, the NestJS gateway calls `client.join('tenant_' + jwt.tenantId)`. The `createDashboardRealtimeExtension` is updated to emit `this.server.to('tenant_' + tenantId).emit(...)` instead of broadcasting globally. `tenantId` is sourced from the ALS context, which is already populated by `TenantMiddleware` for the duration of the originating HTTP request that triggered the mutation. No changes are required to event payloads.
 - **Testing complexity.** Integration tests must seed a `Tenant` row and establish an ALS context before any Prisma operation. Test helpers must be updated to inject a default `tenantId`.
-- **Dual-write synchronization complexity.** Membership changes now touch both PostgreSQL and Firebase Custom Claims. Failure handling, retries, and token refresh semantics must be defined carefully.
+- **Dual-write synchronization complexity.** Membership changes now touch both PostgreSQL and Firebase Custom Claims. Failure handling, retries, token refresh semantics, and selective refresh-token revocation for security-sensitive changes must be defined carefully.
 - **Token staleness is reduced, not eliminated.** Connected sessions can be forced to refresh through `auth:claims_updated`, but disconnected clients still depend on the normal token refresh or expiry cycle. Forced-refresh failure is therefore a first-class sign-out and access-loss path, not an exceptional edge case.
 - **User lifecycle becomes broader than authentication.** Placeholder invitees, deactivated memberships, and cross-tenant membership history now require explicit domain handling instead of being delegated entirely to Firebase.
 
@@ -390,14 +393,14 @@ Introduce the relational and administrative foundation required to manage tenant
 
 1. **Database Schema Update (Prisma)**
   - Create a `User` model with `id`, `firebaseUid`, `email`, `firstName`, `lastName`, and standard timestamps.
-  - Create a `TenantMember` model with `id`, `tenantId`, `userId`, `role`, `isActive`, and standard timestamps.
-  - Add `@@unique([tenantId, userId])` on `TenantMember`.
+  - Create a `TenantMember` model with `id`, `tenant_id`, `user_id`, `role`, `is_active`, and standard timestamps.
+  - Add `@@unique([tenant_id, user_id])` on `TenantMember`.
 
 2. **Backend API Development (NestJS)**
   - Create `PlatformAdminModule` with internal `Tenant` CRUD endpoints.
-  - Protect tenant CRUD routes with `SuperAdminGuard` using a system-level claim or a temporary hardcoded allowlist of platform-admin emails.
+  - Protect tenant CRUD routes with `SuperAdminGuard` using a system-level claim. If a bootstrap fallback is needed temporarily, it must use an environment-configured allowlist of platform-admin emails with an explicit expiration date and removal criterion.
   - Create `TenantMemberModule` with `POST /tenant-members/invite` and supporting list/update endpoints.
-  - `TenantMember` mutations (invite, role change, deactivate, reactivate, tenant reassignment) must trigger the same three-step side effect chain in order: persist PostgreSQL state, synchronize Firebase Custom Claims, then emit `auth:claims_updated` to the affected user's private socket room.
+  - `TenantMember` mutations (invite, role change, deactivate, reactivate, tenant reassignment) must trigger the same side effect chain in order: persist PostgreSQL state, synchronize Firebase Custom Claims, revoke Firebase refresh tokens when the change is security-sensitive, then emit `auth:claims_updated` to the affected user's private socket room.
   - Invite workflow:
     - Check whether the user exists by email.
     - If not, provision the Firebase identity required to obtain a `firebaseUid`, create the `User` row, and trigger a Firebase invite/reset-link flow.
@@ -431,6 +434,7 @@ Introduce the relational and administrative foundation required to manage tenant
 
 - [ ] Prisma migrations run successfully without data loss.
 - [ ] NestJS successfully synchronizes a membership change in PostgreSQL to Firebase Custom Claims.
+- [ ] Security-sensitive membership changes revoke Firebase refresh tokens after claims are synchronized.
 - [ ] `TenantMember` role / activation changes emit `auth:claims_updated` to the affected user's private socket room.
 - [ ] A connected frontend session silently forces a token refresh, updates the auth context, and invalidates TanStack Query caches when `auth:claims_updated` is received.
 - [ ] Existing `auth.service.ts` request middleware continues to function without modification by reading the synchronized claims.

--- a/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
+++ b/docs/internal/01-ADR/2026-04-15-row-level-multi-tenancy.md
@@ -12,6 +12,8 @@ tags:
   - prisma
   - auth
   - database
+  - firebase
+  - user-management
 ---
 
 # ADR-0013: Row-Level Multi-Tenancy
@@ -19,6 +21,8 @@ tags:
 ## Status
 
 **Accepted** — 2026-04-15
+
+**Amended** — 2026-04-22 (Hybrid Authentication & Membership Foundation)
 
 ## Context
 
@@ -30,6 +34,8 @@ Our core constraints are:
 2. **Cost-efficiency.** Each new dedicated PostgreSQL instance adds a fixed monthly floor cost regardless of utilisation. At launch scale, most customer databases would be nearly idle. Google Cloud Run's shared-compute model is already proven to serve our workload cost-effectively.
 3. **DRY codebase.** Schema, business logic, API layer, and frontend must remain unified. Per-customer forks violate every principle of sustainable product development.
 4. **Strict data isolation.** Despite sharing infrastructure, a mechanic logged into Workshop A must have **zero ability** to read, write, or infer the existence of Workshop B's data — even in the event of a developer error. Data isolation must be enforced at the ORM layer, not left to per-query discipline.
+
+As the platform moves from script-based onboarding toward real SaaS administration, a second problem has become unavoidable: **Firebase Custom Claims alone cannot act as the system of record for user membership**. They are excellent for stateless request-time authorization, but they are poor at powering relational product features such as a tenant user directory, invite flows, team management DataTables, and cross-tenant platform administration. We therefore need a persistent relational membership layer in PostgreSQL without sacrificing the performance and simplicity of JWT-based request authorization.
 
 The decision determines the architectural foundation for all future domain work: every table, every query, every unique constraint, and every authentication flow is affected.
 
@@ -90,9 +96,59 @@ model SalesOrder {
 
 This applies to every uniqueness invariant across the schema, including (but not limited to) `order_number`, `invoice_number`, `sku`, and `slug` fields.
 
-#### 2. Authentication: JWT with Embedded `tenantId`
+#### 2. Authentication & Membership: Hybrid Auth Architecture
 
-The current global API-key authentication is replaced by JWT-based authentication. JWTs are issued by the Auth module upon successful login and contain the following claims:
+The original JWT-based request model remains intact, but **Firebase Custom Claims are no longer treated as the system of record for user membership**. Instead, we adopt a hybrid model:
+
+- **PostgreSQL is the source of truth** for users and tenant memberships.
+- **Firebase remains the authentication provider and token transport layer**.
+- **JWT bearer tokens still carry `tenantId` and `role`** for fast, stateless request processing.
+- **Existing request middleware remains unchanged** because the database state is synchronized into Firebase Custom Claims.
+
+**New relational models:**
+
+```prisma
+model User {
+  id          String         @id @default(uuid())
+  firebaseUid String         @unique
+  email       String         @unique
+  firstName   String?
+  lastName    String?
+  memberships TenantMember[]
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  @@map("users")
+}
+
+enum TenantMemberRole {
+  OWNER
+  ADMIN
+  TECH
+  SALES
+}
+
+model TenantMember {
+  id        String           @id @default(uuid())
+  tenant_id String
+  tenant    Tenant           @relation(fields: [tenant_id], references: [id])
+  user_id   String
+  user      User             @relation(fields: [user_id], references: [id])
+  role      TenantMemberRole
+  is_active Boolean          @default(true)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@index([tenant_id])
+  @@index([user_id])
+  @@unique([tenant_id, user_id])
+  @@map("tenant_members")
+}
+```
+
+A single `User` may hold memberships in multiple tenants in PostgreSQL. However, the JWT still represents **one active tenant context per session**. The `tenantId` and `role` claims embedded in the bearer token are therefore treated as a synchronized projection of the user's currently active `TenantMember`, not the source of truth.
+
+**JWT payload remains hot-path optimized:**
 
 ```json
 {
@@ -105,7 +161,23 @@ The current global API-key authentication is replaced by JWT-based authenticatio
 }
 ```
 
-The `tenantId` claim is extracted and validated by a NestJS `JwtAuthGuard` on every authenticated request. It is **never sourced from the request body or query parameters** — only from the signed JWT payload, preventing tenant spoofing.
+The `tenantId` claim is still extracted and validated by `JwtAuthGuard` on every authenticated request. It is **never sourced from the request body or query parameters** — only from the signed JWT payload, preventing tenant spoofing.
+
+**Synchronization workflow:**
+
+1. Backend writes `User` and `TenantMember` state to PostgreSQL.
+2. Backend immediately calls the Firebase Admin SDK to update the user's custom claims, e.g. `{ tenantId: "xyz", role: "ADMIN" }`.
+3. Client obtains a refreshed Firebase ID token on the next token refresh or sign-in.
+4. Existing `auth.service.ts` logic continues to trust the token claims for request-time authorization without an extra membership database lookup.
+
+**Administrative modules introduced by this decision:**
+
+- `PlatformAdminModule` for internal `Tenant` CRUD, protected by a `SuperAdminGuard` backed by a platform-level claim or a temporary hardcoded admin-email allowlist.
+- `TenantMemberModule` for invite, list, update, and deactivate membership workflows.
+- `POST /tenant-members/invite` resolves or provisions the Firebase user, writes the `User`, writes the `TenantMember`, and synchronizes custom claims.
+- Frontend admin routes:
+  - `/platform/tenants` for Super Admin tenant management.
+  - `/settings/team` for tenant-scoped team management.
 
 #### 3. Data Isolation: Prisma Client Extension + AsyncLocalStorage
 
@@ -277,6 +349,9 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 - **Single codebase, single deployment pipeline.** All tenants run identical application code. Bug fixes and feature releases are deployed once.
 - **Defence-in-depth isolation.** The ALS + Prisma extension chain ensures that forgetting to add `where: { tenant_id }` in a new query is not a security vulnerability — the ORM layer enforces it automatically.
 - **Audit trail is tenant-scoped by default.** `InventoryTransaction`, `InvoiceSequence`, and all append-only tables carry `tenant_id`, so per-tenant historical reports are trivially filterable.
+- **Relational user management becomes possible.** `User` and `TenantMember` allow efficient DataTable-backed features such as team directories, invite flows, and tenant membership administration.
+- **Request-time auth remains fast.** Existing middleware continues to read `tenantId` and `role` from the JWT without an additional database lookup on every request.
+- **Platform administration becomes tractable.** Super Admin workflows such as tenant CRUD and subscription-facing management now have a relational foundation.
 
 ### Negative
 
@@ -285,12 +360,60 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 - **Raw query prohibition.** Any RLS bypass (e.g., cross-tenant admin reporting) requires out-of-band tooling (e.g., a privileged internal service with a non-extended Prisma client) that is not covered by this ADR and must undergo separate architectural review before use.
 - **WebSocket tenant isolation — resolved via Socket.io Rooms.** On socket connection, the NestJS gateway calls `client.join('tenant_' + jwt.tenantId)`. The `createDashboardRealtimeExtension` is updated to emit `this.server.to('tenant_' + tenantId).emit(...)` instead of broadcasting globally. `tenantId` is sourced from the ALS context, which is already populated by `TenantMiddleware` for the duration of the originating HTTP request that triggered the mutation. No changes are required to event payloads.
 - **Testing complexity.** Integration tests must seed a `Tenant` row and establish an ALS context before any Prisma operation. Test helpers must be updated to inject a default `tenantId`.
+- **Dual-write synchronization complexity.** Membership changes now touch both PostgreSQL and Firebase Custom Claims. Failure handling, retries, and token refresh semantics must be defined carefully.
+- **Token staleness becomes a product concern.** After a role or membership change, users may carry an old token until refresh or re-authentication. UI and backend workflows must account for this delay.
+- **User lifecycle becomes broader than authentication.** Placeholder invitees, deactivated memberships, and cross-tenant membership history now require explicit domain handling instead of being delegated entirely to Firebase.
 
 ### Neutral
 
 - The authentication change from API key to JWT is a prerequisite, not a consequence. Existing consumers must rotate credentials at cutover.
 - The `Tenant` table is not a "domain entity" in the business sense — it is infrastructure. It does not participate in the real-time entity map (ADR-0001) and is explicitly excluded from `SUPPORTED_ENTITY_TYPES`.
 - Per-tenant `FinanceSettings` means the initial data seeding step at tenant onboarding must create a `FinanceSettings` row. Onboarding runbooks must be updated accordingly.
+- A JWT still carries only one active tenant context per session. Supporting a tenant switcher or simultaneous multi-tenant sessions is a future product decision, not part of this amendment.
+
+---
+
+## Follow-On Feature: Tenant Management & User Membership Foundation
+
+### Objective
+
+Introduce the relational and administrative foundation required to manage tenants and tenant members as first-class SaaS concepts while preserving the current fast JWT-based request pipeline.
+
+### Execution Steps
+
+1. **Database Schema Update (Prisma)**
+  - Create a `User` model with `id`, `firebaseUid`, `email`, `firstName`, `lastName`, and standard timestamps.
+  - Create a `TenantMember` model with `id`, `tenantId`, `userId`, `role`, `isActive`, and standard timestamps.
+  - Add `@@unique([tenantId, userId])` on `TenantMember`.
+
+2. **Backend API Development (NestJS)**
+  - Create `PlatformAdminModule` with internal `Tenant` CRUD endpoints.
+  - Protect tenant CRUD routes with `SuperAdminGuard` using a system-level claim or a temporary hardcoded allowlist of platform-admin emails.
+  - Create `TenantMemberModule` with `POST /tenant-members/invite` and supporting list/update endpoints.
+  - Invite workflow:
+    - Check whether the user exists by email.
+    - If not, provision the Firebase identity required to obtain a `firebaseUid`, create the `User` row, and trigger a Firebase invite/reset-link flow.
+    - Create the `TenantMember` record.
+    - Immediately synchronize Firebase Custom Claims to reflect the user's active `tenantId` and `role`.
+
+3. **Frontend UI Implementation (React 19 / Vite)**
+  - Add `/platform/tenants` for Super Admins.
+  - Use the shared `DataTable` for tenant listing.
+  - Place `+ Tenant` in the top-right header area.
+  - Open a shadcn `Sheet` on row click for tenant editing with debounced auto-save (750ms).
+  - Add `/settings/team` for tenant admins.
+  - Use the shared `DataTable` for `TenantMember` listing.
+  - Place `+ Member` in the top-right header area and open an invite modal.
+  - Use TanStack Query v5 with strict query key factories, e.g. `tenantMemberKeys.list({ tenantId })`.
+
+### Acceptance Criteria
+
+- [ ] Prisma migrations run successfully without data loss.
+- [ ] NestJS successfully synchronizes a membership change in PostgreSQL to Firebase Custom Claims.
+- [ ] Existing `auth.service.ts` request middleware continues to function without modification by reading the synchronized claims.
+- [ ] Frontend query usage follows TanStack Query v5 key-factory discipline.
+- [ ] Primary list pages use the standardized shared `DataTable` component.
+- [ ] Database access uses bulk-fetch / pre-fetch-and-map patterns; no `await` calls inside loops when resolving tenant member data.
 
 ---
 
@@ -301,6 +424,14 @@ All `prisma.$queryRaw` and `prisma.$executeRaw` usages are **banned in applicati
 | **A — Database-per-tenant** | Each customer gets a dedicated PostgreSQL instance. Application routes to the correct DB by tenant subdomain at connection time. | Strongest possible isolation. Easy per-tenant backup and restore. Schema migrations can be staggered per customer. | $50–$150+/month per customer at minimum regardless of activity. Requires a connection-routing layer. Prisma does not natively support dynamic database URLs per request. Operational burden grows linearly with customer count. | **Rejected** |
 | **B — Schema-per-tenant** | All tenants share a single PostgreSQL server. Each tenant gets its own PostgreSQL schema (`thunder_auto.*`, `city_motors.*`). Prisma sets `search_path` per request. | Strong isolation (PostgreSQL enforces schema separation at the engine level). Easier per-tenant migrations. Backup per schema is possible. | Prisma Migrate does not support dynamic schema targeting — migrations run against a single, hard-coded schema. Workarounds (running migrations programmatically per schema) introduce operational fragility. At 50+ tenants, the number of live schemas creates non-trivial PostgreSQL catalog overhead. The real-time extension (ADR-0001) and connection pooling (PgBouncer / Cloud SQL) interact poorly with per-request `search_path` switching. | **Rejected** |
 | **C — Row-Level Multi-Tenancy (Shared Schema)** | All tenants share tables. Every row is tagged with `tenant_id`. ORM layer enforces scoping via Prisma `$extends` + NestJS ALS. | Zero infrastructure overhead for new tenants. No Prisma Migrate limitations. Works seamlessly with existing Cloud Run + Cloud SQL setup. Defence-in-depth isolation enforced at ORM layer. | Requires schema migration across all tables. Composite unique constraints must be maintained as a convention. Raw queries bypass isolation. | **Accepted** |
+
+### Authentication & Membership Alternatives Considered
+
+| Option | Description | Pros | Cons | Verdict |
+|--------|-------------|------|------|---------|
+| **D — Claims-Only Membership** | Store tenant assignment and role exclusively in Firebase Custom Claims, with no relational membership tables in PostgreSQL. | Fast request-time auth. Minimal schema work. | Cannot support user directory queries, invite workflows, tenant team tables, or cross-tenant administration without abusing Firebase as an application database. No reliable system of record for memberships. | **Rejected** |
+| **E — Database Lookup on Every Request** | Resolve tenant membership from PostgreSQL for every authenticated request and ignore token claims for authorization. | PostgreSQL is authoritative. No claim synchronization required. | Adds a membership database hit to every request, complicates the hot path, and throws away the performance benefits of stateless JWT authorization already established in this ADR. | **Rejected** |
+| **F — Hybrid Auth & Membership** | Store `User` and `TenantMember` in PostgreSQL, then synchronize active membership into Firebase Custom Claims so JWTs still carry `tenantId` and `role`. | Preserves fast stateless auth while enabling relational admin features and DataTable-backed user management. | Introduces claim synchronization and token-refresh complexity. | **Accepted as Amendment** |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-core-platform",
+  "name": "feature-hybrid-auth-membership-foundation",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- tighten the row-level multi-tenancy ADR with real-time auth claim revocation for membership changes
- require targeted `auth:claims_updated` socket events, silent token refresh, and auth/query cache invalidation on the frontend
- add strict team/admin UX constraints, N+1 prevention rules, DataTable loading/error expectations, and a deployment-scoped Prisma seed or CLI bootstrap path for the first platform admin

## Review Notes
- this is a docs-only amendment to the approved ADR
- no code, build, or test changes were made
- the new requirements are meant to be enforced in the future tenant-management implementation
