### PR TITLE
[codex] Harden voice note upload guardrails

### DIFF
--- a/apps/core-api/src/mechanic/audio-duration.ts
+++ b/apps/core-api/src/mechanic/audio-duration.ts
@@ -1,0 +1,187 @@
+const WEBM_SEGMENT_ID = 0x18538067;
+const WEBM_INFO_ID = 0x1549a966;
+const WEBM_TIMECODE_SCALE_ID = 0x2ad7b1;
+const WEBM_DURATION_ID = 0x4489;
+const DEFAULT_WEBM_TIMECODE_SCALE_NS = 1_000_000;
+const NANOSECONDS_PER_SECOND = 1_000_000_000;
+
+interface EbmlElement {
+  id: number;
+  dataOffset: number;
+  dataSize: number;
+  nextOffset: number;
+}
+
+interface Vint {
+  value: number;
+  length: number;
+  isUnknownSize: boolean;
+}
+
+function readVint(
+  buffer: Buffer,
+  offset: number,
+  stripLengthMarker: boolean,
+): Vint | null {
+  const firstByte = buffer[offset];
+  if (!firstByte) {
+    return null;
+  }
+
+  let mask = 0x80;
+  let length = 1;
+  while (length <= 8 && (firstByte & mask) === 0) {
+    mask >>= 1;
+    length += 1;
+  }
+
+  if (length > 8 || offset + length > buffer.length) {
+    return null;
+  }
+
+  let value = stripLengthMarker ? firstByte & (mask - 1) : firstByte;
+  let unknownSizeMarker = stripLengthMarker && value === mask - 1;
+  for (let index = 1; index < length; index += 1) {
+    unknownSizeMarker =
+      unknownSizeMarker && buffer[offset + index] === 0xff;
+    value = value * 256 + buffer[offset + index];
+  }
+
+  return { value, length, isUnknownSize: unknownSizeMarker };
+}
+
+function readElement(buffer: Buffer, offset: number): EbmlElement | null {
+  const id = readVint(buffer, offset, false);
+  if (!id) {
+    return null;
+  }
+
+  const size = readVint(buffer, offset + id.length, true);
+  if (!size) {
+    return null;
+  }
+
+  const dataOffset = offset + id.length + size.length;
+  const nextOffset = size.isUnknownSize ? buffer.length : dataOffset + size.value;
+  const dataSize = nextOffset - dataOffset;
+  if (nextOffset > buffer.length) {
+    return null;
+  }
+
+  return {
+    id: id.value,
+    dataOffset,
+    dataSize,
+    nextOffset,
+  };
+}
+
+function findElement(
+  buffer: Buffer,
+  startOffset: number,
+  endOffset: number,
+  expectedId: number,
+): EbmlElement | null {
+  let offset = startOffset;
+  while (offset < endOffset) {
+    const element = readElement(buffer, offset);
+    if (!element) {
+      return null;
+    }
+
+    if (element.id === expectedId) {
+      return element;
+    }
+
+    offset = element.nextOffset;
+  }
+
+  return null;
+}
+
+function readUnsignedInteger(
+  buffer: Buffer,
+  element: EbmlElement,
+): number | null {
+  if (element.dataSize < 1 || element.dataSize > 6) {
+    return null;
+  }
+
+  let value = 0;
+  for (
+    let offset = element.dataOffset;
+    offset < element.nextOffset;
+    offset += 1
+  ) {
+    value = value * 256 + buffer[offset];
+  }
+
+  return value;
+}
+
+function readFloat(buffer: Buffer, element: EbmlElement): number | null {
+  if (element.dataSize === 4) {
+    return buffer.readFloatBE(element.dataOffset);
+  }
+
+  if (element.dataSize === 8) {
+    return buffer.readDoubleBE(element.dataOffset);
+  }
+
+  return null;
+}
+
+function readWebmDurationSeconds(buffer: Buffer): number | undefined {
+  const segment = findElement(buffer, 0, buffer.length, WEBM_SEGMENT_ID);
+  if (!segment) {
+    return undefined;
+  }
+
+  const info = findElement(
+    buffer,
+    segment.dataOffset,
+    segment.nextOffset,
+    WEBM_INFO_ID,
+  );
+  if (!info) {
+    return undefined;
+  }
+
+  const duration = findElement(
+    buffer,
+    info.dataOffset,
+    info.nextOffset,
+    WEBM_DURATION_ID,
+  );
+  if (!duration) {
+    return undefined;
+  }
+
+  const timecodeScale = findElement(
+    buffer,
+    info.dataOffset,
+    info.nextOffset,
+    WEBM_TIMECODE_SCALE_ID,
+  );
+  const timecodeScaleNs = timecodeScale
+    ? readUnsignedInteger(buffer, timecodeScale)
+    : DEFAULT_WEBM_TIMECODE_SCALE_NS;
+  const durationTimecodes = readFloat(buffer, duration);
+
+  if (!timecodeScaleNs || !durationTimecodes || durationTimecodes < 0) {
+    return undefined;
+  }
+
+  return (durationTimecodes * timecodeScaleNs) / NANOSECONDS_PER_SECOND;
+}
+
+export function readAudioDurationSeconds(
+  buffer: Buffer,
+  mimeType: string,
+): number | undefined {
+  if (mimeType === 'audio/webm') {
+    return readWebmDurationSeconds(buffer);
+  }
+
+  return undefined;
+}

--- a/apps/core-api/src/mechanic/dto/voice-note.dto.ts
+++ b/apps/core-api/src/mechanic/dto/voice-note.dto.ts
@@ -17,8 +17,8 @@ export const MAX_VOICE_NOTE_BYTES = 25 * 1024 * 1024; // 25 MiB
 /**
  * Maximum permitted audio recording duration in seconds (5 minutes).
  * ADR-0014 §5.3 — validate before provider submission.
- * The check uses the duration reported by the provider in the verbose response;
- * an error is returned to the caller when the limit is exceeded.
+ * The backend rejects parseable over-limit recordings before provider submission
+ * and keeps the provider-reported duration check as a fallback.
  */
 export const MAX_VOICE_NOTE_DURATION_SECONDS = 300;
 

--- a/apps/core-api/src/mechanic/mechanic.service.spec.ts
+++ b/apps/core-api/src/mechanic/mechanic.service.spec.ts
@@ -1428,6 +1428,34 @@ describe('MechanicService', () => {
         ...overrides,
       }) as Express.Multer.File;
 
+    const createEbmlElement = (id: number[], data: Buffer): Buffer =>
+      Buffer.concat([Buffer.from(id), Buffer.from([0x80 | data.length]), data]);
+
+    const createUnknownSizeEbmlElement = (id: number[], data: Buffer): Buffer =>
+      Buffer.concat([
+        Buffer.from(id),
+        Buffer.from([0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        data,
+      ]);
+
+    const createWebmDurationFixture = (durationSeconds: number): Buffer => {
+      const duration = Buffer.alloc(8);
+      duration.writeDoubleBE(durationSeconds * 1000, 0);
+
+      const info = createEbmlElement(
+        [0x15, 0x49, 0xa9, 0x66],
+        Buffer.concat([
+          createEbmlElement([0x2a, 0xd7, 0xb1], Buffer.from([0x0f, 0x42, 0x40])),
+          createEbmlElement([0x44, 0x89], duration),
+        ]),
+      );
+
+      return Buffer.concat([
+        createUnknownSizeEbmlElement([0x18, 0x53, 0x80, 0x67], info),
+        Buffer.alloc(128),
+      ]);
+    };
+
     it('throws NotFoundException when task does not exist', async () => {
       (mockPrisma.workshopTask.findFirst as jest.Mock).mockResolvedValue(null);
 
@@ -1474,7 +1502,7 @@ describe('MechanicService', () => {
       ).rejects.toThrow(UnprocessableEntityException);
     });
 
-    it('throws UnprocessableEntityException when duration exceeds the limit', async () => {
+    it('throws UnprocessableEntityException before transcription when parseable duration exceeds the limit', async () => {
       (mockPrisma.workshopTask.findFirst as jest.Mock).mockResolvedValue(makeTask());
       (mockSpeechNoteService.transcribeNote as jest.Mock).mockResolvedValue({
         text: 'Long recording content',
@@ -1482,10 +1510,16 @@ describe('MechanicService', () => {
         model: 'whisper-1',
         durationSeconds: 301,
       });
+      const longRecording = createWebmDurationFixture(301);
 
       await expect(
-        service.uploadVoiceNote(MECHANIC_ID, TASK_ID, makeFile()),
+        service.uploadVoiceNote(
+          MECHANIC_ID,
+          TASK_ID,
+          makeFile({ buffer: longRecording, size: longRecording.length }),
+        ),
       ).rejects.toThrow(UnprocessableEntityException);
+      expect(mockSpeechNoteService.transcribeNote).not.toHaveBeenCalled();
     });
 
     it('throws UnprocessableEntityException when transcription text is empty (silent audio)', async () => {

--- a/apps/core-api/src/mechanic/mechanic.service.ts
+++ b/apps/core-api/src/mechanic/mechanic.service.ts
@@ -56,6 +56,7 @@ import {
   TASK_WAITING_CUSTOMER_EVENT,
   type TaskWaitingCustomerPayload,
 } from './mechanic-events.constants';
+import { readAudioDurationSeconds } from './audio-duration';
 
 /**
  * Rate-limit configuration for the voice-note upload endpoint.
@@ -80,6 +81,28 @@ function getVoiceNoteRateLimitConfig(): { max: number; ttlMs: number } {
 interface RateLimitEntry {
   count: number;
   windowStart: number;
+}
+
+const VOICE_NOTE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'audio/webm': 'webm',
+  'audio/mp4': 'm4a',
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+  'audio/ogg': 'ogg',
+};
+
+function getVoiceNoteFilename(file: Express.Multer.File, mimeType: string): string {
+  const originalName = file.originalname?.trim();
+  if (
+    originalName &&
+    originalName !== 'blob' &&
+    /\.[a-z0-9]+$/i.test(originalName)
+  ) {
+    return originalName;
+  }
+
+  const extension = VOICE_NOTE_EXTENSION_BY_MIME_TYPE[mimeType] ?? 'bin';
+  return `voice-note.${extension}`;
 }
 
 const QUEUE_ORDER_STATUSES: WorkshopOrderStatus[] = [
@@ -1400,14 +1423,26 @@ export class MechanicService {
       `voice_note_start tenantId=${tenantId} taskId=${taskId} bytes=${sizeBytes} mimeType=${normalizedMime}`,
     );
 
+    const parsedDurationSeconds = readAudioDurationSeconds(
+      file.buffer,
+      normalizedMime,
+    );
+    if (
+      parsedDurationSeconds !== undefined &&
+      parsedDurationSeconds > MAX_VOICE_NOTE_DURATION_SECONDS
+    ) {
+      file.buffer.fill(0);
+      throw new UnprocessableEntityException(
+        `Audio recording duration ${parsedDurationSeconds.toFixed(1)}s exceeds the maximum of ${MAX_VOICE_NOTE_DURATION_SECONDS}s.`,
+      );
+    }
+
     const startedAt = Date.now();
     let draft: VoiceNoteDraftResponseDto;
     try {
       draft = await this.speechNote.transcribeNote({
         audioBuffer: file.buffer,
-        filename:
-          file.originalname ||
-          `voice-note.${normalizedMime.split('/')[1] ?? 'bin'}`,
+        filename: getVoiceNoteFilename(file, normalizedMime),
         mimeType: normalizedMime,
       });
     } catch (error) {

--- a/apps/core-web/src/api/mechanic.test.tsx
+++ b/apps/core-web/src/api/mechanic.test.tsx
@@ -11,6 +11,7 @@ import {
   useCompleteTask,
   useSaveDiagnostics,
   useRequestPart,
+  useUploadVoiceNote,
   mechanicQueueKeys,
 } from './mechanic'
 import { fetchWithAuth } from './client'
@@ -483,6 +484,34 @@ describe('mechanic api hooks', () => {
       const item = data as Record<string, unknown>
       expect(item).not.toHaveProperty('unitPrice')
       expect(item).not.toHaveProperty('lineTotal')
+    })
+  })
+
+  describe('useUploadVoiceNote', () => {
+    it('uploads browser Blob recordings with a MIME-derived filename', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(
+        createJsonResponse({
+          text: 'Translated note',
+          provider: 'openai',
+          model: 'whisper-1',
+        }),
+      )
+
+      const queryClient = createQueryClient()
+      const { result } = renderHook(() => useUploadVoiceNote(), {
+        wrapper: createWrapper(queryClient),
+      })
+
+      await result.current.mutateAsync({
+        taskId: TASK_ID,
+        audio: new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' }),
+      })
+
+      const [, init] = vi.mocked(fetchWithAuth).mock.calls[0]
+      const body = init?.body as FormData
+      const uploadedAudio = body.get('audio') as File
+
+      expect(uploadedAudio.name).toBe('voice-note.webm')
     })
   })
 })

--- a/apps/core-web/src/api/mechanic.ts
+++ b/apps/core-web/src/api/mechanic.ts
@@ -18,6 +18,23 @@ export type CreateMediaPayload = components['schemas']['CreateMediaDto']
 export type WorkshopMedia = components['schemas']['WorkshopMediaDto']
 export type VoiceNoteDraftResponse = components['schemas']['VoiceNoteDraftResponseDto']
 
+const voiceNoteExtensionByMimeType: Record<string, string> = {
+  'audio/webm': 'webm',
+  'audio/mp4': 'm4a',
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+  'audio/ogg': 'ogg',
+}
+
+function getVoiceNoteFilename(audio: File | Blob): string {
+  if (typeof File !== 'undefined' && audio instanceof File && audio.name && audio.name !== 'blob') {
+    return audio.name
+  }
+
+  const extension = voiceNoteExtensionByMimeType[audio.type] ?? 'bin'
+  return `voice-note.${extension}`
+}
+
 export const mechanicQueueKeys = {
   all: ['mechanic'] as const,
   queue: () => [...mechanicQueueKeys.all, 'queue'] as const,
@@ -316,7 +333,7 @@ export function useUploadVoiceNote() {
         )
       }
       const form = new FormData()
-      form.append('audio', audio)
+      form.append('audio', audio, getVoiceNoteFilename(audio))
       const response = await fetchWithAuth(
         `/api/mechanic/tasks/${encodeURIComponent(taskId)}/voice-notes`,
         { method: 'POST', body: form },


### PR DESCRIPTION
## Summary
- send browser-recorded voice-note blobs with a MIME-derived filename instead of the default `blob`
- add backend filename fallback for extensionless/blob uploads before calling the speech provider
- reject parseable over-limit WebM recordings before provider submission, including unknown-size MediaRecorder segments

## Root Cause
Browser `FormData.append(name, blob)` uses `blob` as the filename unless a filename is provided, so the provider could receive extensionless audio. Duration validation also relied on the provider response, so over-limit recordings were still submitted upstream before the app rejected them.

## Validation
- `npm --prefix apps/core-web test -- src/api/mechanic.test.tsx`
- `npm --prefix apps/core-api test -- src/mechanic/mechanic.service.spec.ts --runInBand`
- `npm --prefix apps/core-api run build`
- `npm --prefix apps/core-web run build`
