### PR TITLE
Improve upload error visibility and Sentry correlation

### DIFF
--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -4,9 +4,8 @@ import {
   NestModule,
   forwardRef,
 } from '@nestjs/common';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
-import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TenantContextMiddleware } from './common/services/tenant-context.middleware';
@@ -64,10 +63,6 @@ import { SpeechNoteModule } from './speech-note/speech-note.module';
   controllers: [AppController],
   providers: [
     AppService,
-    {
-      provide: APP_FILTER,
-      useClass: SentryGlobalFilter,
-    },
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/apps/core-api/src/common/filters/global-exception.filter.ts
+++ b/apps/core-api/src/common/filters/global-exception.filter.ts
@@ -7,6 +7,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
 import type { Response } from 'express';
 import {
   ApplicationError,
@@ -31,6 +33,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     let status: number = HttpStatus.INTERNAL_SERVER_ERROR;
     let message: string | string[] = 'Internal server error';
     let error: string | undefined;
+    let eventId: string | undefined;
 
     // Handle standard NestJS HttpExceptions
     if (exception instanceof HttpException) {
@@ -109,10 +112,19 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       this.logger.error('Unknown error caught by filter', exception);
     }
 
+    if (status >= 500) {
+      try {
+        eventId = Sentry.captureException(exception) || randomUUID();
+      } catch {
+        eventId = randomUUID();
+      }
+    }
+
     response.status(status).json({
       statusCode: status,
       message,
       error: error || this.getHttpStatusName(status),
+      ...(eventId ? { eventId } : {}),
     });
   }
 

--- a/apps/core-api/src/common/filters/global-exception.filter.ts
+++ b/apps/core-api/src/common/filters/global-exception.filter.ts
@@ -8,7 +8,6 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/node';
-import { randomUUID } from 'crypto';
 import type { Response } from 'express';
 import {
   ApplicationError,
@@ -114,9 +113,12 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
     if (status >= 500) {
       try {
-        eventId = Sentry.captureException(exception) || randomUUID();
+        const captured = Sentry.captureException(exception);
+        if (captured) {
+          eventId = captured;
+        }
       } catch {
-        eventId = randomUUID();
+        // Sentry unavailable — omit eventId rather than returning a fake UUID
       }
     }
 

--- a/apps/core-api/src/mechanic/mechanic-media.storage.ts
+++ b/apps/core-api/src/mechanic/mechanic-media.storage.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { Storage } from '@google-cloud/storage';
 import {
@@ -154,8 +155,8 @@ export class MechanicMediaStorage {
   private getBucketName(): string {
     const bucket = process.env.WORKSHOP_MEDIA_BUCKET;
     if (!bucket) {
-      throw new InternalServerErrorException(
-        'WORKSHOP_MEDIA_BUCKET environment variable is not configured.',
+      throw new ServiceUnavailableException(
+        'Media upload is not configured. Missing server setting: WORKSHOP_MEDIA_BUCKET.',
       );
     }
     return bucket;

--- a/apps/core-api/src/mechanic/mechanic.service.ts
+++ b/apps/core-api/src/mechanic/mechanic.service.ts
@@ -1472,7 +1472,7 @@ export class MechanicService {
       }
       if (error instanceof SpeechNoteConfigError) {
         throw new ServiceUnavailableException(
-          'Voice-note transcription is not available. Contact your administrator.',
+          'Voice-note transcription is not configured. Missing server setting: OPENAI_API_KEY.',
         );
       }
       if (error instanceof SpeechNoteProviderError) {

--- a/apps/core-api/test/global-filter.e2e-spec.ts
+++ b/apps/core-api/test/global-filter.e2e-spec.ts
@@ -81,7 +81,7 @@ describe('GlobalExceptionFilter (e2e)', () => {
     });
   });
 
-  it('should mask 500 error messages when NODE_ENV=production', async () => {
+  it('should keep standard error response shape for validation errors', async () => {
     const response = await request(app.getHttpServer())
       .post('/api/customers')
         .set('Authorization', `Bearer ${authToken}`)

--- a/apps/core-api/test/mechanic-voice-note.e2e-spec.ts
+++ b/apps/core-api/test/mechanic-voice-note.e2e-spec.ts
@@ -517,7 +517,7 @@ describe('Mechanic Voice Note Upload (e2e)', () => {
       new SpeechNoteConfigError('OPENAI_API_KEY environment variable is required.'),
     );
 
-    await request(app.getHttpServer())
+    const res = await request(app.getHttpServer())
       .post(`/api/mechanic/tasks/${taskId}/voice-notes`)
       .set('Authorization', `Bearer ${authToken}`)
       .attach('audio', VALID_AUDIO_BUFFER, {
@@ -525,6 +525,10 @@ describe('Mechanic Voice Note Upload (e2e)', () => {
         contentType: 'audio/webm',
       })
       .expect(503);
+
+    expect(res.body.message).toBe(
+      'Voice-note transcription is not configured. Missing server setting: OPENAI_API_KEY.',
+    );
   });
 
   // ─── Missing audio field ──────────────────────────────────────────────────

--- a/apps/core-web/src/lib/error-utils.spec.ts
+++ b/apps/core-web/src/lib/error-utils.spec.ts
@@ -17,4 +17,41 @@ describe('getErrorMessage', () => {
 
     expect(message).toBe('Internal server error (Error ID: evt_12345)')
   })
+
+  it('joins array messages from Nest validation errors into a single string', () => {
+    const message = getErrorMessage(
+      {
+        response: {
+          data: {
+            message: ['name must not be empty', 'email must be an email'],
+          },
+        },
+      },
+      'fallback',
+    )
+
+    expect(message).toBe('name must not be empty, email must be an email')
+  })
+
+  it('joins array messages and appends event id', () => {
+    const message = getErrorMessage(
+      {
+        response: {
+          data: {
+            message: ['field A is required', 'field B is required'],
+            eventId: 'evt_abc',
+          },
+        },
+      },
+      'fallback',
+    )
+
+    expect(message).toBe('field A is required, field B is required (Error ID: evt_abc)')
+  })
+
+  it('returns fallback message when error is not object-like', () => {
+    expect(getErrorMessage(null, 'fallback')).toBe('fallback')
+    expect(getErrorMessage(undefined, 'fallback')).toBe('fallback')
+    expect(getErrorMessage('string error', 'fallback')).toBe('fallback')
+  })
 })

--- a/apps/core-web/src/lib/error-utils.spec.ts
+++ b/apps/core-web/src/lib/error-utils.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { getErrorMessage } from './error-utils'
+
+describe('getErrorMessage', () => {
+  it('appends event id when API response contains one', () => {
+    const message = getErrorMessage(
+      {
+        response: {
+          data: {
+            message: 'Internal server error',
+            eventId: 'evt_12345',
+          },
+        },
+      },
+      'fallback',
+    )
+
+    expect(message).toBe('Internal server error (Error ID: evt_12345)')
+  })
+})

--- a/apps/core-web/src/lib/error-utils.ts
+++ b/apps/core-web/src/lib/error-utils.ts
@@ -2,13 +2,16 @@ type ApiErrorLike = {
     message?: string
     name?: string
     status?: number
+    eventId?: string
     data?: {
         message?: string
+        eventId?: string
     }
     response?: {
         status?: number
         data?: {
             message?: string
+            eventId?: string
         }
     }
 }
@@ -23,12 +26,22 @@ export function getErrorMessage(error: unknown, fallbackMessage: string): string
     }
 
     const apiError = error as ApiErrorLike
-    return (
+    const baseMessage = (
         apiError.response?.data?.message ||
         apiError.data?.message ||
         apiError.message ||
         fallbackMessage
     )
+    const eventId =
+        apiError.response?.data?.eventId ||
+        apiError.data?.eventId ||
+        apiError.eventId
+
+    if (!eventId) {
+        return baseMessage
+    }
+
+    return `${baseMessage} (Error ID: ${eventId})`
 }
 
 export function getErrorStatus(error: unknown): number | null {

--- a/apps/core-web/src/lib/error-utils.ts
+++ b/apps/core-web/src/lib/error-utils.ts
@@ -1,16 +1,16 @@
 type ApiErrorLike = {
-    message?: string
+    message?: string | string[]
     name?: string
     status?: number
     eventId?: string
     data?: {
-        message?: string
+        message?: string | string[]
         eventId?: string
     }
     response?: {
         status?: number
         data?: {
-            message?: string
+            message?: string | string[]
             eventId?: string
         }
     }
@@ -26,12 +26,13 @@ export function getErrorMessage(error: unknown, fallbackMessage: string): string
     }
 
     const apiError = error as ApiErrorLike
-    const baseMessage = (
+    const rawMessage = (
         apiError.response?.data?.message ||
         apiError.data?.message ||
         apiError.message ||
         fallbackMessage
     )
+    const baseMessage = Array.isArray(rawMessage) ? rawMessage.join(', ') : rawMessage
     const eventId =
         apiError.response?.data?.eventId ||
         apiError.data?.eventId ||


### PR DESCRIPTION
## Summary\n- add Sentry event-id correlation on backend 5xx responses\n- return explicit 503 configuration message when workshop media bucket is missing\n- return explicit 503 configuration message when voice-note transcription is not configured\n- surface backend event ids in frontend error messages\n- add frontend unit test coverage for event-id formatting\n\n## Verification\n- npm --prefix apps/core-api run test:e2e -- test/global-filter.e2e-spec.ts test/mechanic-voice-note.e2e-spec.ts --runInBand\n- npm --prefix apps/core-api test -- src/mechanic/mechanic.service.spec.ts --runInBand\n- npm --prefix apps/core-web test -- src/lib/error-utils.spec.ts