### PR TITLE
🔒 [security fix] Remove hardcoded test JWT secret (Refactored)

### DIFF
--- a/apps/core-api/src/auth/auth.service.ts
+++ b/apps/core-api/src/auth/auth.service.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import {
   ForbiddenException,
   Inject,
@@ -30,7 +31,10 @@ type AuthenticateBearerTokenOptions = {
 
 @Injectable()
 export class AuthService {
-  private readonly testJwtSecret = 'test-jwt-secret';
+  private readonly testJwtSecret =
+    process.env.NODE_ENV === 'test'
+      ? (process.env.TEST_JWT_SECRET || randomBytes(32).toString('hex'))
+      : undefined;
 
   constructor(
     @Inject(forwardRef(() => PrismaService))
@@ -113,6 +117,10 @@ export class AuthService {
   }
 
   createTestToken(overrides: Partial<AuthClaims> = {}): string {
+    if (!this.testJwtSecret) {
+      throw new Error('Test tokens can only be created in test environment.');
+    }
+
     return this.jwtService.sign(
       {
         sub: 'e2e-user-id',
@@ -167,6 +175,10 @@ export class AuthService {
   private async verifyTestToken(
     token: string,
   ): Promise<AuthClaims | undefined> {
+    if (!this.testJwtSecret) {
+      return undefined;
+    }
+
     try {
       return await this.jwtService.verifyAsync<AuthClaims>(token, {
         secret: this.testJwtSecret,


### PR DESCRIPTION
🎯 **What:** Addressed PR feedback regarding the test JWT secret.

🛡️ **Solution:**
1.  **Strict Environment Isolation:** `testJwtSecret` is now initialized to `undefined` in all environments except when `NODE_ENV === 'test'`. This eliminates unnecessary crypto dependency overhead and nondeterminism in production.
2.  **Removal of Hardcoded Literal:** The `'test-jwt-secret'` string literal has been removed from the codebase. In test mode, it now requires `TEST_JWT_SECRET` or defaults to a per-process random 32-byte hex string.
3.  **Safety Guards:** Added explicit checks in `createTestToken` (throws Error if secret is missing) and `verifyTestToken` (returns undefined if secret is missing) to ensure the service behaves predictably if these methods are invoked in non-test environments.

---
*PR created automatically by Jules for task [16190448674874293204](https://jules.google.com/task/16190448674874293204) started by @vandean25*