### PR TITLE
feat(workshop): add inspection domain models

### DIFF
--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -5274,6 +5274,16 @@
           "unitPrice": {
             "type": "number"
           },
+          "partExecutionStatus": {
+            "type": "string",
+            "enum": [
+              "PENDING_PICK",
+              "STAGED",
+              "CONSUMED",
+              "CANCELLED"
+            ],
+            "nullable": true
+          },
           "laborOperationId": {
             "type": "string",
             "nullable": true
@@ -5776,6 +5786,16 @@
           },
           "unitPrice": {
             "type": "number"
+          },
+          "partExecutionStatus": {
+            "type": "string",
+            "enum": [
+              "PENDING_PICK",
+              "STAGED",
+              "CONSUMED",
+              "CANCELLED"
+            ],
+            "nullable": true
           },
           "catalogItemId": {
             "type": "string",

--- a/apps/core-api/prisma/migrations/20260428113000_aut_90_workshop_domain_models/migration.sql
+++ b/apps/core-api/prisma/migrations/20260428113000_aut_90_workshop_domain_models/migration.sql
@@ -1,0 +1,201 @@
+-- CreateEnum
+CREATE TYPE "WorkshopPartLineExecutionStatus" AS ENUM (
+  'PENDING_PICK',
+  'STAGED',
+  'CONSUMED',
+  'CANCELLED'
+);
+
+-- CreateEnum
+CREATE TYPE "InspectionTemplateItemResponseType" AS ENUM (
+  'PASS_FAIL',
+  'NUMERIC',
+  'TEXT'
+);
+
+-- CreateEnum
+CREATE TYPE "WorkshopInspectionSeverity" AS ENUM (
+  'OK',
+  'ADVISORY',
+  'REQUIRED'
+);
+
+-- CreateEnum
+CREATE TYPE "WorkshopMediaUrlStrategy" AS ENUM (
+  'SIGNED',
+  'PUBLIC'
+);
+
+-- AlterTable
+ALTER TABLE "workshop_task_line_items"
+  ADD COLUMN "part_execution_status" "WorkshopPartLineExecutionStatus";
+
+UPDATE "workshop_task_line_items"
+SET "part_execution_status" = 'PENDING_PICK'
+WHERE "type" = 'PART' AND "part_execution_status" IS NULL;
+
+ALTER TABLE "workshop_task_line_items"
+  ADD CONSTRAINT "workshop_task_line_items_part_status_check"
+  CHECK (
+    (
+      "type" = 'PART'
+      AND "part_execution_status" IS NOT NULL
+    )
+    OR (
+      "type" = 'LABOR'
+      AND "part_execution_status" IS NULL
+    )
+  );
+
+CREATE INDEX "idx_workshop_task_line_items_part_status"
+  ON "workshop_task_line_items"("tenant_id", "type", "part_execution_status");
+
+-- CreateTable
+CREATE TABLE "inspection_templates" (
+  "id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "code" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "version" INTEGER NOT NULL,
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "inspection_templates_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "inspection_template_items" (
+  "id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "inspection_template_id" TEXT NOT NULL,
+  "code" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "response_type" "InspectionTemplateItemResponseType" NOT NULL,
+  "unit" TEXT,
+  "sort_order" INTEGER NOT NULL DEFAULT 0,
+  "is_required" BOOLEAN NOT NULL DEFAULT false,
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "inspection_template_items_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "workshop_inspections" (
+  "id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "workshop_order_id" TEXT NOT NULL,
+  "workshop_task_id" TEXT,
+  "inspection_template_id" TEXT,
+  "title" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "workshop_inspections_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "workshop_inspection_items" (
+  "id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "workshop_inspection_id" TEXT NOT NULL,
+  "inspection_template_item_id" TEXT,
+  "label_snapshot" TEXT NOT NULL,
+  "response_value" TEXT,
+  "unit" TEXT,
+  "passed" BOOLEAN,
+  "severity" "WorkshopInspectionSeverity",
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "workshop_inspection_items_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "workshop_media" (
+  "id" TEXT NOT NULL,
+  "tenant_id" TEXT NOT NULL,
+  "workshop_order_id" TEXT NOT NULL,
+  "workshop_task_id" TEXT,
+  "uploaded_by_employee_id" TEXT NOT NULL,
+  "storage_bucket" TEXT NOT NULL,
+  "storage_key" TEXT NOT NULL,
+  "url_strategy" "WorkshopMediaUrlStrategy" NOT NULL,
+  "mime_type" TEXT NOT NULL,
+  "size_bytes" INTEGER NOT NULL,
+  "duration_seconds" DECIMAL(10, 2),
+  "caption" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "workshop_media_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "inspection_templates_tenant_id_idx" ON "inspection_templates"("tenant_id");
+CREATE UNIQUE INDEX "inspection_templates_tenant_id_id_key" ON "inspection_templates"("tenant_id", "id");
+CREATE UNIQUE INDEX "inspection_templates_tenant_id_code_version_key" ON "inspection_templates"("tenant_id", "code", "version");
+
+CREATE INDEX "inspection_template_items_tenant_id_idx" ON "inspection_template_items"("tenant_id");
+CREATE UNIQUE INDEX "inspection_template_items_tenant_id_id_key" ON "inspection_template_items"("tenant_id", "id");
+CREATE UNIQUE INDEX "inspection_template_items_tenant_id_inspection_template_id_code_key" ON "inspection_template_items"("tenant_id", "inspection_template_id", "code");
+CREATE INDEX "idx_inspection_template_items_template" ON "inspection_template_items"("tenant_id", "inspection_template_id");
+
+CREATE INDEX "workshop_inspections_tenant_id_idx" ON "workshop_inspections"("tenant_id");
+CREATE UNIQUE INDEX "workshop_inspections_tenant_id_id_key" ON "workshop_inspections"("tenant_id", "id");
+CREATE INDEX "idx_workshop_inspections_order" ON "workshop_inspections"("tenant_id", "workshop_order_id");
+CREATE INDEX "idx_workshop_inspections_task" ON "workshop_inspections"("tenant_id", "workshop_task_id");
+CREATE INDEX "idx_workshop_inspections_template" ON "workshop_inspections"("tenant_id", "inspection_template_id");
+
+CREATE INDEX "workshop_inspection_items_tenant_id_idx" ON "workshop_inspection_items"("tenant_id");
+CREATE UNIQUE INDEX "workshop_inspection_items_tenant_id_id_key" ON "workshop_inspection_items"("tenant_id", "id");
+CREATE INDEX "idx_workshop_inspection_items_inspection" ON "workshop_inspection_items"("tenant_id", "workshop_inspection_id");
+CREATE INDEX "idx_workshop_inspection_items_template_item" ON "workshop_inspection_items"("tenant_id", "inspection_template_item_id");
+
+CREATE INDEX "workshop_media_tenant_id_idx" ON "workshop_media"("tenant_id");
+CREATE UNIQUE INDEX "workshop_media_tenant_id_id_key" ON "workshop_media"("tenant_id", "id");
+CREATE INDEX "idx_workshop_media_order" ON "workshop_media"("tenant_id", "workshop_order_id");
+CREATE INDEX "idx_workshop_media_task" ON "workshop_media"("tenant_id", "workshop_task_id");
+CREATE INDEX "idx_workshop_media_employee" ON "workshop_media"("tenant_id", "uploaded_by_employee_id");
+
+-- AddForeignKey
+ALTER TABLE "inspection_templates" ADD CONSTRAINT "inspection_templates_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "inspection_template_items" ADD CONSTRAINT "inspection_template_items_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "inspection_template_items" ADD CONSTRAINT "inspection_template_items_tenant_id_inspection_template_id_fkey"
+  FOREIGN KEY ("tenant_id", "inspection_template_id") REFERENCES "inspection_templates"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_workshop_order_id_fkey"
+  FOREIGN KEY ("tenant_id", "workshop_order_id") REFERENCES "workshop_orders"("tenant_id", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_workshop_task_id_fkey"
+  FOREIGN KEY ("workshop_task_id") REFERENCES "workshop_tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_inspection_template_id_fkey"
+  FOREIGN KEY ("tenant_id", "inspection_template_id") REFERENCES "inspection_templates"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspection_items" ADD CONSTRAINT "workshop_inspection_items_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspection_items" ADD CONSTRAINT "workshop_inspection_items_tenant_id_workshop_inspection_id_fkey"
+  FOREIGN KEY ("tenant_id", "workshop_inspection_id") REFERENCES "workshop_inspections"("tenant_id", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_inspection_items" ADD CONSTRAINT "workshop_inspection_items_tenant_id_inspection_template_item_id_fkey"
+  FOREIGN KEY ("tenant_id", "inspection_template_item_id") REFERENCES "inspection_template_items"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_workshop_order_id_fkey"
+  FOREIGN KEY ("tenant_id", "workshop_order_id") REFERENCES "workshop_orders"("tenant_id", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_workshop_task_id_fkey"
+  FOREIGN KEY ("workshop_task_id") REFERENCES "workshop_tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_uploaded_by_employee_id_fkey"
+  FOREIGN KEY ("tenant_id", "uploaded_by_employee_id") REFERENCES "employees"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/core-api/prisma/migrations/20260428113000_aut_90_workshop_domain_models/migration.sql
+++ b/apps/core-api/prisma/migrations/20260428113000_aut_90_workshop_domain_models/migration.sql
@@ -173,8 +173,8 @@ ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_i
 ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_workshop_order_id_fkey"
   FOREIGN KEY ("tenant_id", "workshop_order_id") REFERENCES "workshop_orders"("tenant_id", "id") ON DELETE CASCADE ON UPDATE CASCADE;
 
-ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_workshop_task_id_fkey"
-  FOREIGN KEY ("workshop_task_id") REFERENCES "workshop_tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_workshop_task_id_fkey"
+  FOREIGN KEY ("tenant_id", "workshop_task_id") REFERENCES "workshop_tasks"("tenant_id", "id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 ALTER TABLE "workshop_inspections" ADD CONSTRAINT "workshop_inspections_tenant_id_inspection_template_id_fkey"
   FOREIGN KEY ("tenant_id", "inspection_template_id") REFERENCES "inspection_templates"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -194,8 +194,8 @@ ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_fkey"
 ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_workshop_order_id_fkey"
   FOREIGN KEY ("tenant_id", "workshop_order_id") REFERENCES "workshop_orders"("tenant_id", "id") ON DELETE CASCADE ON UPDATE CASCADE;
 
-ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_workshop_task_id_fkey"
-  FOREIGN KEY ("workshop_task_id") REFERENCES "workshop_tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_workshop_task_id_fkey"
+  FOREIGN KEY ("tenant_id", "workshop_task_id") REFERENCES "workshop_tasks"("tenant_id", "id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 ALTER TABLE "workshop_media" ADD CONSTRAINT "workshop_media_tenant_id_uploaded_by_employee_id_fkey"
   FOREIGN KEY ("tenant_id", "uploaded_by_employee_id") REFERENCES "employees"("tenant_id", "id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -900,7 +900,7 @@ model WorkshopInspection {
   workshop_order_id      String
   workshop_order         WorkshopOrder            @relation(fields: [tenant_id, workshop_order_id], references: [tenant_id, id], onDelete: Cascade, onUpdate: Cascade)
   workshop_task_id       String?
-  workshop_task          WorkshopTask?            @relation(fields: [workshop_task_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  workshop_task          WorkshopTask?            @relation(fields: [tenant_id, workshop_task_id], references: [tenant_id, id], onDelete: SetNull, onUpdate: Cascade)
   inspection_template_id String?
   inspection_template    InspectionTemplate?      @relation(fields: [tenant_id, inspection_template_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
   title                  String
@@ -947,7 +947,7 @@ model WorkshopMedia {
   workshop_order_id       String
   workshop_order          WorkshopOrder            @relation(fields: [tenant_id, workshop_order_id], references: [tenant_id, id], onDelete: Cascade, onUpdate: Cascade)
   workshop_task_id        String?
-  workshop_task           WorkshopTask?            @relation(fields: [workshop_task_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  workshop_task           WorkshopTask?            @relation(fields: [tenant_id, workshop_task_id], references: [tenant_id, id], onDelete: SetNull, onUpdate: Cascade)
   uploaded_by_employee_id String
   uploaded_by_employee    Employee                 @relation("WorkshopMediaUploadedByEmployee", fields: [tenant_id, uploaded_by_employee_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
   storage_bucket          String

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -59,6 +59,11 @@ model Tenant {
   invoiceItems         InvoiceItem[]
   purchaseInvoices     PurchaseInvoice[]
   purchaseInvoiceLines PurchaseInvoiceLine[]
+  inspectionTemplates  InspectionTemplate[]
+  inspectionTemplateItems InspectionTemplateItem[]
+  workshopInspections  WorkshopInspection[]
+  workshopInspectionItems WorkshopInspectionItem[]
+  workshopMedia        WorkshopMedia[]
   workshopOrders       WorkshopOrder[]
   workshopTasks        WorkshopTask[]
   workshopTaskLineItems WorkshopTaskLineItem[]
@@ -659,6 +664,7 @@ model Employee {
   workshopOrdersAsMechanic WorkshopOrder[] @relation("WorkshopOrderMechanic")
   workshopTasksAsMechanic  WorkshopTask[]  @relation("WorkshopTaskMechanic")
   laborEntries             LaborEntry[]    @relation("EmployeeLaborEntries")
+  uploadedWorkshopMedia    WorkshopMedia[] @relation("WorkshopMediaUploadedByEmployee")
   createdAt               DateTime        @default(now())
   updatedAt               DateTime        @updatedAt
 
@@ -707,6 +713,8 @@ model WorkshopOrder {
   fuel_level   Int                 // 0-100
   reported_issue String?
   notes        String?
+  inspections  WorkshopInspection[]
+  media        WorkshopMedia[]
   tasks        WorkshopTask[]
   invoice      Invoice?
 
@@ -749,6 +757,30 @@ enum WorkshopLineItemType {
   PART
 }
 
+enum WorkshopPartLineExecutionStatus {
+  PENDING_PICK
+  STAGED
+  CONSUMED
+  CANCELLED
+}
+
+enum InspectionTemplateItemResponseType {
+  PASS_FAIL
+  NUMERIC
+  TEXT
+}
+
+enum WorkshopInspectionSeverity {
+  OK
+  ADVISORY
+  REQUIRED
+}
+
+enum WorkshopMediaUrlStrategy {
+  SIGNED
+  PUBLIC
+}
+
 model WorkshopTask {
   id                String             @id @default(uuid())
   tenant_id         String
@@ -773,8 +805,10 @@ model WorkshopTask {
   scheduled_date    DateTime?          @db.Date
   sequence          Int                @default(0)
 
+  inspections       WorkshopInspection[]
   line_items        WorkshopTaskLineItem[]
   labor_entries     LaborEntry[]
+  media             WorkshopMedia[]
 
   createdAt         DateTime           @default(now())
   updatedAt         DateTime           @updatedAt
@@ -795,6 +829,7 @@ model WorkshopTaskLineItem {
   workshop_task     WorkshopTask         @relation(fields: [tenant_id, workshop_task_id], references: [tenant_id, id], onDelete: Cascade)
 
   type              WorkshopLineItemType
+  part_execution_status WorkshopPartLineExecutionStatus?
   // For PART this stores SKU/part number; for LABOR this stores a labor code.
   item_no           String
   description       String
@@ -812,6 +847,125 @@ model WorkshopTaskLineItem {
   @@map("workshop_task_line_items")
   @@index([tenant_id])
   @@index([labor_operation_id])
+  @@index([tenant_id, type, part_execution_status], map: "idx_workshop_task_line_items_part_status")
+}
+
+model InspectionTemplate {
+  id          String                   @id @default(uuid())
+  tenant_id   String
+  tenant      Tenant                   @relation(fields: [tenant_id], references: [id])
+  code        String
+  title       String
+  version     Int
+  is_active   Boolean                  @default(true)
+  items       InspectionTemplateItem[]
+  inspections WorkshopInspection[]
+  createdAt   DateTime                 @default(now())
+  updatedAt   DateTime                 @updatedAt
+
+  @@index([tenant_id])
+  @@unique([tenant_id, id])
+  @@unique([tenant_id, code, version])
+  @@map("inspection_templates")
+}
+
+model InspectionTemplateItem {
+  id                     String                             @id @default(uuid())
+  tenant_id              String
+  tenant                 Tenant                             @relation(fields: [tenant_id], references: [id])
+  inspection_template_id String
+  inspection_template    InspectionTemplate                 @relation(fields: [tenant_id, inspection_template_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
+  code                   String
+  label                  String
+  response_type          InspectionTemplateItemResponseType
+  unit                   String?
+  sort_order             Int                                @default(0)
+  is_required            Boolean                            @default(false)
+  is_active              Boolean                            @default(true)
+  responses              WorkshopInspectionItem[]
+  createdAt              DateTime                           @default(now())
+  updatedAt              DateTime                           @updatedAt
+
+  @@index([tenant_id])
+  @@unique([tenant_id, id])
+  @@unique([tenant_id, inspection_template_id, code])
+  @@index([tenant_id, inspection_template_id], map: "idx_inspection_template_items_template")
+  @@map("inspection_template_items")
+}
+
+model WorkshopInspection {
+  id                     String                   @id @default(uuid())
+  tenant_id              String
+  tenant                 Tenant                   @relation(fields: [tenant_id], references: [id])
+  workshop_order_id      String
+  workshop_order         WorkshopOrder            @relation(fields: [tenant_id, workshop_order_id], references: [tenant_id, id], onDelete: Cascade, onUpdate: Cascade)
+  workshop_task_id       String?
+  workshop_task          WorkshopTask?            @relation(fields: [workshop_task_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  inspection_template_id String?
+  inspection_template    InspectionTemplate?      @relation(fields: [tenant_id, inspection_template_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
+  title                  String
+  items                  WorkshopInspectionItem[]
+  createdAt              DateTime                 @default(now())
+  updatedAt              DateTime                 @updatedAt
+
+  @@index([tenant_id])
+  @@unique([tenant_id, id])
+  @@index([tenant_id, workshop_order_id], map: "idx_workshop_inspections_order")
+  @@index([tenant_id, workshop_task_id], map: "idx_workshop_inspections_task")
+  @@index([tenant_id, inspection_template_id], map: "idx_workshop_inspections_template")
+  @@map("workshop_inspections")
+}
+
+model WorkshopInspectionItem {
+  id                          String                     @id @default(uuid())
+  tenant_id                   String
+  tenant                      Tenant                     @relation(fields: [tenant_id], references: [id])
+  workshop_inspection_id      String
+  workshop_inspection         WorkshopInspection         @relation(fields: [tenant_id, workshop_inspection_id], references: [tenant_id, id], onDelete: Cascade, onUpdate: Cascade)
+  inspection_template_item_id String?
+  inspection_template_item    InspectionTemplateItem?    @relation(fields: [tenant_id, inspection_template_item_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
+  label_snapshot              String
+  response_value              String?
+  unit                        String?
+  passed                      Boolean?
+  severity                    WorkshopInspectionSeverity?
+  notes                       String?
+  createdAt                   DateTime                   @default(now())
+  updatedAt                   DateTime                   @updatedAt
+
+  @@index([tenant_id])
+  @@unique([tenant_id, id])
+  @@index([tenant_id, workshop_inspection_id], map: "idx_workshop_inspection_items_inspection")
+  @@index([tenant_id, inspection_template_item_id], map: "idx_workshop_inspection_items_template_item")
+  @@map("workshop_inspection_items")
+}
+
+model WorkshopMedia {
+  id                      String                   @id @default(uuid())
+  tenant_id               String
+  tenant                  Tenant                   @relation(fields: [tenant_id], references: [id])
+  workshop_order_id       String
+  workshop_order          WorkshopOrder            @relation(fields: [tenant_id, workshop_order_id], references: [tenant_id, id], onDelete: Cascade, onUpdate: Cascade)
+  workshop_task_id        String?
+  workshop_task           WorkshopTask?            @relation(fields: [workshop_task_id], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  uploaded_by_employee_id String
+  uploaded_by_employee    Employee                 @relation("WorkshopMediaUploadedByEmployee", fields: [tenant_id, uploaded_by_employee_id], references: [tenant_id, id], onDelete: Restrict, onUpdate: Cascade)
+  storage_bucket          String
+  storage_key             String
+  url_strategy            WorkshopMediaUrlStrategy
+  mime_type               String
+  size_bytes              Int
+  duration_seconds        Decimal?                 @db.Decimal(10, 2)
+  caption                 String?
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
+
+  @@index([tenant_id])
+  @@unique([tenant_id, id])
+  @@index([tenant_id, workshop_order_id], map: "idx_workshop_media_order")
+  @@index([tenant_id, workshop_task_id], map: "idx_workshop_media_task")
+  @@index([tenant_id, uploaded_by_employee_id], map: "idx_workshop_media_employee")
+  @@map("workshop_media")
 }
 
 // ============================================================================

--- a/apps/core-api/src/workshop/dto/board-response.dto.ts
+++ b/apps/core-api/src/workshop/dto/board-response.dto.ts
@@ -4,6 +4,7 @@ import {
   EmployeeRole,
   WorkshopLineItemType,
   WorkshopOrderStatus,
+  WorkshopPartLineExecutionStatus,
   WorkshopTaskStatus,
 } from '@prisma/client';
 
@@ -75,6 +76,13 @@ export class BoardLineItemDto {
 
   @ApiProperty()
   unitPrice!: number;
+
+  @ApiProperty({
+    enum: WorkshopPartLineExecutionStatus,
+    required: false,
+    nullable: true,
+  })
+  partExecutionStatus?: WorkshopPartLineExecutionStatus | null;
 
   @ApiProperty({ type: String, nullable: true, required: false })
   catalogItemId?: string | null;

--- a/apps/core-api/src/workshop/dto/workshop-response.dto.ts
+++ b/apps/core-api/src/workshop/dto/workshop-response.dto.ts
@@ -3,6 +3,7 @@ import {
   CustomerType,
   WorkshopLineItemType,
   WorkshopOrderStatus,
+  WorkshopPartLineExecutionStatus,
   WorkshopTaskStatus,
 } from '@prisma/client';
 import { PaginationMetaDto } from '../../common/dto/paginated-response.dto';
@@ -76,6 +77,13 @@ export class WorkshopTaskLineItemResponseDto {
 
   @ApiProperty()
   unitPrice!: number;
+
+  @ApiProperty({
+    enum: WorkshopPartLineExecutionStatus,
+    required: false,
+    nullable: true,
+  })
+  partExecutionStatus?: WorkshopPartLineExecutionStatus | null;
 
   @ApiProperty({ type: String, required: false, nullable: true })
   laborOperationId?: string | null;

--- a/apps/core-api/src/workshop/workshop.service.spec.ts
+++ b/apps/core-api/src/workshop/workshop.service.spec.ts
@@ -7,6 +7,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   Prisma,
   TransactionType,
+  WorkshopPartLineExecutionStatus,
   WorkshopLineItemType,
   WorkshopOrderStatus,
   WorkshopTaskStatus,
@@ -65,6 +66,7 @@ describe('WorkshopService', () => {
       deleteMany: jest.fn(),
       createMany: jest.fn(),
       findMany: jest.fn(),
+      updateMany: jest.fn(),
     },
     laborOperation: {
       count: jest.fn(),
@@ -323,6 +325,9 @@ describe('WorkshopService', () => {
     expect(secondLineItem.standard_aw).toBeNull();
     expect(secondLineItem.actual_hours).toBeNull();
     expect(secondLineItem.internal_cost_rate).toBeNull();
+    expect(secondLineItem.part_execution_status).toBe(
+      WorkshopPartLineExecutionStatus.PENDING_PICK,
+    );
   });
 
   it('returns a bad request error for invalid laborOperationId', async () => {
@@ -374,6 +379,7 @@ describe('WorkshopService', () => {
               description: 'Brake labor',
               quantity: new Prisma.Decimal(1),
               unit_price: new Prisma.Decimal(100),
+              part_execution_status: null,
               labor_operation_id: '550e8400-e29b-41d4-a716-446655440000',
               standard_aw: new Prisma.Decimal(0),
               actual_hours: new Prisma.Decimal(1.25),
@@ -386,6 +392,8 @@ describe('WorkshopService', () => {
               description: 'Pad',
               quantity: new Prisma.Decimal(1),
               unit_price: new Prisma.Decimal(90),
+              part_execution_status:
+                WorkshopPartLineExecutionStatus.PENDING_PICK,
               labor_operation_id: null,
               standard_aw: null,
               actual_hours: null,
@@ -410,6 +418,9 @@ describe('WorkshopService', () => {
     expect(partLineItem.standardAw).toBeNull();
     expect(partLineItem.actualHours).toBeNull();
     expect(partLineItem.internalCostRate).toBeNull();
+    expect(partLineItem.partExecutionStatus).toBe(
+      WorkshopPartLineExecutionStatus.PENDING_PICK,
+    );
   });
 
   it('rejects pick-parts when workshop order status is not eligible', async () => {

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -21,6 +21,7 @@ import {
   TransactionType,
   WorkshopLineItemType,
   WorkshopOrderStatus,
+  WorkshopPartLineExecutionStatus,
   WorkshopTaskStatus,
 } from '@prisma/client';
 import { InvoicesService } from '../invoices/invoices.service';
@@ -283,6 +284,7 @@ export class WorkshopService {
               description: line.description,
               qty: Number(line.quantity),
               unitPrice: Number(line.unit_price),
+              partExecutionStatus: line.part_execution_status,
               laborOperationId: line.labor_operation_id,
               standardAw:
                 line.standard_aw != null ? Number(line.standard_aw) : null,
@@ -800,6 +802,10 @@ export class WorkshopService {
                 item.type === WorkshopLineItemType.LABOR
                   ? WorkshopLineItemType.LABOR
                   : WorkshopLineItemType.PART,
+              part_execution_status:
+                item.type === WorkshopLineItemType.PART
+                  ? WorkshopPartLineExecutionStatus.PENDING_PICK
+                  : null,
               item_no: item.itemNo,
               description: item.description,
               quantity: new Prisma.Decimal(item.qty),
@@ -945,6 +951,7 @@ export class WorkshopService {
         select: {
           id: true,
           item_no: true,
+          quantity: true,
         },
       });
 
@@ -985,6 +992,7 @@ export class WorkshopService {
       const transferGroupId = `WO-PICK-${order.id}-${Date.now()}`;
       const ledgerTransactions: RecordTransactionParams[] = [];
       const reservations: AllocationReservationMap = new Map();
+      const fullyStagedLineIds = new Set<string>();
       const movedLines: Array<{
         workshopTaskLineItemId: string;
         movedQuantity: number;
@@ -1001,6 +1009,10 @@ export class WorkshopService {
           throw new NotFoundException(
             `Line item ${requestedItem.workshopTaskLineItemId} not found`,
           );
+        }
+
+        if (requestedItem.quantity >= Number(lineItem.quantity)) {
+          fullyStagedLineIds.add(lineItem.id);
         }
 
         const catalogItem = catalogItemBySku.get(lineItem.item_no);
@@ -1076,6 +1088,19 @@ export class WorkshopService {
       }
 
       await this.ledgerService.recordTransactions(ledgerTransactions, tx);
+
+      if (fullyStagedLineIds.size > 0) {
+        await tx.workshopTaskLineItem.updateMany({
+          where: {
+            tenant_id: tenantId,
+            id: { in: Array.from(fullyStagedLineIds) },
+            type: WorkshopLineItemType.PART,
+          },
+          data: {
+            part_execution_status: WorkshopPartLineExecutionStatus.STAGED,
+          },
+        });
+      }
 
       const orderUpdateResult = await tx.workshopOrder.updateMany({
         where: {
@@ -1344,6 +1369,7 @@ export class WorkshopService {
             description: li.description,
             quantity: Number(li.quantity),
             unitPrice: Number(li.unit_price),
+            partExecutionStatus: li.part_execution_status,
             catalogItemId: catalogIdBySku.get(li.item_no) ?? null,
           })),
         })),

--- a/apps/core-api/src/workshop/workshop.service.ts
+++ b/apps/core-api/src/workshop/workshop.service.ts
@@ -942,6 +942,7 @@ export class WorkshopService {
       const requestedLineItemIds = Array.from(aggregatedItems.keys());
       const lineItems = await tx.workshopTaskLineItem.findMany({
         where: {
+          tenant_id: tenantId,
           id: { in: requestedLineItemIds },
           type: WorkshopLineItemType.PART,
           workshop_task: {
@@ -1011,7 +1012,14 @@ export class WorkshopService {
           );
         }
 
-        if (requestedItem.quantity >= Number(lineItem.quantity)) {
+        const lineItemQuantity = Number(lineItem.quantity);
+        if (requestedItem.quantity > lineItemQuantity) {
+          throw new BadRequestException(
+            `Requested quantity ${requestedItem.quantity} exceeds required quantity ${lineItemQuantity} for line item ${lineItem.id}`,
+          );
+        }
+
+        if (requestedItem.quantity >= lineItemQuantity) {
           fullyStagedLineIds.add(lineItem.id);
         }
 
@@ -1095,6 +1103,8 @@ export class WorkshopService {
             tenant_id: tenantId,
             id: { in: Array.from(fullyStagedLineIds) },
             type: WorkshopLineItemType.PART,
+            part_execution_status:
+              WorkshopPartLineExecutionStatus.PENDING_PICK,
           },
           data: {
             part_execution_status: WorkshopPartLineExecutionStatus.STAGED,
@@ -1104,6 +1114,7 @@ export class WorkshopService {
 
       const orderUpdateResult = await tx.workshopOrder.updateMany({
         where: {
+          tenant_id: tenantId,
           id: orderId,
           status: {
             in: PICK_ELIGIBLE_ORDER_STATUSES,

--- a/apps/core-api/test/workshop-domain-models.e2e-spec.ts
+++ b/apps/core-api/test/workshop-domain-models.e2e-spec.ts
@@ -1,0 +1,233 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { AuthService } from '../src/auth/auth.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { createTenantAwarePrisma, createTestTenant } from './tenant-test-utils';
+
+jest.setTimeout(30000);
+
+describe('Workshop Domain Models (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  let tenantId: string;
+  let customerId: string;
+  let vehicleId: string;
+  let orderId: string;
+  let taskId: string;
+  let mechanicId: string;
+  let authToken: string;
+  let templateId: string;
+  let templateItemId: string;
+  let inspectionId: string;
+
+  beforeAll(async () => {
+    process.env.API_KEY = 'test-api-key';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
+    await app.init();
+
+    const basePrisma = app.get<PrismaService>(PrismaService);
+    const authService = app.get<AuthService>(AuthService);
+    const testTenant = await createTestTenant(basePrisma, 'workshop-domain');
+    tenantId = testTenant.tenantId;
+    prisma = createTenantAwarePrisma(basePrisma, tenantId);
+    authToken = authService.createTestToken({
+      sub: 'e2e-workshop-domain-user',
+      email: 'e2e-workshop-domain-user@example.com',
+      tenantId,
+      role: 'ADMIN',
+    });
+
+    const customer = await prisma.customer.create({
+      data: {
+        first_name: 'Domain',
+        last_name: 'Tester',
+        email: `workshop-domain-${Date.now()}@example.com`,
+        type: 'PRIVATE',
+      },
+    });
+    customerId = customer.id;
+
+    const vehicle = await prisma.vehicle.create({
+      data: {
+        make: 'Skoda',
+        model: 'Octavia',
+        year: 2021,
+        vin: `VIN-DOMAIN-${Date.now()}`,
+        customer_id: customerId,
+      },
+    });
+    vehicleId = vehicle.id;
+
+    const mechanic = await prisma.employee.create({
+      data: {
+        name: 'Domain Mechanic',
+        role: 'MECHANIC',
+        is_active: true,
+      },
+    });
+    mechanicId = mechanic.id;
+
+    const order = await prisma.workshopOrder.create({
+      data: {
+        order_number: `WO-DOMAIN-${Date.now()}`,
+        customer_id: customerId,
+        vehicle_id: vehicleId,
+        mechanic_id: mechanicId,
+        odometer: 88000,
+        fuel_level: 35,
+        status: 'INTAKE',
+      },
+    });
+    orderId = order.id;
+
+    const task = await prisma.workshopTask.create({
+      data: {
+        workshop_order_id: orderId,
+        title: 'Brake inspection task',
+        status: 'NOT_STARTED',
+        mechanic_id: mechanicId,
+      },
+    });
+    taskId = task.id;
+  });
+
+  afterAll(async () => {
+    if (orderId) {
+      await prisma.workshopTaskLineItem.deleteMany({
+        where: { workshop_task: { workshop_order_id: orderId } },
+      });
+      await prisma.workshopTask.deleteMany({ where: { workshop_order_id: orderId } });
+      await prisma.workshopOrder.deleteMany({ where: { id: orderId } });
+    }
+    if (templateItemId) {
+      await prisma.inspectionTemplateItem.deleteMany({ where: { id: templateItemId } });
+    }
+    if (templateId) {
+      await prisma.inspectionTemplate.deleteMany({ where: { id: templateId } });
+    }
+    if (mechanicId) {
+      await prisma.employee.deleteMany({ where: { id: mechanicId } });
+    }
+    if (vehicleId) {
+      await prisma.vehicle.deleteMany({ where: { id: vehicleId } });
+    }
+    if (customerId) {
+      await prisma.customer.deleteMany({ where: { id: customerId } });
+    }
+    if (tenantId) {
+      await prisma.tenant.deleteMany({ where: { id: tenantId } });
+    }
+    await app.close();
+  });
+
+  it('persists inspection templates, inspections, media metadata, and part execution status', async () => {
+    const template = await prisma.inspectionTemplate.create({
+      data: {
+        code: `MPI-${Date.now()}`,
+        title: 'Multi-point inspection',
+        version: 1,
+        is_active: true,
+        items: {
+          create: [
+            {
+              code: 'BRAKE-PAD',
+              label: 'Brake pad wear',
+              response_type: 'PASS_FAIL',
+              unit: 'mm',
+              sort_order: 1,
+              is_required: true,
+              is_active: true,
+            },
+          ],
+        },
+      },
+      include: { items: true },
+    });
+    templateId = template.id;
+    templateItemId = template.items[0]?.id ?? '';
+
+    const inspection = await prisma.workshopInspection.create({
+      data: {
+        workshop_order_id: orderId,
+        workshop_task_id: taskId,
+        inspection_template_id: template.id,
+        title: 'Brake inspection',
+        items: {
+          create: [
+            {
+              inspection_template_item_id: template.items[0]?.id,
+              label_snapshot: 'Brake pad wear',
+              response_value: 'Replace soon',
+              unit: 'mm',
+              passed: false,
+              severity: 'ADVISORY',
+              notes: 'Pads are near minimum thickness.',
+            },
+          ],
+        },
+      },
+      include: { items: true },
+    });
+    inspectionId = inspection.id;
+
+    const media = await prisma.workshopMedia.create({
+      data: {
+        workshop_order_id: orderId,
+        workshop_task_id: taskId,
+        uploaded_by_employee_id: mechanicId,
+        storage_bucket: 'workshop-media-test',
+        storage_key: `tenant/${tenantId}/orders/${orderId}/tasks/${taskId}/brake-pad.jpg`,
+        url_strategy: 'SIGNED',
+        mime_type: 'image/jpeg',
+        size_bytes: 24576,
+        caption: 'Brake pad wear photo',
+      },
+    });
+
+    const partLine = await prisma.workshopTaskLineItem.create({
+      data: {
+        workshop_task_id: taskId,
+        type: 'PART',
+        item_no: 'PAD-001',
+        description: 'Brake pad set',
+        quantity: 1,
+        unit_price: 90,
+        part_execution_status: 'PENDING_PICK',
+      },
+    });
+
+    expect(template.items).toHaveLength(1);
+    expect(inspection.workshop_order_id).toBe(orderId);
+    expect(inspection.workshop_task_id).toBe(taskId);
+    expect(inspection.items[0]?.inspection_template_item_id).toBe(template.items[0]?.id);
+    expect(media.storage_key).toContain(orderId);
+    expect(partLine.part_execution_status).toBe('PENDING_PICK');
+  });
+
+  it('returns part execution status on the workshop order response', async () => {
+    const response = await request(app.getHttpServer())
+      .get(`/api/workshop/orders/${orderId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(response.body.tasks).toHaveLength(1);
+    expect(response.body.tasks[0].lineItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'PART',
+          partExecutionStatus: 'PENDING_PICK',
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -1426,6 +1426,8 @@ export interface components {
             description: string;
             qty: number;
             unitPrice: number;
+            /** @enum {string|null} */
+            partExecutionStatus?: "PENDING_PICK" | "STAGED" | "CONSUMED" | "CANCELLED" | null;
             laborOperationId?: string | null;
             standardAw?: number | null;
             actualHours?: number | null;
@@ -1559,6 +1561,8 @@ export interface components {
             description: string;
             quantity: number;
             unitPrice: number;
+            /** @enum {string|null} */
+            partExecutionStatus?: "PENDING_PICK" | "STAGED" | "CONSUMED" | "CANCELLED" | null;
             catalogItemId?: string | null;
         };
         BoardTaskDto: {

--- a/docs/deletion-policy.md
+++ b/docs/deletion-policy.md
@@ -38,6 +38,11 @@ This document defines when deletion is allowed in Auto Core Platform.
 | Bay | Conditional (future API) | DB FK is `ON DELETE SET NULL` from `WorkshopOrder.bay_id`; if delete API is added, default to deactivation (`is_active = false`) and allow hard delete only under explicit business rules. |
 | WorkshopOrder | Conditional (future API) | Prefer cancel/archive flow; if delete is added, limit to pre-work intake states only. |
 | WorkshopTask | Conditional | Allow only when parent `WorkshopOrder` is not `INVOICED`, no linked invoice exists yet on the order, and no `LaborEntry` records exist for the task. |
+| InspectionTemplate | Conditional | Cannot delete if any `WorkshopInspection` references it; deactivate or supersede it instead. |
+| InspectionTemplateItem | Conditional | Cannot delete if any `WorkshopInspectionItem` references it; change future template versions instead. |
+| WorkshopInspection | Conditional | Cannot delete after the parent order is completed; before completion only manager-controlled void/delete flows should be allowed. |
+| WorkshopInspectionItem | No direct delete | Managed by the parent `WorkshopInspection` lifecycle and should not be deleted independently after completion. |
+| WorkshopMedia | Conditional | Cannot delete after the parent order is completed; before completion, only failed or unattached media may be removed by mechanics, otherwise manager-only. |
 | LaborEntry | No | Immutable audit trail of mechanic time intervals; never hard-deleted through the API. The nightly close-out job may set `ended_at` and `pause_reason = AUTO_SHIFT_CLOSE` on open entries, but does not delete records. |
 | InvoiceSequence | No | Numbering integrity record; never deleted. |
 | LaborCategory | Conditional | Allow only when no `LaborOperation` references it (i.e. `labor_operations` relation is empty) and no child categories exist. |

--- a/docs/internal/01-ADR/2026-04-27-mechanic-digital-repair-order-tablet-rbac.md
+++ b/docs/internal/01-ADR/2026-04-27-mechanic-digital-repair-order-tablet-rbac.md
@@ -318,6 +318,8 @@ When a mechanic adds a required part:
 
 `WorkshopTaskLineItem` needs a part-line lifecycle for `type = PART` rows:
 
+Implementation note: this lifecycle is modeled as a dedicated enum named `WorkshopPartLineExecutionStatus` so it cannot be conflated with `WorkshopTaskStatus`.
+
 - `PENDING_PICK` — mechanic requested or advisor added; parts department has not staged it.
 - `STAGED` — parts were picked into the order's staging tote.
 - `CONSUMED` — part was installed/used on the job.


### PR DESCRIPTION
## Summary

- Add persisted workshop inspection templates, inspection captures, and media metadata models.
- Add dedicated part-line execution status for `WorkshopTaskLineItem` PART rows.
- Update workshop responses, generated API contracts, and deletion policy documentation.

## Verification

- `npm --prefix apps/core-api run test -- src/workshop/workshop.service.spec.ts`
- `npm --prefix apps/core-api run test:e2e -- workshop-domain-models.e2e-spec.ts`
- `npm --prefix apps/core-api run lint:prisma-tenant`
- `npm --prefix apps/core-api run build`
- `npm --prefix apps/core-web run build`
