### PR TITLE
🔒 [security fix] Remove hardcoded test JWT secret

### DIFF
--- a/apps/core-api/src/auth/auth.service.ts
+++ b/apps/core-api/src/auth/auth.service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import {
   ForbiddenException,
   Inject,
@@ -30,7 +31,11 @@ type AuthenticateBearerTokenOptions = {
 
 @Injectable()
 export class AuthService {
-  private readonly testJwtSecret = 'test-jwt-secret';
+  private readonly testJwtSecret =
+    process.env.TEST_JWT_SECRET ||
+    (process.env.NODE_ENV === 'test'
+      ? 'test-jwt-secret'
+      : randomBytes(32).toString('hex'));
 
   constructor(
     @Inject(forwardRef(() => PrismaService))


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded JWT secret in `apps/core-api/src/auth/auth.service.ts` used for test token verification.

⚠️ **Risk:** The potential impact if left unfixed
If the test secret is left hardcoded, an attacker who knows this secret can forge valid JWT tokens for the application, potentially gaining unauthorized access as any user or even a platform admin.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix introduces a hierarchical approach to the secret:
1. Use `process.env.TEST_JWT_SECRET` if provided.
2. If not provided and `process.env.NODE_ENV` is 'test', fall back to the known 'test-jwt-secret' to maintain test compatibility.
3. In all other cases (production, development), generate a cryptographically secure random 32-byte hex string. This ensures that a unique, unpredictable secret is used even if the environment variable is missing, preventing token forgery.

---
*PR created automatically by Jules for task [16190448674874293204](https://jules.google.com/task/16190448674874293204) started by @vandean25*