### PR TITLE
feat: implement mark as sent for purchase orders

### DIFF
--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -622,6 +622,36 @@
         ]
       }
     },
+    "/api/purchase-orders/{id}/mark-as-sent": {
+      "post": {
+        "operationId": "PurchaseController_markAsSent",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      }
+    },
     "/api/purchase-orders/{id}": {
       "get": {
         "operationId": "PurchaseController_findOne",

--- a/apps/core-api/src/purchase/purchase.controller.ts
+++ b/apps/core-api/src/purchase/purchase.controller.ts
@@ -55,6 +55,15 @@ export class PurchaseController {
     return result;
   }
 
+  @Post(':id/mark-as-sent')
+  @HttpCode(200)
+  @ApiOkResponse({
+    schema: { type: 'object' },
+  })
+  async markAsSent(@Param('id') id: string) {
+    return this.purchaseService.markAsSent(id);
+  }
+
   @Get()
   @ApiQuery({
     name: 'status',

--- a/apps/core-api/src/purchase/purchase.service.ts
+++ b/apps/core-api/src/purchase/purchase.service.ts
@@ -589,6 +589,35 @@ export class PurchaseService {
     });
   }
 
+  async markAsSent(id: string) {
+    const tenantId = await this.tenantContext.getTenantId();
+
+    const order = await this.prisma.purchaseOrder.findFirst({
+      where: { id, tenant_id: tenantId },
+    });
+
+    if (!order) {
+      throw new NotFoundException('Purchase Order not found');
+    }
+
+    if (order.status !== PurchaseOrderStatus.DRAFT) {
+      throw new BadRequestException(
+        'Only DRAFT purchase orders can be marked as sent',
+      );
+    }
+
+    return this.prisma.purchaseOrder.update({
+      where: { id },
+      data: { status: PurchaseOrderStatus.SENT },
+      include: {
+        vendor: true,
+        items: {
+          include: { catalog_item: true },
+        },
+      },
+    });
+  }
+
   async remove(id: string) {
     const tenantId = await this.tenantContext.getTenantId();
     const deletedOrder = await this.prisma.$transaction(async (tx) => {

--- a/apps/core-web/e2e/pom/AutoCorePage.ts
+++ b/apps/core-web/e2e/pom/AutoCorePage.ts
@@ -1,4 +1,4 @@
-import { Page, expect, Locator } from '@playwright/test';
+import { Page, expect, Locator } from "@playwright/test";
 
 /**
  * AutoCorePage encapsulates the "Golden Rules" of the Auto Core Platform UI.
@@ -22,7 +22,7 @@ export class AutoCorePage {
 
   /** Escapes a string for safe embedding in a RegExp literal. */
   private static escapeRegex(text: string): string {
-    return text.replace(/[+.*?^${}()|[\]\\]/g, '\\$&');
+    return text.replace(/[+.*?^${}()|[\]\\]/g, "\\$&");
   }
 
   /**
@@ -35,14 +35,16 @@ export class AutoCorePage {
    */
   get createButton(): Locator {
     // Anchored: matches exactly "Item" or "+ Item" but NOT "Items", "Purchase Orders", etc.
-    const nameRegex = new RegExp(`^(\\+ )?${AutoCorePage.escapeRegex(this.entityName)}$`);
+    const nameRegex = new RegExp(
+      `^(\\+ )?${AutoCorePage.escapeRegex(this.entityName)}$`,
+    );
     return this.page
-      .getByRole('button', { name: nameRegex })
-      .or(this.page.getByRole('link', { name: nameRegex }));
+      .getByRole("button", { name: nameRegex })
+      .or(this.page.getByRole("link", { name: nameRegex }));
   }
 
   get dataTable(): Locator {
-    return this.page.getByRole('table');
+    return this.page.getByRole("table");
   }
 
   /**
@@ -50,36 +52,25 @@ export class AutoCorePage {
    * are served before any assertions are made.
    */
   async navigate(path: string) {
-    // Mock auth session to prevent "Unable to load your tenant session" blocking the UI
-    // This is done globally here to avoid repeating it in every test file.
-    await this.page.route(AutoCorePage.apiRouteMatcher("/api/auth/me"), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          userId: "e2e-test-user",
-          email: "testauto@auto.core.at",
-          activeTenant: {
-            id: "e2e-tenant-id",
-            name: "E2E Tenant",
-            slug: "e2e-tenant",
-          },
-          activeRole: "ADMIN",
-          memberships: [
-            {
-              tenantId: "e2e-tenant-id",
-              role: "ADMIN",
-              tenant: {
-                id: "e2e-tenant-id",
-                name: "E2E Tenant",
-                slug: "e2e-tenant",
-              },
+    await this.page.route(
+      AutoCorePage.apiRouteMatcher("/api/auth/session"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            user: {
+              id: "test-user",
+              email: "test@example.com",
             },
-          ],
-        }),
-      });
-    });
-
+            tenant: {
+              id: "test-tenant",
+              name: "Test Tenant",
+            },
+          }),
+        });
+      },
+    );
     await this.page.goto(path);
     await this.page.waitForLoadState("networkidle");
   }
@@ -93,7 +84,10 @@ export class AutoCorePage {
    * - A create button matching `entityName` is visible (typically top-right).
    */
   async verifyHeaderConsistency(title: string) {
-    const heading = this.page.getByRole('heading', { name: title, exact: true });
+    const heading = this.page.getByRole("heading", {
+      name: title,
+      exact: true,
+    });
     await expect(heading).toBeVisible();
     await expect(this.createButton).toBeVisible();
   }
@@ -106,7 +100,10 @@ export class AutoCorePage {
    * b) Navigation      → the URL changes (e.g. `/vendors/:id`).
    */
   async openRowDetails(searchText: string) {
-    const row = this.page.locator('[data-table-row="true"]').filter({ hasText: searchText }).first();
+    const row = this.page
+      .locator('[data-table-row="true"]')
+      .filter({ hasText: searchText })
+      .first();
     await expect(row).toBeVisible();
 
     const urlBefore = this.page.url();
@@ -157,7 +154,8 @@ export class AutoCorePage {
     const responsePromise = this.page.waitForResponse(
       (res) =>
         res.url().includes(apiPath) &&
-        (res.request().method() === 'PATCH' || res.request().method() === 'POST'),
+        (res.request().method() === "PATCH" ||
+          res.request().method() === "POST"),
     );
 
     // 1. UI transitions to "Saving…"

--- a/apps/core-web/e2e/pom/AutoCorePage.ts
+++ b/apps/core-web/e2e/pom/AutoCorePage.ts
@@ -50,8 +50,38 @@ export class AutoCorePage {
    * are served before any assertions are made.
    */
   async navigate(path: string) {
+    // Mock auth session to prevent "Unable to load your tenant session" blocking the UI
+    // This is done globally here to avoid repeating it in every test file.
+    await this.page.route(AutoCorePage.apiRouteMatcher("/api/auth/me"), async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          userId: "e2e-test-user",
+          email: "testauto@auto.core.at",
+          activeTenant: {
+            id: "e2e-tenant-id",
+            name: "E2E Tenant",
+            slug: "e2e-tenant",
+          },
+          activeRole: "ADMIN",
+          memberships: [
+            {
+              tenantId: "e2e-tenant-id",
+              role: "ADMIN",
+              tenant: {
+                id: "e2e-tenant-id",
+                name: "E2E Tenant",
+                slug: "e2e-tenant",
+              },
+            },
+          ],
+        }),
+      });
+    });
+
     await this.page.goto(path);
-    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForLoadState("networkidle");
   }
 
   /**

--- a/apps/core-web/e2e/purchase-order-detail.spec.ts
+++ b/apps/core-web/e2e/purchase-order-detail.spec.ts
@@ -21,8 +21,6 @@ test.describe("Blueprint: Purchase Order Detail", () => {
   const VENDOR_ID = "vendor-mock-123";
   const MOCK_AVAILABLE_QUANTITY = 25;
 
-
-
   test("Purchase Order Detail - rendering and items", async ({ page }) => {
     const corePage = new AutoCorePage(page, "Purchase Order");
 
@@ -143,9 +141,7 @@ test.describe("Blueprint: Purchase Order Detail", () => {
       id: VENDOR_ID,
       name: "Bosch Automotive",
     });
-
-    // Track state locally to simulate backend transitions
-    let currentPO = createMockPurchaseOrder({
+    const mockPO = createMockPurchaseOrder({
       id: PO_ID,
       order_number: "PO-2026-0001",
       status: "DRAFT",
@@ -159,35 +155,20 @@ test.describe("Blueprint: Purchase Order Detail", () => {
       async (route) => {
         if (route.request().method() === "PATCH") {
           const body = JSON.parse(route.request().postData() || "{}");
-          currentPO = { ...currentPO, ...body };
           await route.fulfill({
             status: 200,
             contentType: "application/json",
-            body: JSON.stringify(currentPO),
+            body: JSON.stringify({ ...mockPO, ...body }),
           });
         } else {
           await route.fulfill({
             status: 200,
             contentType: "application/json",
-            body: JSON.stringify(currentPO),
+            body: JSON.stringify(mockPO),
           });
         }
       },
     );
-
-    // Mock the POST route for status transition
-    await page.route(
-      AutoCorePage.apiRouteMatcher(`/api/purchase-orders/${PO_ID}/mark-as-sent`),
-      async (route) => {
-        currentPO.status = "SENT";
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(currentPO),
-        });
-      },
-    );
-
     await page.route(
       AutoCorePage.apiRouteMatcher("/api/vendors"),
       async (route) => {
@@ -226,10 +207,7 @@ test.describe("Blueprint: Purchase Order Detail", () => {
     const sendButton = page.getByRole("button", { name: /Mark as Sent/i });
     await expect(sendButton).toBeVisible();
     await sendButton.click();
-    await expect(sendButton).not.toBeVisible();
-
-    // Verify the status changes to Sent in the UI
-    await expect(page.getByText("Sent", { exact: true })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("SENT", { exact: true })).toBeVisible();
   });
 
   // Auto-save (Saving → Saved cycle) is not yet implemented on the PO detail page.

--- a/apps/core-web/e2e/purchase-order-detail.spec.ts
+++ b/apps/core-web/e2e/purchase-order-detail.spec.ts
@@ -21,6 +21,8 @@ test.describe("Blueprint: Purchase Order Detail", () => {
   const VENDOR_ID = "vendor-mock-123";
   const MOCK_AVAILABLE_QUANTITY = 25;
 
+
+
   test("Purchase Order Detail - rendering and items", async ({ page }) => {
     const corePage = new AutoCorePage(page, "Purchase Order");
 
@@ -141,7 +143,9 @@ test.describe("Blueprint: Purchase Order Detail", () => {
       id: VENDOR_ID,
       name: "Bosch Automotive",
     });
-    const mockPO = createMockPurchaseOrder({
+
+    // Track state locally to simulate backend transitions
+    let currentPO = createMockPurchaseOrder({
       id: PO_ID,
       order_number: "PO-2026-0001",
       status: "DRAFT",
@@ -155,20 +159,35 @@ test.describe("Blueprint: Purchase Order Detail", () => {
       async (route) => {
         if (route.request().method() === "PATCH") {
           const body = JSON.parse(route.request().postData() || "{}");
+          currentPO = { ...currentPO, ...body };
           await route.fulfill({
             status: 200,
             contentType: "application/json",
-            body: JSON.stringify({ ...mockPO, ...body }),
+            body: JSON.stringify(currentPO),
           });
         } else {
           await route.fulfill({
             status: 200,
             contentType: "application/json",
-            body: JSON.stringify(mockPO),
+            body: JSON.stringify(currentPO),
           });
         }
       },
     );
+
+    // Mock the POST route for status transition
+    await page.route(
+      AutoCorePage.apiRouteMatcher(`/api/purchase-orders/${PO_ID}/mark-as-sent`),
+      async (route) => {
+        currentPO.status = "SENT";
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(currentPO),
+        });
+      },
+    );
+
     await page.route(
       AutoCorePage.apiRouteMatcher("/api/vendors"),
       async (route) => {
@@ -207,7 +226,10 @@ test.describe("Blueprint: Purchase Order Detail", () => {
     const sendButton = page.getByRole("button", { name: /Mark as Sent/i });
     await expect(sendButton).toBeVisible();
     await sendButton.click();
-    await expect(page.getByText("SENT", { exact: true })).toBeVisible();
+    await expect(sendButton).not.toBeVisible();
+
+    // Verify the status changes to Sent in the UI
+    await expect(page.getByText("Sent", { exact: true })).toBeVisible({ timeout: 10000 });
   });
 
   // Auto-save (Saving → Saved cycle) is not yet implemented on the PO detail page.

--- a/apps/core-web/e2e/purchase-order-detail.spec.ts
+++ b/apps/core-web/e2e/purchase-order-detail.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect } from '@playwright/test'
-import { AutoCorePage } from './pom/AutoCorePage'
+import { test, expect } from "@playwright/test";
+import { AutoCorePage } from "./pom/AutoCorePage";
 import {
   createMockPurchaseOrder,
   createMockVendor,
   createMockInventoryItem,
   createMockListResponse,
-} from './utils/mock-factories'
+} from "./utils/mock-factories";
 
 /**
  * Blueprint: Purchase Order Detail
@@ -16,35 +16,38 @@ import {
  * - Accurate line item mocking with quantity_available.
  * - Proper status transition modeling.
  */
-test.describe('Blueprint: Purchase Order Detail', () => {
-  const PO_ID = 'po-blueprint-123'
-  const VENDOR_ID = 'vendor-mock-123'
-  const MOCK_AVAILABLE_QUANTITY = 25
+test.describe("Blueprint: Purchase Order Detail", () => {
+  const PO_ID = "po-blueprint-123";
+  const VENDOR_ID = "vendor-mock-123";
+  const MOCK_AVAILABLE_QUANTITY = 25;
 
-  test('Purchase Order Detail - rendering and items', async ({ page }) => {
-    const corePage = new AutoCorePage(page, 'Purchase Order')
+  test("Purchase Order Detail - rendering and items", async ({ page }) => {
+    const corePage = new AutoCorePage(page, "Purchase Order");
 
-    const mockVendor = createMockVendor({ id: VENDOR_ID, name: 'Bosch Automotive' })
+    const mockVendor = createMockVendor({
+      id: VENDOR_ID,
+      name: "Bosch Automotive",
+    });
     const mockPO = createMockPurchaseOrder({
       id: PO_ID,
-      order_number: 'PO-2026-0001',
-      status: 'DRAFT',
+      order_number: "PO-2026-0001",
+      status: "DRAFT",
       vendor_id: VENDOR_ID,
       vendor: mockVendor,
       items: [
         {
-          id: 'item-1',
-          catalog_item_id: 'cat-1',
+          id: "item-1",
+          catalog_item_id: "cat-1",
           quantity: 10,
           quantity_received: 0,
           unit_cost: 15.0,
           catalog_item: {
-            sku: 'TEST-SKU-1',
-            name: 'Test Part',
+            sku: "TEST-SKU-1",
+            name: "Test Part",
           },
         },
       ],
-    })
+    });
 
     // 1. Mock all dependencies BEFORE navigation (network isolation)
 
@@ -52,200 +55,239 @@ test.describe('Blueprint: Purchase Order Detail', () => {
     await page.route(
       AutoCorePage.apiRouteMatcher(`/api/purchase-orders/${PO_ID}`),
       async (route) => {
-        if (route.request().method() === 'PATCH') {
-          const body = JSON.parse(route.request().postData() || '{}')
+        if (route.request().method() === "PATCH") {
+          const body = JSON.parse(route.request().postData() || "{}");
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify({ ...mockPO, ...body }),
-          })
+          });
         } else {
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify(mockPO),
-          })
+          });
         }
       },
-    )
+    );
 
     // GET /api/vendors -> secondary API for vendor resolution
-    await page.route(AutoCorePage.apiRouteMatcher('/api/vendors'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(createMockListResponse([mockVendor])),
-      })
-    })
+    await page.route(
+      AutoCorePage.apiRouteMatcher("/api/vendors"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(createMockListResponse([mockVendor])),
+        });
+      },
+    );
 
     // GET /api/inventory -> secondary API for item search
-    await page.route(AutoCorePage.apiRouteMatcher('/api/inventory'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(
-          createMockListResponse([createMockInventoryItem({ quantity_available: MOCK_AVAILABLE_QUANTITY })]),
-        ),
-      })
-    })
+    await page.route(
+      AutoCorePage.apiRouteMatcher("/api/inventory"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(
+            createMockListResponse([
+              createMockInventoryItem({
+                quantity_available: MOCK_AVAILABLE_QUANTITY,
+              }),
+            ]),
+          ),
+        });
+      },
+    );
 
     // GET /api/vendors/:vendorId/unbilled-receipts -> required to render correctly
     await page.route(
-      AutoCorePage.apiRouteMatcher(`/api/vendors/${VENDOR_ID}/unbilled-receipts`),
+      AutoCorePage.apiRouteMatcher(
+        `/api/vendors/${VENDOR_ID}/unbilled-receipts`,
+      ),
       async (route) => {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify([]),
-        })
+        });
       },
-    )
+    );
 
     // 2. Navigate to the page
-    await corePage.navigate(`/purchase-orders/${PO_ID}`)
+    await corePage.navigate(`/purchase-orders/${PO_ID}`);
 
     // 3. Detail page load: verify header renders
-    await expect(page.getByRole('heading', { name: 'PO-2026-0001', exact: true })).toBeVisible()
-    await expect(page.getByText('Vendor: Bosch Automotive')).toBeVisible()
-    await expect(page.getByText(/DRAFT/i)).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: "PO-2026-0001", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Vendor: Bosch Automotive")).toBeVisible();
+    await expect(page.getByText(/DRAFT/i)).toBeVisible();
 
     // 4. Line items: verify the table renders the mocked items
-    await expect(page.getByRole('cell', { name: 'TEST-SKU-1' })).toBeVisible()
-    await expect(page.getByRole('cell', { name: 'Test Part' })).toBeVisible()
-  })
+    await expect(page.getByRole("cell", { name: "TEST-SKU-1" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Test Part" })).toBeVisible();
+  });
 
   // Blueprint requires the workflow control to exist and the status to change to SENT.
   // Mark as fixme until the PO detail UI implements an explicit "Mark as Sent" action.
-  test.fixme('Purchase Order Detail - status workflow: Mark as Sent', async ({ page }) => {
-    const corePage = new AutoCorePage(page, 'Purchase Order')
-    const mockVendor = createMockVendor({ id: VENDOR_ID, name: 'Bosch Automotive' })
+  test("Purchase Order Detail - status workflow: Mark as Sent", async ({
+    page,
+  }) => {
+    const corePage = new AutoCorePage(page, "Purchase Order");
+    const mockVendor = createMockVendor({
+      id: VENDOR_ID,
+      name: "Bosch Automotive",
+    });
     const mockPO = createMockPurchaseOrder({
       id: PO_ID,
-      order_number: 'PO-2026-0001',
-      status: 'DRAFT',
+      order_number: "PO-2026-0001",
+      status: "DRAFT",
       vendor_id: VENDOR_ID,
       vendor: mockVendor,
       items: [],
-    })
+    });
 
     await page.route(
       AutoCorePage.apiRouteMatcher(`/api/purchase-orders/${PO_ID}`),
       async (route) => {
-        if (route.request().method() === 'PATCH') {
-          const body = JSON.parse(route.request().postData() || '{}')
+        if (route.request().method() === "PATCH") {
+          const body = JSON.parse(route.request().postData() || "{}");
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify({ ...mockPO, ...body }),
-          })
+          });
         } else {
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify(mockPO),
-          })
+          });
         }
       },
-    )
-    await page.route(AutoCorePage.apiRouteMatcher('/api/vendors'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(createMockListResponse([mockVendor])),
-      })
-    })
-    await page.route(AutoCorePage.apiRouteMatcher('/api/inventory'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(createMockListResponse([])),
-      })
-    })
+    );
     await page.route(
-      AutoCorePage.apiRouteMatcher(`/api/vendors/${VENDOR_ID}/unbilled-receipts`),
+      AutoCorePage.apiRouteMatcher("/api/vendors"),
       async (route) => {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([]),
-        })
+          contentType: "application/json",
+          body: JSON.stringify(createMockListResponse([mockVendor])),
+        });
       },
-    )
+    );
+    await page.route(
+      AutoCorePage.apiRouteMatcher("/api/inventory"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(createMockListResponse([])),
+        });
+      },
+    );
+    await page.route(
+      AutoCorePage.apiRouteMatcher(
+        `/api/vendors/${VENDOR_ID}/unbilled-receipts`,
+      ),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([]),
+        });
+      },
+    );
 
-    await corePage.navigate(`/purchase-orders/${PO_ID}`)
+    await corePage.navigate(`/purchase-orders/${PO_ID}`);
 
-    const sendButton = page.getByRole('button', { name: /Mark as Sent/i })
-    await expect(sendButton).toBeVisible()
-    await sendButton.click()
-    await expect(page.getByText('SENT', { exact: true })).toBeVisible()
-  })
+    const sendButton = page.getByRole("button", { name: /Mark as Sent/i });
+    await expect(sendButton).toBeVisible();
+    await sendButton.click();
+    await expect(page.getByText("SENT", { exact: true })).toBeVisible();
+  });
 
   // Auto-save (Saving → Saved cycle) is not yet implemented on the PO detail page.
   // Mark as fixme until the UI implements a debounced form-level auto-save indicator.
-  test.fixme('Purchase Order Detail - auto-save on field change', async ({ page }) => {
-    const corePage = new AutoCorePage(page, 'Purchase Order')
-    const mockVendor = createMockVendor({ id: VENDOR_ID, name: 'Bosch Automotive' })
+  test.fixme("Purchase Order Detail - auto-save on field change", async ({
+    page,
+  }) => {
+    const corePage = new AutoCorePage(page, "Purchase Order");
+    const mockVendor = createMockVendor({
+      id: VENDOR_ID,
+      name: "Bosch Automotive",
+    });
     const mockPO = createMockPurchaseOrder({
       id: PO_ID,
-      order_number: 'PO-2026-0001',
-      status: 'DRAFT',
+      order_number: "PO-2026-0001",
+      status: "DRAFT",
       vendor_id: VENDOR_ID,
       vendor: mockVendor,
       items: [],
-    })
+    });
 
     await page.route(
       AutoCorePage.apiRouteMatcher(`/api/purchase-orders/${PO_ID}`),
       async (route) => {
-        if (route.request().method() === 'PATCH') {
-          const body = JSON.parse(route.request().postData() || '{}')
+        if (route.request().method() === "PATCH") {
+          const body = JSON.parse(route.request().postData() || "{}");
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify({ ...mockPO, ...body }),
-          })
+          });
         } else {
           await route.fulfill({
             status: 200,
-            contentType: 'application/json',
+            contentType: "application/json",
             body: JSON.stringify(mockPO),
-          })
+          });
         }
       },
-    )
-    await page.route(AutoCorePage.apiRouteMatcher('/api/vendors'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(createMockListResponse([mockVendor])),
-      })
-    })
-    await page.route(AutoCorePage.apiRouteMatcher('/api/inventory'), async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(createMockListResponse([])),
-      })
-    })
+    );
     await page.route(
-      AutoCorePage.apiRouteMatcher(`/api/vendors/${VENDOR_ID}/unbilled-receipts`),
+      AutoCorePage.apiRouteMatcher("/api/vendors"),
       async (route) => {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify([]),
-        })
+          contentType: "application/json",
+          body: JSON.stringify(createMockListResponse([mockVendor])),
+        });
       },
-    )
+    );
+    await page.route(
+      AutoCorePage.apiRouteMatcher("/api/inventory"),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(createMockListResponse([])),
+        });
+      },
+    );
+    await page.route(
+      AutoCorePage.apiRouteMatcher(
+        `/api/vendors/${VENDOR_ID}/unbilled-receipts`,
+      ),
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([]),
+        });
+      },
+    );
 
-    await corePage.navigate(`/purchase-orders/${PO_ID}`)
+    await corePage.navigate(`/purchase-orders/${PO_ID}`);
 
-    const notesInput = page.getByLabel(/Notes/i)
-    await expect(notesInput).toBeVisible()
-    const autoSavePromise = corePage.waitForAutoSave('/api/purchase-orders')
-    await notesInput.fill('Updated notes')
-    await autoSavePromise
-    await expect(notesInput).toHaveValue('Updated notes')
-  })
-})
-
+    const notesInput = page.getByLabel(/Notes/i);
+    await expect(notesInput).toBeVisible();
+    const autoSavePromise = corePage.waitForAutoSave("/api/purchase-orders");
+    await notesInput.fill("Updated notes");
+    await autoSavePromise;
+    await expect(notesInput).toHaveValue("Updated notes");
+  });
+});

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -228,6 +228,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/purchase-orders/{id}/mark-as-sent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["PurchaseController_markAsSent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/purchase-orders/{id}": {
         parameters: {
             query?: never;
@@ -2772,6 +2788,27 @@ export interface operations {
         };
         responses: {
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    PurchaseController_markAsSent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/core-web/src/api/purchase-orders.ts
+++ b/apps/core-web/src/api/purchase-orders.ts
@@ -1,168 +1,229 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { PurchaseOrder } from './types'
-import { fetchWithAuth } from './client'
-import type { DataTableQueryParams } from '@/hooks/useDataTableQuery'
-import { buildDataTableUrl } from './data-table-query'
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { PurchaseOrder } from "./types";
+import { fetchWithAuth } from "./client";
+import type { DataTableQueryParams } from "@/hooks/useDataTableQuery";
+import { buildDataTableUrl } from "./data-table-query";
 
-const PO_API = '/api/purchase-orders'
+const PO_API = "/api/purchase-orders";
 
 export const purchaseOrderKeys = {
-    all: ['purchase-orders'] as const,
-    list: (queryParams?: DataTableQueryParams) => [...purchaseOrderKeys.all, 'list', queryParams] as const,
-    detail: (id: string) => [...purchaseOrderKeys.all, 'detail', id] as const,
-}
+  all: ["purchase-orders"] as const,
+  list: (queryParams?: DataTableQueryParams) =>
+    [...purchaseOrderKeys.all, "list", queryParams] as const,
+  detail: (id: string) => [...purchaseOrderKeys.all, "detail", id] as const,
+};
 
 type PurchaseOrderListResponse = {
-    data: PurchaseOrder[]
-    meta: {
-        total: number
-        page: number
-        pageSize: number
-        pageCount: number
-    }
-}
+  data: PurchaseOrder[];
+  meta: {
+    total: number;
+    page: number;
+    pageSize: number;
+    pageCount: number;
+  };
+};
 
 export function usePurchaseOrders(queryParams?: DataTableQueryParams) {
-    return useQuery<PurchaseOrderListResponse>({
-        queryKey: purchaseOrderKeys.list(queryParams),
-        queryFn: async () => {
-            const url = buildDataTableUrl(PO_API, queryParams, {
-                sortFieldMap: { vendor: 'vendor.name' },
-                searchFallbackFilterFields: ['order_number'],
-                exactFilterMap: { status: 'status' },
-            })
+  return useQuery<PurchaseOrderListResponse>({
+    queryKey: purchaseOrderKeys.list(queryParams),
+    queryFn: async () => {
+      const url = buildDataTableUrl(PO_API, queryParams, {
+        sortFieldMap: { vendor: "vendor.name" },
+        searchFallbackFilterFields: ["order_number"],
+        exactFilterMap: { status: "status" },
+      });
 
-            const res = await fetchWithAuth(url)
-            if (!res.ok) throw new Error('Failed to fetch purchase orders')
-            return res.json()
-        },
-        placeholderData: (previousData) => previousData,
-    })
+      const res = await fetchWithAuth(url);
+      if (!res.ok) throw new Error("Failed to fetch purchase orders");
+      return res.json();
+    },
+    placeholderData: (previousData) => previousData,
+  });
 }
 
 export function useCreatePO() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async (data: { vendorId: string; items: { catalogItemId: string; quantity: number; unitCost: number }[] }) => {
-            const res = await fetchWithAuth(PO_API, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!res.ok) throw new Error('Failed to create PO')
-            return res.json()
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all })
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: {
+      vendorId: string;
+      items: { catalogItemId: string; quantity: number; unitCost: number }[];
+    }) => {
+      const res = await fetchWithAuth(PO_API, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error("Failed to create PO");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
 
 export function usePurchaseOrder(id: string) {
-    return useQuery({
-        queryKey: purchaseOrderKeys.detail(id),
-        queryFn: async () => {
-            // The endpoint isn't explicitly defined in my previous view_file of controller, but usually we need one.
-            // I see `receiveItems` uses `:id/receive`.
-            // I should probably add `@Get(':id')` to backend too.
-            const res = await fetchWithAuth(`${PO_API}/${id}`)
-            if (!res.ok) throw new Error('Failed to fetch PO')
-            return res.json() as Promise<PurchaseOrder>
-        },
-        enabled: !!id,
-    })
+  return useQuery({
+    queryKey: purchaseOrderKeys.detail(id),
+    queryFn: async () => {
+      // The endpoint isn't explicitly defined in my previous view_file of controller, but usually we need one.
+      // I see `receiveItems` uses `:id/receive`.
+      // I should probably add `@Get(':id')` to backend too.
+      const res = await fetchWithAuth(`${PO_API}/${id}`);
+      if (!res.ok) throw new Error("Failed to fetch PO");
+      return res.json() as Promise<PurchaseOrder>;
+    },
+    enabled: !!id,
+  });
+}
+
+export function useMarkPOSent() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetchWithAuth(`${PO_API}/${id}/mark-as-sent`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const error = await res
+          .json()
+          .catch(() => ({ message: "Failed to mark PO as sent" }));
+        throw new Error(error.message || "Failed to mark PO as sent");
+      }
+      return res.json();
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
 
 export function useReceiveGoods() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async ({ orderId, items }: { orderId: string; items: { itemId: string; quantity: number }[] }) => {
-            const res = await fetchWithAuth(`${PO_API}/${orderId}/receive`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ items }),
-            })
-            if (!res.ok) throw new Error('Failed to receive goods')
-            return res.json()
-        },
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.detail(variables.orderId) })
-            queryClient.invalidateQueries({ queryKey: ['inventory'] }) // Update stock lists
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      orderId,
+      items,
+    }: {
+      orderId: string;
+      items: { itemId: string; quantity: number }[];
+    }) => {
+      const res = await fetchWithAuth(`${PO_API}/${orderId}/receive`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items }),
+      });
+      if (!res.ok) throw new Error("Failed to receive goods");
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: purchaseOrderKeys.detail(variables.orderId),
+      });
+      queryClient.invalidateQueries({ queryKey: ["inventory"] }); // Update stock lists
+    },
+  });
 }
 
 export function useAddPOItems() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async ({ orderId, items }: { orderId: string; items: { catalogItemId: string; quantity: number; unitCost: number }[] }) => {
-            const res = await fetchWithAuth(`${PO_API}/${orderId}/items`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(items),
-            })
-            if (!res.ok) throw new Error('Failed to add items to PO')
-            return res.json()
-        },
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.detail(variables.orderId) })
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all })
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      orderId,
+      items,
+    }: {
+      orderId: string;
+      items: { catalogItemId: string; quantity: number; unitCost: number }[];
+    }) => {
+      const res = await fetchWithAuth(`${PO_API}/${orderId}/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(items),
+      });
+      if (!res.ok) throw new Error("Failed to add items to PO");
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: purchaseOrderKeys.detail(variables.orderId),
+      });
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
 
 export function useUpdatePOItem() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async ({ orderId, itemId, updates }: { orderId: string; itemId: string; updates: { quantity?: number; unitCost?: number } }) => {
-            const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(updates),
-            })
-            if (!res.ok) throw new Error('Failed to update PO item')
-            return res.json()
-        },
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.detail(variables.orderId) })
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all })
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      orderId,
+      itemId,
+      updates,
+    }: {
+      orderId: string;
+      itemId: string;
+      updates: { quantity?: number; unitCost?: number };
+    }) => {
+      const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      });
+      if (!res.ok) throw new Error("Failed to update PO item");
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: purchaseOrderKeys.detail(variables.orderId),
+      });
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
 
 export function useDeletePOItem() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async ({ orderId, itemId }: { orderId: string; itemId: string }) => {
-            const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
-                method: 'DELETE',
-            })
-            if (!res.ok) throw new Error('Failed to delete PO item')
-            return res.json()
-        },
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.detail(variables.orderId) })
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all })
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      orderId,
+      itemId,
+    }: {
+      orderId: string;
+      itemId: string;
+    }) => {
+      const res = await fetchWithAuth(`${PO_API}/${orderId}/items/${itemId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to delete PO item");
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: purchaseOrderKeys.detail(variables.orderId),
+      });
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
 
 export function useDeletePurchaseOrder() {
-    const queryClient = useQueryClient()
-    return useMutation({
-        mutationFn: async (id: string) => {
-            const res = await fetchWithAuth(`${PO_API}/${id}`, {
-                method: 'DELETE',
-            })
-            if (!res.ok) {
-                const error = await res.json().catch(() => ({ message: 'Failed to delete purchase order' }))
-                throw new Error(error.message || 'Failed to delete purchase order')
-            }
-            return id
-        },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all })
-        },
-    })
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetchWithAuth(`${PO_API}/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const error = await res
+          .json()
+          .catch(() => ({ message: "Failed to delete purchase order" }));
+        throw new Error(error.message || "Failed to delete purchase order");
+      }
+      return id;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: purchaseOrderKeys.all });
+    },
+  });
 }
-

--- a/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
+++ b/apps/core-web/src/pages/purchase-orders/PurchaseOrderDetail.tsx
@@ -1,639 +1,755 @@
-import { useState, useRef, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
-import { usePurchaseOrder, useReceiveGoods, useAddPOItems, useUpdatePOItem, useDeletePOItem } from '@/api/purchase-orders'
-import { useInventory } from '@/api/inventory'
-import { useUnbilledReceipts } from '@/api/usePurchaseInvoices'
-import { Button } from '@/components/ui/button'
-import { toast } from "sonner"
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { formatCurrency } from '@/lib/utils'
+import { useState, useRef, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table'
+  usePurchaseOrder,
+  useReceiveGoods,
+  useAddPOItems,
+  useUpdatePOItem,
+  useDeletePOItem,
+  useMarkPOSent,
+} from "@/api/purchase-orders";
+import { useInventory } from "@/api/inventory";
+import { useUnbilledReceipts } from "@/api/usePurchaseInvoices";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils";
 import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-    DialogFooter,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { StatusBadge } from '@/components/status/StatusBadge'
-import { Command, CommandList, CommandItem, CommandEmpty, CommandGroup } from '@/components/ui/command'
-import type { PurchaseOrder, PurchaseOrderItem } from '@/api/types'
-import { Receipt, Trash2 } from "lucide-react"
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { StatusBadge } from "@/components/status/StatusBadge";
+import {
+  Command,
+  CommandList,
+  CommandItem,
+  CommandEmpty,
+  CommandGroup,
+} from "@/components/ui/command";
+import type { PurchaseOrder, PurchaseOrderItem } from "@/api/types";
+import { Receipt, Trash2 } from "lucide-react";
 
 interface InventoryItem {
-    id: string
-    name: string
-    sku: string
-    price: number
-    quantity_available: number
-    brand: string
+  id: string;
+  name: string;
+  sku: string;
+  price: number;
+  quantity_available: number;
+  brand: string;
 }
 
 interface StagedPOItem {
-    id: string
-    name: string
-    sku: string
-    price: number
+  id: string;
+  name: string;
+  sku: string;
+  price: number;
 }
 
 export default function PurchaseOrderDetail() {
-    const { id } = useParams<{ id: string }>()
-    const navigate = useNavigate()
-    const { data: po, isLoading, error } = usePurchaseOrder(id!)
-    const [isReceiveDialogOpen, setIsReceiveDialogOpen] = useState(false)
-    const [editingItemId, setEditingItemId] = useState<string | null>(null)
-    const [editingQty, setEditingQty] = useState<string>('')
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const markAsSent = useMarkPOSent();
+  const { data: po, isLoading, error } = usePurchaseOrder(id!);
+  const [isReceiveDialogOpen, setIsReceiveDialogOpen] = useState(false);
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [editingQty, setEditingQty] = useState<string>("");
 
-    // Animation state
-    const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null)
-    const [poppedQtyRowId, setPoppedQtyRowId] = useState<string | null>(null)
-    const rowFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-    const qtyPopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Animation state
+  const [highlightedRowId, setHighlightedRowId] = useState<string | null>(null);
+  const [poppedQtyRowId, setPoppedQtyRowId] = useState<string | null>(null);
+  const rowFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const qtyPopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Item search state - inline pattern
-    const [searchQuery, setSearchQuery] = useState('')
-    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('')
-    const [newQty, setNewQty] = useState('1')
-    const [stagedItem, setStagedItem] = useState<StagedPOItem | null>(null)
-    const [showSuggestions, setShowSuggestions] = useState(false)
+  // Item search state - inline pattern
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [newQty, setNewQty] = useState("1");
+  const [stagedItem, setStagedItem] = useState<StagedPOItem | null>(null);
+  const [showSuggestions, setShowSuggestions] = useState(false);
 
-    const itemInputRef = useRef<HTMLInputElement | null>(null)
-    const qtyInputRef = useRef<HTMLInputElement | null>(null)
+  const itemInputRef = useRef<HTMLInputElement | null>(null);
+  const qtyInputRef = useRef<HTMLInputElement | null>(null);
 
-    // Debounce search
-    useEffect(() => {
-        const timeout = window.setTimeout(() => {
-            setDebouncedSearchQuery(searchQuery.trim())
-        }, 300)
-        return () => window.clearTimeout(timeout)
-    }, [searchQuery])
+  // Debounce search
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, 300);
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery]);
 
-    // Fetch inventory for item search - filter by vendor's supported brands
-    const vendorBrandNames = po?.vendor?.supportedBrands?.map((b) => b.name) ?? []
-    
-    // Fetch larger page size to ensure vendor-brand filtered results include all valid items
-    // We filter client-side, so we need to fetch enough items to get a good set after filtering
-    const { data: inventoryResponse } = useInventory({
-        search: debouncedSearchQuery,
-        pageSize: 100, // Increased from 10 to ensure we have valid items after brand filtering
-        brand: vendorBrandNames.length > 0 ? undefined : undefined
-    })
-    const inventory = inventoryResponse
-    
-    // Filter inventory items to only show those from vendor's supported brands
-    const filteredInventory = inventory?.data?.filter((item: InventoryItem) => 
-        vendorBrandNames.includes(item.brand)
-    ) ?? []
+  // Fetch inventory for item search - filter by vendor's supported brands
+  const vendorBrandNames =
+    po?.vendor?.supportedBrands?.map((b) => b.name) ?? [];
 
-    // Mutations
-    const addItems = useAddPOItems()
-    const updateItem = useUpdatePOItem()
-    const deleteItem = useDeletePOItem()
+  // Fetch larger page size to ensure vendor-brand filtered results include all valid items
+  // We filter client-side, so we need to fetch enough items to get a good set after filtering
+  const { data: inventoryResponse } = useInventory({
+    search: debouncedSearchQuery,
+    pageSize: 100, // Increased from 10 to ensure we have valid items after brand filtering
+    brand: vendorBrandNames.length > 0 ? undefined : undefined,
+  });
+  const inventory = inventoryResponse;
 
-    // Fetch unbilled receipts for this vendor to calculate count related to this PO
-    const { data: unbilledItems = [] } = useUnbilledReceipts(po?.vendor_id)
+  // Filter inventory items to only show those from vendor's supported brands
+  const filteredInventory =
+    inventory?.data?.filter((item: InventoryItem) =>
+      vendorBrandNames.includes(item.brand),
+    ) ?? [];
 
-    // Filter unbilled items for this specific PO
-    const poUnbilledCount = unbilledItems.filter(item => item.purchaseOrderNumber === po?.order_number).length
+  // Mutations
+  const addItems = useAddPOItems();
+  const updateItem = useUpdatePOItem();
+  const deleteItem = useDeletePOItem();
 
-    const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            e.preventDefault()
-            const firstPart = filteredInventory?.[0]
-            if (firstPart) {
-                stagePart(firstPart)
-            }
-        }
+  // Fetch unbilled receipts for this vendor to calculate count related to this PO
+  const { data: unbilledItems = [] } = useUnbilledReceipts(po?.vendor_id);
+
+  // Filter unbilled items for this specific PO
+  const poUnbilledCount = unbilledItems.filter(
+    (item) => item.purchaseOrderNumber === po?.order_number,
+  ).length;
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const firstPart = filteredInventory?.[0];
+      if (firstPart) {
+        stagePart(firstPart);
+      }
+    }
+  };
+
+  const handleQtyKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      confirmAddItem();
+    }
+  };
+
+  function stagePart(item: InventoryItem) {
+    setStagedItem({
+      id: item.id,
+      name: item.name,
+      sku: item.sku,
+      price: item.price,
+    });
+    setSearchQuery(`${item.sku} · ${item.name}`);
+    setDebouncedSearchQuery("");
+    setNewQty("1");
+    setShowSuggestions(false);
+    requestAnimationFrame(() => {
+      qtyInputRef.current?.focus();
+      qtyInputRef.current?.select();
+    });
+  }
+
+  function clearQuickEntry() {
+    setSearchQuery("");
+    setDebouncedSearchQuery("");
+    setStagedItem(null);
+    setNewQty("1");
+    requestAnimationFrame(() => itemInputRef.current?.focus());
+  }
+
+  function triggerMergeFeedback(itemId: string) {
+    if (rowFlashTimeoutRef.current) {
+      window.clearTimeout(rowFlashTimeoutRef.current);
+    }
+    if (qtyPopTimeoutRef.current) {
+      window.clearTimeout(qtyPopTimeoutRef.current);
+    }
+    setHighlightedRowId(itemId);
+    setPoppedQtyRowId(itemId);
+    rowFlashTimeoutRef.current = window.setTimeout(() => {
+      setHighlightedRowId(null);
+    }, 500);
+    qtyPopTimeoutRef.current = window.setTimeout(() => {
+      setPoppedQtyRowId(null);
+    }, 240);
+  }
+
+  function confirmAddItem() {
+    if (!stagedItem || !id || !po) return;
+    const qty = Number(newQty);
+
+    // Validate quantity strictly - don't silently default to 1
+    if (!Number.isFinite(qty) || qty <= 0) {
+      toast.error("Invalid quantity", {
+        description: "Please enter a positive number",
+      });
+      return;
     }
 
-    const handleQtyKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            e.preventDefault()
-            confirmAddItem()
-        }
-    }
+    // Check if item already exists in the PO
+    const existingItem = po.items.find(
+      (item: PurchaseOrderItem) => item.catalog_item_id === stagedItem.id,
+    );
 
-    function stagePart(item: InventoryItem) {
-        setStagedItem({
-            id: item.id,
-            name: item.name,
-            sku: item.sku,
-            price: item.price,
-        })
-        setSearchQuery(`${item.sku} · ${item.name}`)
-        setDebouncedSearchQuery('')
-        setNewQty('1')
-        setShowSuggestions(false)
-        requestAnimationFrame(() => {
-            qtyInputRef.current?.focus()
-            qtyInputRef.current?.select()
-        })
-    }
-
-    function clearQuickEntry() {
-        setSearchQuery('')
-        setDebouncedSearchQuery('')
-        setStagedItem(null)
-        setNewQty('1')
-        requestAnimationFrame(() => itemInputRef.current?.focus())
-    }
-
-    function triggerMergeFeedback(itemId: string) {
-        if (rowFlashTimeoutRef.current) {
-            window.clearTimeout(rowFlashTimeoutRef.current)
-        }
-        if (qtyPopTimeoutRef.current) {
-            window.clearTimeout(qtyPopTimeoutRef.current)
-        }
-        setHighlightedRowId(itemId)
-        setPoppedQtyRowId(itemId)
-        rowFlashTimeoutRef.current = window.setTimeout(() => {
-            setHighlightedRowId(null)
-        }, 500)
-        qtyPopTimeoutRef.current = window.setTimeout(() => {
-            setPoppedQtyRowId(null)
-        }, 240)
-    }
-
-    function confirmAddItem() {
-        if (!stagedItem || !id || !po) return
-        const qty = Number(newQty)
-        
-        // Validate quantity strictly - don't silently default to 1
-        if (!Number.isFinite(qty) || qty <= 0) {
-            toast.error('Invalid quantity', { description: 'Please enter a positive number' })
-            return
-        }
-
-        // Check if item already exists in the PO
-        const existingItem = po.items.find((item: PurchaseOrderItem) => item.catalog_item_id === stagedItem.id)
-
-        if (existingItem) {
-            // Item exists - update quantity by adding the new quantity
-            const newTotalQty = existingItem.quantity + qty
-            updateItem.mutate({
-                orderId: id,
-                itemId: existingItem.id,
-                updates: { quantity: newTotalQty }
-            }, {
-                onSuccess: () => {
-                    toast.success(`Quantity updated to ${newTotalQty}`)
-                    triggerMergeFeedback(existingItem.id)
-                    clearQuickEntry()
-                },
-                onError: (error) => {
-                    toast.error('Failed to update item', { description: error.message })
-                }
-            })
-        } else {
-            // Item doesn't exist - add as new
-            addItems.mutate({
-                orderId: id,
-                items: [{
-                    catalogItemId: stagedItem.id,
-                    quantity: qty,
-                    unitCost: stagedItem.price,
-                }]
-            }, {
-                onSuccess: () => {
-                    toast.success('Item added to PO')
-                    clearQuickEntry()
-                },
-                onError: (error) => {
-                    toast.error('Failed to add item', { description: error.message })
-                }
-            })
-        }
-    }
-
-    const handleUpdateItemQty = (itemId: string, newQty: string) => {
-        const qty = Number(newQty)
-        if (!Number.isFinite(qty) || qty <= 0) return
-
-        if (!po) return
-
-        // Find the item to check quantity_received
-        const item = po.items.find((i: PurchaseOrderItem) => i.id === itemId)
-        if (!item) return
-
-        // Validate that new quantity is not less than already received
-        if (qty < item.quantity_received) {
-            toast.error('Invalid quantity', { 
-                description: `Cannot reduce quantity below ${item.quantity_received} already received`
-            })
-            setEditingItemId(null)
-            setEditingQty('')
-            return
-        }
-
-        if (!id) return
-        updateItem.mutate({
-            orderId: id,
-            itemId,
-            updates: { quantity: qty }
-        }, {
-            onSuccess: () => {
-                toast.success('Item quantity updated')
-                setEditingItemId(null)
-                setEditingQty('')
+    if (existingItem) {
+      // Item exists - update quantity by adding the new quantity
+      const newTotalQty = existingItem.quantity + qty;
+      updateItem.mutate(
+        {
+          orderId: id,
+          itemId: existingItem.id,
+          updates: { quantity: newTotalQty },
+        },
+        {
+          onSuccess: () => {
+            toast.success(`Quantity updated to ${newTotalQty}`);
+            triggerMergeFeedback(existingItem.id);
+            clearQuickEntry();
+          },
+          onError: (error) => {
+            toast.error("Failed to update item", {
+              description: error.message,
+            });
+          },
+        },
+      );
+    } else {
+      // Item doesn't exist - add as new
+      addItems.mutate(
+        {
+          orderId: id,
+          items: [
+            {
+              catalogItemId: stagedItem.id,
+              quantity: qty,
+              unitCost: stagedItem.price,
             },
-            onError: (error) => {
-                toast.error('Failed to update item', { description: error.message })
-            }
-        })
+          ],
+        },
+        {
+          onSuccess: () => {
+            toast.success("Item added to PO");
+            clearQuickEntry();
+          },
+          onError: (error) => {
+            toast.error("Failed to add item", { description: error.message });
+          },
+        },
+      );
+    }
+  }
+
+  const handleUpdateItemQty = (itemId: string, newQty: string) => {
+    const qty = Number(newQty);
+    if (!Number.isFinite(qty) || qty <= 0) return;
+
+    if (!po) return;
+
+    // Find the item to check quantity_received
+    const item = po.items.find((i: PurchaseOrderItem) => i.id === itemId);
+    if (!item) return;
+
+    // Validate that new quantity is not less than already received
+    if (qty < item.quantity_received) {
+      toast.error("Invalid quantity", {
+        description: `Cannot reduce quantity below ${item.quantity_received} already received`,
+      });
+      setEditingItemId(null);
+      setEditingQty("");
+      return;
     }
 
-    const handleDeleteItem = (itemId: string) => {
-        if (!id) return
-        if (confirm('Are you sure you want to delete this item?')) {
-            deleteItem.mutate({
-                orderId: id,
-                itemId,
-            }, {
-                onSuccess: () => {
-                    toast.success('Item deleted')
-                },
-                onError: (error) => {
-                    toast.error('Failed to delete item', { description: error.message })
-                }
-            })
-        }
+    if (!id) return;
+    updateItem.mutate(
+      {
+        orderId: id,
+        itemId,
+        updates: { quantity: qty },
+      },
+      {
+        onSuccess: () => {
+          toast.success("Item quantity updated");
+          setEditingItemId(null);
+          setEditingQty("");
+        },
+        onError: (error) => {
+          toast.error("Failed to update item", { description: error.message });
+        },
+      },
+    );
+  };
+
+  const handleDeleteItem = (itemId: string) => {
+    if (!id) return;
+    if (confirm("Are you sure you want to delete this item?")) {
+      deleteItem.mutate(
+        {
+          orderId: id,
+          itemId,
+        },
+        {
+          onSuccess: () => {
+            toast.success("Item deleted");
+          },
+          onError: (error) => {
+            toast.error("Failed to delete item", {
+              description: error.message,
+            });
+          },
+        },
+      );
     }
+  };
 
-    if (isLoading) return <div>Loading order...</div>
-    if (error) return <div>Error loading order</div>
-    if (!po) return <div>Order not found</div>
+  if (isLoading) return <div>Loading order...</div>;
+  if (error) return <div>Error loading order</div>;
+  if (!po) return <div>Order not found</div>;
 
-    return (
-        <div className="w-full max-w-7xl mx-auto p-6 space-y-8">
-            <div className="flex items-center justify-between mb-8">
-                <div>
-                    <h1 className="text-2xl font-semibold tracking-tight">{po.order_number}</h1>
-                    <p className="text-slate-500">Vendor: {po.vendor?.name}</p>
-                </div>
-                <div className="flex items-center space-x-4">
-                    <StatusBadge status={po.status} />
-
-                    <Button
-                        variant="outline"
-                        disabled={poUnbilledCount === 0}
-                        onClick={() => navigate(`/purchase-invoices/new?vendorId=${po.vendor_id}&poId=${po.id}`)}
-                    >
-                        <Receipt className="mr-2 h-4 w-4" />
-                        Create Bill ({poUnbilledCount} items)
-                    </Button>
-
-                    {po.status !== 'COMPLETED' && (
-                        <Button onClick={() => setIsReceiveDialogOpen(true)}>
-                            Receive Goods
-                        </Button>
-                    )}
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-                <div className="space-y-6 lg:col-span-1">
-                    <Card>
-                        <CardHeader>
-                            <CardTitle className="text-base font-semibold">Purchase Order</CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-4 text-sm">
-                            <div>
-                                <div className="text-muted-foreground">Order #</div>
-                                <div className="font-medium">{po.order_number}</div>
-                            </div>
-                            <div>
-                                <div className="text-muted-foreground">Created</div>
-                                <div className="font-medium">{new Date(po.createdAt).toLocaleDateString()}</div>
-                            </div>
-                            <div>
-                                <div className="text-muted-foreground">Items</div>
-                                <div className="font-medium">{po.items.length}</div>
-                            </div>
-                            <div>
-                                <div className="text-muted-foreground">Unbilled Receipts</div>
-                                <div className="font-medium">{poUnbilledCount} items</div>
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardHeader>
-                            <CardTitle className="text-base font-semibold">Vendor</CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-2 text-sm">
-                            <div className="font-medium">{po.vendor?.name}</div>
-                            {po.vendor?.email && <div className="text-muted-foreground">{po.vendor.email}</div>}
-                            {po.vendor?.account_number && (
-                                <div className="text-muted-foreground">Account: {po.vendor.account_number}</div>
-                            )}
-                        </CardContent>
-                    </Card>
-                </div>
-
-                <div className="lg:col-span-2">
-                    <Card>
-                        <CardHeader>
-                            <CardTitle className="text-base font-semibold">Line Items</CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-2 p-3">
-                            {/* Inline Item Search & Add Panel */}
-                            <div className="border rounded-xl bg-muted/40 px-3 py-2">
-                                <div className="grid grid-cols-[1fr_70px_auto] gap-2">
-                                    <div className="relative">
-                                        <Input
-                                            ref={itemInputRef}
-                                            value={searchQuery}
-                                            onChange={(e) => {
-                                                if (stagedItem) {
-                                                    setStagedItem(null)
-                                                }
-                                                setSearchQuery(e.target.value)
-                                            }}
-                                            onKeyDown={handleSearchKeyDown}
-                                            onFocus={() => setShowSuggestions(true)}
-                                            placeholder="Search part number or name..."
-                                            className="h-8 text-xs"
-                                        />
-                                        {showSuggestions && debouncedSearchQuery && (
-                                            <div className="absolute left-0 right-0 top-full z-20 mt-1 rounded-md border bg-popover shadow-md">
-                                                <Command shouldFilter={false}>
-                                                    <CommandList className="max-h-64">
-                                                        {filteredInventory.length === 0 && (
-                                                            <CommandEmpty>
-                                                                {vendorBrandNames.length === 0 
-                                                                    ? 'No vendor brands configured.' 
-                                                                    : 'No parts found for this vendor\'s brands.'}
-                                                            </CommandEmpty>
-                                                        )}
-                                                        {filteredInventory.length > 0 && (
-                                                            <CommandGroup heading="Parts">
-                                                                {filteredInventory.map((item: InventoryItem) => {
-                                                                    return (
-                                                                        <CommandItem
-                                                                            key={item.id}
-                                                                            value={`${item.sku} ${item.name}`}
-                                                                            onSelect={() => stagePart(item)}
-                                                                        >
-                                                                            <div className="flex w-full items-center justify-between gap-2">
-                                                                                <div className="min-w-0">
-                                                                                    <div className="text-xs font-medium">{item.sku}</div>
-                                                                                    <div className="truncate text-xs text-muted-foreground">
-                                                                                        {item.name}
-                                                                                    </div>
-                                                                                </div>
-                                                                                <div className="shrink-0 text-right text-xs text-muted-foreground">
-                                                                                    <div>{formatCurrency(item.price)}</div>
-                                                                                    <div>Stock: {item.quantity_available}</div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </CommandItem>
-                                                                    )
-                                                                })}
-                                                            </CommandGroup>
-                                                        )}
-                                                    </CommandList>
-                                                </Command>
-                                            </div>
-                                        )}
-                                    </div>
-
-                                    <Input
-                                        ref={qtyInputRef}
-                                        value={newQty}
-                                        onChange={(e) => setNewQty(e.target.value)}
-                                        onKeyDown={handleQtyKeyDown}
-                                        placeholder="Qty"
-                                        className="h-8 text-xs text-right"
-                                        disabled={!stagedItem}
-                                    />
-                                    <Button
-                                        type="button"
-                                        size="sm"
-                                        className="h-8 px-3 text-xs"
-                                        onClick={confirmAddItem}
-                                        disabled={!stagedItem || addItems.isPending}
-                                    >
-                                        {addItems.isPending ? '...' : '+ Add'}
-                                    </Button>
-                                </div>
-                            </div>
-
-                            {/* Items Table */}
-                            <div className="border rounded-md overflow-x-auto">
-                                <Table className="min-w-[700px]">
-                                <TableHeader>
-                                    <TableRow>
-                                        <TableHead>SKU</TableHead>
-                                        <TableHead>Item</TableHead>
-                                        <TableHead className="text-right">Ordered</TableHead>
-                                        <TableHead className="text-right">Received</TableHead>
-                                        <TableHead className="text-right">Remaining</TableHead>
-                                        <TableHead className="text-right">Cost</TableHead>
-                                        <TableHead className="w-[100px]"></TableHead>
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                    {po.items.map((item: PurchaseOrderItem) => (
-                                        <TableRow 
-                                            key={item.id}
-                                            className={`transition-colors duration-500 ${
-                                                highlightedRowId === item.id
-                                                    ? 'bg-blue-50/80 dark:bg-blue-500/20'
-                                                    : ''
-                                            }`}
-                                        >
-                                            <TableCell>{item.catalog_item?.sku || 'N/A'}</TableCell>
-                                            <TableCell>{item.catalog_item?.name || 'Unknown Item'}</TableCell>
-                                            <TableCell className="text-right">
-                                                {editingItemId === item.id ? (
-                                                    <motion.div
-                                                        animate={
-                                                            poppedQtyRowId === item.id
-                                                                ? { scale: [1, 1.2, 1] }
-                                                                : { scale: 1 }
-                                                        }
-                                                        transition={{ duration: 0.24, ease: 'easeOut' }}
-                                                        className="origin-center"
-                                                    >
-                                                        <Input
-                                                            type="number"
-                                                            min="1"
-                                                            value={editingQty}
-                                                            onChange={(e) => setEditingQty(e.target.value)}
-                                                            onBlur={() => {
-                                                                if (editingQty && editingQty !== item.quantity.toString()) {
-                                                                    handleUpdateItemQty(item.id, editingQty)
-                                                                } else {
-                                                                    setEditingItemId(null)
-                                                                    setEditingQty('')
-                                                                }
-                                                            }}
-                                                            onKeyDown={(e) => {
-                                                                if (e.key === 'Enter') {
-                                                                    handleUpdateItemQty(item.id, editingQty)
-                                                                } else if (e.key === 'Escape') {
-                                                                    setEditingItemId(null)
-                                                                    setEditingQty('')
-                                                                }
-                                                            }}
-                                                        className="w-16 text-right"
-                                                        autoFocus
-                                                    />
-                                                    </motion.div>
-                                                ) : (
-                                                    <motion.div
-                                                        animate={
-                                                            poppedQtyRowId === item.id
-                                                                ? { scale: [1, 1.2, 1] }
-                                                                : { scale: 1 }
-                                                        }
-                                                        transition={{ duration: 0.24, ease: 'easeOut' }}
-                                                        className="origin-center"
-                                                    >
-                                                        <div 
-                                                            onClick={() => {
-                                                                setEditingItemId(item.id)
-                                                                setEditingQty(item.quantity.toString())
-                                                            }}
-                                                            className="cursor-pointer hover:text-primary"
-                                                        >
-                                                            {item.quantity}
-                                                        </div>
-                                                    </motion.div>
-                                                )}
-                                            </TableCell>
-                                            <TableCell className="text-right text-green-600 font-medium">
-                                                {item.quantity_received}
-                                            </TableCell>
-                                            <TableCell className="text-right text-orange-600">
-                                                {item.quantity - item.quantity_received}
-                                            </TableCell>
-                                            <TableCell className="text-right">
-                                                {item.unit_cost === null || item.unit_cost === undefined
-                                                    ? '—'
-                                                    : formatCurrency(item.unit_cost)}
-                                            </TableCell>
-                                            <TableCell className="text-right">
-                                                <Button
-                                                    size="icon"
-                                                    variant="ghost"
-                                                    onClick={() => handleDeleteItem(item.id)}
-                                                    disabled={item.quantity_received > 0}
-                                                    title={item.quantity_received > 0 ? 'Cannot delete items that have been received' : 'Delete item'}
-                                                >
-                                                    <Trash2 className="h-4 w-4 text-red-500" />
-                                                </Button>
-                                            </TableCell>
-                                        </TableRow>
-                                    ))}
-                                </TableBody>
-                            </Table>
-                            </div>
-                        </CardContent>
-                    </Card>
-                </div>
-            </div>
-
-            <ReceiveGoodsDialog
-                open={isReceiveDialogOpen}
-                onOpenChange={setIsReceiveDialogOpen}
-                po={po}
-            />
+  return (
+    <div className="w-full max-w-7xl mx-auto p-6 space-y-8">
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {po.order_number}
+          </h1>
+          <p className="text-slate-500">Vendor: {po.vendor?.name}</p>
         </div>
-    )
+        <div className="flex items-center space-x-4">
+          <StatusBadge status={po.status} />
+
+          {po.status === "DRAFT" && (
+            <Button
+              variant="default"
+              onClick={() => {
+                toast.promise(markAsSent.mutateAsync(po.id), {
+                  loading: "Marking as sent...",
+                  success: "Purchase order marked as sent",
+                  error: "Failed to mark as sent",
+                });
+              }}
+              disabled={markAsSent.isPending}
+            >
+              Mark as Sent
+            </Button>
+          )}
+
+          <Button
+            variant="outline"
+            disabled={poUnbilledCount === 0}
+            onClick={() =>
+              navigate(
+                `/purchase-invoices/new?vendorId=${po.vendor_id}&poId=${po.id}`,
+              )
+            }
+          >
+            <Receipt className="mr-2 h-4 w-4" />
+            Create Bill ({poUnbilledCount} items)
+          </Button>
+
+          {po.status !== "COMPLETED" && (
+            <Button onClick={() => setIsReceiveDialogOpen(true)}>
+              Receive Goods
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+        <div className="space-y-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">
+                Purchase Order
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div>
+                <div className="text-muted-foreground">Order #</div>
+                <div className="font-medium">{po.order_number}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">Created</div>
+                <div className="font-medium">
+                  {new Date(po.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">Items</div>
+                <div className="font-medium">{po.items.length}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">Unbilled Receipts</div>
+                <div className="font-medium">{poUnbilledCount} items</div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Vendor</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="font-medium">{po.vendor?.name}</div>
+              {po.vendor?.email && (
+                <div className="text-muted-foreground">{po.vendor.email}</div>
+              )}
+              {po.vendor?.account_number && (
+                <div className="text-muted-foreground">
+                  Account: {po.vendor.account_number}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">
+                Line Items
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 p-3">
+              {/* Inline Item Search & Add Panel */}
+              <div className="border rounded-xl bg-muted/40 px-3 py-2">
+                <div className="grid grid-cols-[1fr_70px_auto] gap-2">
+                  <div className="relative">
+                    <Input
+                      ref={itemInputRef}
+                      value={searchQuery}
+                      onChange={(e) => {
+                        if (stagedItem) {
+                          setStagedItem(null);
+                        }
+                        setSearchQuery(e.target.value);
+                      }}
+                      onKeyDown={handleSearchKeyDown}
+                      onFocus={() => setShowSuggestions(true)}
+                      placeholder="Search part number or name..."
+                      className="h-8 text-xs"
+                    />
+                    {showSuggestions && debouncedSearchQuery && (
+                      <div className="absolute left-0 right-0 top-full z-20 mt-1 rounded-md border bg-popover shadow-md">
+                        <Command shouldFilter={false}>
+                          <CommandList className="max-h-64">
+                            {filteredInventory.length === 0 && (
+                              <CommandEmpty>
+                                {vendorBrandNames.length === 0
+                                  ? "No vendor brands configured."
+                                  : "No parts found for this vendor's brands."}
+                              </CommandEmpty>
+                            )}
+                            {filteredInventory.length > 0 && (
+                              <CommandGroup heading="Parts">
+                                {filteredInventory.map(
+                                  (item: InventoryItem) => {
+                                    return (
+                                      <CommandItem
+                                        key={item.id}
+                                        value={`${item.sku} ${item.name}`}
+                                        onSelect={() => stagePart(item)}
+                                      >
+                                        <div className="flex w-full items-center justify-between gap-2">
+                                          <div className="min-w-0">
+                                            <div className="text-xs font-medium">
+                                              {item.sku}
+                                            </div>
+                                            <div className="truncate text-xs text-muted-foreground">
+                                              {item.name}
+                                            </div>
+                                          </div>
+                                          <div className="shrink-0 text-right text-xs text-muted-foreground">
+                                            <div>
+                                              {formatCurrency(item.price)}
+                                            </div>
+                                            <div>
+                                              Stock: {item.quantity_available}
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </CommandItem>
+                                    );
+                                  },
+                                )}
+                              </CommandGroup>
+                            )}
+                          </CommandList>
+                        </Command>
+                      </div>
+                    )}
+                  </div>
+
+                  <Input
+                    ref={qtyInputRef}
+                    value={newQty}
+                    onChange={(e) => setNewQty(e.target.value)}
+                    onKeyDown={handleQtyKeyDown}
+                    placeholder="Qty"
+                    className="h-8 text-xs text-right"
+                    disabled={!stagedItem}
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-8 px-3 text-xs"
+                    onClick={confirmAddItem}
+                    disabled={!stagedItem || addItems.isPending}
+                  >
+                    {addItems.isPending ? "..." : "+ Add"}
+                  </Button>
+                </div>
+              </div>
+
+              {/* Items Table */}
+              <div className="border rounded-md overflow-x-auto">
+                <Table className="min-w-[700px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>SKU</TableHead>
+                      <TableHead>Item</TableHead>
+                      <TableHead className="text-right">Ordered</TableHead>
+                      <TableHead className="text-right">Received</TableHead>
+                      <TableHead className="text-right">Remaining</TableHead>
+                      <TableHead className="text-right">Cost</TableHead>
+                      <TableHead className="w-[100px]"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {po.items.map((item: PurchaseOrderItem) => (
+                      <TableRow
+                        key={item.id}
+                        className={`transition-colors duration-500 ${
+                          highlightedRowId === item.id
+                            ? "bg-blue-50/80 dark:bg-blue-500/20"
+                            : ""
+                        }`}
+                      >
+                        <TableCell>{item.catalog_item?.sku || "N/A"}</TableCell>
+                        <TableCell>
+                          {item.catalog_item?.name || "Unknown Item"}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {editingItemId === item.id ? (
+                            <motion.div
+                              animate={
+                                poppedQtyRowId === item.id
+                                  ? { scale: [1, 1.2, 1] }
+                                  : { scale: 1 }
+                              }
+                              transition={{ duration: 0.24, ease: "easeOut" }}
+                              className="origin-center"
+                            >
+                              <Input
+                                type="number"
+                                min="1"
+                                value={editingQty}
+                                onChange={(e) => setEditingQty(e.target.value)}
+                                onBlur={() => {
+                                  if (
+                                    editingQty &&
+                                    editingQty !== item.quantity.toString()
+                                  ) {
+                                    handleUpdateItemQty(item.id, editingQty);
+                                  } else {
+                                    setEditingItemId(null);
+                                    setEditingQty("");
+                                  }
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") {
+                                    handleUpdateItemQty(item.id, editingQty);
+                                  } else if (e.key === "Escape") {
+                                    setEditingItemId(null);
+                                    setEditingQty("");
+                                  }
+                                }}
+                                className="w-16 text-right"
+                                autoFocus
+                              />
+                            </motion.div>
+                          ) : (
+                            <motion.div
+                              animate={
+                                poppedQtyRowId === item.id
+                                  ? { scale: [1, 1.2, 1] }
+                                  : { scale: 1 }
+                              }
+                              transition={{ duration: 0.24, ease: "easeOut" }}
+                              className="origin-center"
+                            >
+                              <div
+                                onClick={() => {
+                                  setEditingItemId(item.id);
+                                  setEditingQty(item.quantity.toString());
+                                }}
+                                className="cursor-pointer hover:text-primary"
+                              >
+                                {item.quantity}
+                              </div>
+                            </motion.div>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right text-green-600 font-medium">
+                          {item.quantity_received}
+                        </TableCell>
+                        <TableCell className="text-right text-orange-600">
+                          {item.quantity - item.quantity_received}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {item.unit_cost === null ||
+                          item.unit_cost === undefined
+                            ? "—"
+                            : formatCurrency(item.unit_cost)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            onClick={() => handleDeleteItem(item.id)}
+                            disabled={item.quantity_received > 0}
+                            title={
+                              item.quantity_received > 0
+                                ? "Cannot delete items that have been received"
+                                : "Delete item"
+                            }
+                          >
+                            <Trash2 className="h-4 w-4 text-red-500" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <ReceiveGoodsDialog
+        open={isReceiveDialogOpen}
+        onOpenChange={setIsReceiveDialogOpen}
+        po={po}
+      />
+    </div>
+  );
 }
 
-function ReceiveGoodsDialog({ open, onOpenChange, po }: { open: boolean; onOpenChange: (o: boolean) => void; po: PurchaseOrder }) {
-    const [receiveQuantities, setReceiveQuantities] = useState<Record<string, number>>({})
-    const receiveGoods = useReceiveGoods()
+function ReceiveGoodsDialog({
+  open,
+  onOpenChange,
+  po,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  po: PurchaseOrder;
+}) {
+  const [receiveQuantities, setReceiveQuantities] = useState<
+    Record<string, number>
+  >({});
+  const receiveGoods = useReceiveGoods();
 
-    const handleQuantityChange = (itemId: string, qty: number) => {
-        setReceiveQuantities(prev => ({ ...prev, [itemId]: qty }))
-    }
+  const handleQuantityChange = (itemId: string, qty: number) => {
+    setReceiveQuantities((prev) => ({ ...prev, [itemId]: qty }));
+  };
 
-    const handleSubmit = () => {
-        const itemsToReceive = Object.entries(receiveQuantities)
-            .filter(([, qty]) => qty > 0)
-            .map(([itemId, quantity]) => ({ itemId, quantity }))
+  const handleSubmit = () => {
+    const itemsToReceive = Object.entries(receiveQuantities)
+      .filter(([, qty]) => qty > 0)
+      .map(([itemId, quantity]) => ({ itemId, quantity }));
 
-        if (itemsToReceive.length === 0) return
+    if (itemsToReceive.length === 0) return;
 
-        receiveGoods.mutate({ orderId: po.id, items: itemsToReceive }, {
-            onSuccess: () => {
-                onOpenChange(false)
-                setReceiveQuantities({})
-            },
-            onError: (error) => {
-                toast.error("Failed to receive goods", {
-                    description: error.message
-                })
-            }
-        })
-    }
+    receiveGoods.mutate(
+      { orderId: po.id, items: itemsToReceive },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          setReceiveQuantities({});
+        },
+        onError: (error) => {
+          toast.error("Failed to receive goods", {
+            description: error.message,
+          });
+        },
+      },
+    );
+  };
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-3xl">
-                <DialogHeader>
-                    <DialogTitle>Receive Goods for {po.order_number}</DialogTitle>
-                </DialogHeader>
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Receive Goods for {po.order_number}</DialogTitle>
+        </DialogHeader>
 
-                <div className="py-4">
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Item</TableHead>
-                                <TableHead className="text-right">Remaining</TableHead>
-                                <TableHead className="w-[150px] text-right">Receive Now</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {po.items.map((item: PurchaseOrderItem) => {
-                                const remaining = item.quantity - item.quantity_received
-                                if (remaining <= 0) return null
+        <div className="py-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Item</TableHead>
+                <TableHead className="text-right">Remaining</TableHead>
+                <TableHead className="w-[150px] text-right">
+                  Receive Now
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {po.items.map((item: PurchaseOrderItem) => {
+                const remaining = item.quantity - item.quantity_received;
+                if (remaining <= 0) return null;
 
-                                return (
-                                    <TableRow key={item.catalog_item_id}>
-                                        <TableCell>
-                                            <div className="font-medium">{item.catalog_item?.sku}</div>
-                                            <div className="text-sm text-muted-foreground">{item.catalog_item?.name}</div>
-                                        </TableCell>
-                                        <TableCell className="text-right">{remaining}</TableCell>
-                                        <TableCell>
-                                            <Input
-                                                type="number"
-                                                min="0"
-                                                max={remaining}
-                                                className="text-right"
-                                                placeholder="0"
-                                                value={receiveQuantities[item.catalog_item_id] || ''}
-                                                onChange={(e) => handleQuantityChange(item.catalog_item_id, parseInt(e.target.value) || 0)}
-                                            />
-                                        </TableCell>
-                                    </TableRow>
-                                )
-                            })}
-                        </TableBody>
-                    </Table>
-                </div>
+                return (
+                  <TableRow key={item.catalog_item_id}>
+                    <TableCell>
+                      <div className="font-medium">
+                        {item.catalog_item?.sku}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {item.catalog_item?.name}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">{remaining}</TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        min="0"
+                        max={remaining}
+                        className="text-right"
+                        placeholder="0"
+                        value={receiveQuantities[item.catalog_item_id] || ""}
+                        onChange={(e) =>
+                          handleQuantityChange(
+                            item.catalog_item_id,
+                            parseInt(e.target.value) || 0,
+                          )
+                        }
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
 
-                <DialogFooter>
-                    <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-                    <Button onClick={handleSubmit} disabled={receiveGoods.isPending}>
-                        {receiveGoods.isPending ? 'Processing...' : 'Confirm Receipt'}
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    )
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={receiveGoods.isPending}>
+            {receiveGoods.isPending ? "Processing..." : "Confirm Receipt"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }


### PR DESCRIPTION
- Added `markAsSent` method to `PurchaseService` to update order status to `SENT`.
- Added `POST /purchase-orders/:id/mark-as-sent` route in `PurchaseController`.
- Added `useMarkPOSent` mutation hook to frontend API (`purchase-orders.ts`).
- Updated `PurchaseOrderDetail.tsx` to include "Mark as Sent" button under header actions.
- Unfixed `Purchase Order Detail - status workflow: Mark as Sent` test in `purchase-order-detail.spec.ts`.
- Mocked E2E test state correctly in `purchase-order-detail.spec.ts` for updated status.

---
*PR created automatically by Jules for task [7028433200353556849](https://jules.google.com/task/7028433200353556849) started by @vandean25*