### PR TITLE
AUT-108: handle login lazy chunk fetch failures with global fallback

### DIFF
--- a/apps/core-web/src/App.login-chunk-error.test.tsx
+++ b/apps/core-web/src/App.login-chunk-error.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+vi.mock('@/auth/AuthProvider', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    signOutUser: vi.fn(),
+  }),
+}))
+
+vi.mock('@/api/auth-session', () => ({
+  useAuthSession: () => ({
+    isLoading: false,
+    data: null,
+  }),
+  useSwitchTenant: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+}))
+
+vi.mock('@/pages/LoginPage', () => {
+  return {
+    default: () => {
+      throw new TypeError(
+        'Failed to fetch dynamically imported module: https://auto-core-platform-vande.web.app/assets/LoginPage-BDWcsH0-.js',
+      )
+    },
+  }
+})
+
+describe('App login lazy chunk handling', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the global error fallback when login lazy import fails', async () => {
+    render(<App />)
+
+    expect(await screen.findByText('Update Required')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload Application' })).toBeInTheDocument()
+  })
+})

--- a/apps/core-web/src/App.tsx
+++ b/apps/core-web/src/App.tsx
@@ -340,9 +340,11 @@ function App() {
 
   if (!user) {
     return (
-      <React.Suspense fallback={<PageLoader />}>
-        <LoginPage />
-      </React.Suspense>
+      <GlobalErrorBoundary>
+        <React.Suspense fallback={<PageLoader />}>
+          <LoginPage />
+        </React.Suspense>
+      </GlobalErrorBoundary>
     )
   }
 


### PR DESCRIPTION
## Summary
- wrap unauthenticated LoginPage lazy route with GlobalErrorBoundary
- add regression test for failed dynamic import of LoginPage chunk
- ensure chunk fetch errors show the Update Required recovery UI

## Testing
- npm test -- App.login-chunk-error.test.tsx
- npm test -- App.mechanic-shell.test.tsx

## Issue
- AUT-108