### PR TITLE
Add GET endpoints for Purchase Order Items

### DIFF
--- a/apps/core-api/openapi/openapi.json
+++ b/apps/core-api/openapi/openapi.json
@@ -704,6 +704,34 @@
       }
     },
     "/api/purchase-orders/{id}/items": {
+      "get": {
+        "operationId": "PurchaseController_getItems",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      },
       "post": {
         "operationId": "PurchaseController_addItems",
         "parameters": [
@@ -744,6 +772,42 @@
       }
     },
     "/api/purchase-orders/{id}/items/{itemId}": {
+      "get": {
+        "operationId": "PurchaseController_getItem",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "itemId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Purchase"
+        ]
+      },
       "patch": {
         "operationId": "PurchaseController_updateItem",
         "parameters": [

--- a/apps/core-api/src/purchase/purchase.controller.ts
+++ b/apps/core-api/src/purchase/purchase.controller.ts
@@ -188,6 +188,22 @@ export class PurchaseController {
     return this.purchaseService.remove(id);
   }
 
+  @Get(':id/items')
+  @ApiOkResponse({
+    schema: { type: 'object' },
+  })
+  async getItems(@Param('id') orderId: string) {
+    return this.purchaseService.getPurchaseOrderItems(orderId);
+  }
+
+  @Get(':id/items/:itemId')
+  @ApiOkResponse({
+    schema: { type: 'object' },
+  })
+  async getItem(@Param('id') orderId: string, @Param('itemId') itemId: string) {
+    return this.purchaseService.getPurchaseOrderItem(orderId, itemId);
+  }
+
   @Post(':id/items')
   @ApiCreatedResponse({
     schema: { type: 'object' },

--- a/apps/core-api/src/purchase/purchase.service.ts
+++ b/apps/core-api/src/purchase/purchase.service.ts
@@ -616,17 +616,65 @@ export class PurchaseService {
     return { data, total: data.length };
   }
 
+  async getPurchaseOrderItems(orderId: string) {
+    const tenantId = await this.tenantContext.getTenantId();
+    const po = await this.prisma.purchaseOrder.findFirst({
+      where: { id: orderId, tenant_id: tenantId },
+      select: { id: true },
+    });
+    if (!po) throw new NotFoundException('Purchase Order not found');
+
+    return this.prisma.purchaseOrderItem.findMany({
+      where: { purchase_order_id: orderId, tenant_id: tenantId },
+      include: {
+        catalog_item: {
+          include: { brand: true },
+        },
+      },
+    });
+  }
+
+  async getPurchaseOrderItem(orderId: string, itemId: string) {
+    const tenantId = await this.tenantContext.getTenantId();
+    const po = await this.prisma.purchaseOrder.findFirst({
+      where: { id: orderId, tenant_id: tenantId },
+      select: { id: true },
+    });
+    if (!po) throw new NotFoundException('Purchase Order not found');
+
+    const item = await this.prisma.purchaseOrderItem.findFirst({
+      where: { id: itemId, purchase_order_id: orderId, tenant_id: tenantId },
+      include: {
+        catalog_item: {
+          include: { brand: true },
+        },
+      },
+    });
+
+    if (!item) throw new NotFoundException('Purchase order item not found');
+
+    return item;
+  }
+
   async findOne(id: string) {
     const tenantId = await this.tenantContext.getTenantId();
-    return this.prisma.purchaseOrder.findFirst({
+    const po = await this.prisma.purchaseOrder.findFirst({
       where: { id, tenant_id: tenantId },
       include: {
         vendor: { include: { supportedBrands: true } },
         items: {
-          include: { catalog_item: true },
+          include: {
+            catalog_item: { include: { brand: true } },
+          },
         },
       },
     });
+
+    if (!po) {
+      throw new NotFoundException('Purchase Order not found');
+    }
+
+    return po;
   }
 
   async markAsSent(id: string) {

--- a/apps/core-api/verify_po_check.ts
+++ b/apps/core-api/verify_po_check.ts
@@ -3,67 +3,75 @@ import axios from 'axios';
 const API_URL = 'http://localhost:3000/api';
 
 async function run() {
-    try {
-        console.log('1. Creating Vendor...');
-        const vendorRes = await axios.post(`${API_URL}/vendors`, {
-            name: 'Test Vendor ' + Date.now(),
-            email: 'test@vendor.com',
-            accountNumber: 'TEST-123',
-            supportedBrands: ['VW', 'Audi', 'Castrol', 'Bosch', 'Mahle', 'Brembo', 'Shell', 'NGK', 'Valeo']
-        });
-        const vendor = vendorRes.data;
-        console.log('   Vendor created:', vendor.id);
+  try {
+    console.log('1. Creating Vendor...');
+    const vendorRes = await axios.post(`${API_URL}/vendors`, {
+      name: 'Test Vendor ' + Date.now(),
+      email: 'test@vendor.com',
+      accountNumber: 'TEST-123',
+      supportedBrands: [
+        'VW',
+        'Audi',
+        'Castrol',
+        'Bosch',
+        'Mahle',
+        'Brembo',
+        'Shell',
+        'NGK',
+        'Valeo',
+      ],
+    });
+    const vendor = vendorRes.data;
+    console.log('   Vendor created:', vendor.id);
 
-        console.log('2. Fetching Catalog Items...');
-        // We need an item ID. Let's fetch one.
-        // Assuming search endpoint works or list works.
-        // Actually existing inventory controller might not have list all without params?
-        // Let's try searching 'a' or just fetching via prisma if we could, but let's try API.
-        const inventoryRes = await axios.get(`${API_URL}/inventory?limit=1`);
-        const item = inventoryRes.data.data[0];
-        if (!item) {
-            console.error('No items in inventory to order!');
-            return;
-        }
-        console.log('   Found item:', item.sku);
-
-        console.log('3. Creating Purchase Order...');
-        const poRes = await axios.post(`${API_URL}/purchase-orders`, {
-            vendorId: vendor.id,
-            items: [
-                { catalogItemId: item.id, quantity: 10, unitCost: 100 }
-            ]
-        });
-        const po = poRes.data;
-        console.log('   PO created:', po.id, po.status);
-
-        console.log('4. Receiving Goods (Partial)...');
-        await axios.post(`${API_URL}/purchase-orders/${po.id}/receive`, {
-            items: [
-                { itemId: item.id, quantity: 5 }
-            ]
-        });
-        console.log('   Goods received.');
-
-        console.log('5. Verifying PO Status...');
-        // Currently relying on my memory of endpoints. I didn't explicitly create GET /purchase-orders/:id in controller?
-        // Wait, I checked PurchaseController in step 630.
-        // It has:
-        // @Post() createPurchaseOrder
-        // @Post(':id/receive') receiveItems
-        // IT DOES NOT HAVE @Get(':id') !!! 
-        // I missed adding the GET endpoints in the backend!
-
-        // I need to add GET endpoints to PurchaseController NOW.
-
-        console.log('   (Skipping GET check as endpoint might be missing, checking via Receive response if possible?)');
-        // Actually receiveItems returns updatedPO.
-        // But I really need to fix the backend first.
-    } catch (error: any) {
-        console.error('Error Status:', error.response?.status);
-        console.error('Error Data:', error.response?.data);
-        console.error('Error Message:', error.message);
+    console.log('2. Fetching Catalog Items...');
+    // We need an item ID. Let's fetch one.
+    // Assuming search endpoint works or list works.
+    // Actually existing inventory controller might not have list all without params?
+    // Let's try searching 'a' or just fetching via prisma if we could, but let's try API.
+    const inventoryRes = await axios.get(`${API_URL}/inventory?limit=1`);
+    const item = inventoryRes.data.data[0];
+    if (!item) {
+      console.error('No items in inventory to order!');
+      return;
     }
+    console.log('   Found item:', item.sku);
+
+    console.log('3. Creating Purchase Order...');
+    const poRes = await axios.post(`${API_URL}/purchase-orders`, {
+      vendorId: vendor.id,
+      items: [{ catalogItemId: item.id, quantity: 10, unitCost: 100 }],
+    });
+    const po = poRes.data;
+    console.log('   PO created:', po.id, po.status);
+
+    console.log('4. Receiving Goods (Partial)...');
+    await axios.post(`${API_URL}/purchase-orders/${po.id}/receive`, {
+      items: [{ itemId: item.id, quantity: 5 }],
+    });
+    console.log('   Goods received.');
+
+    console.log('5. Verifying PO Status...');
+    console.log('   Checking PO via GET endpoint...');
+    const getPoRes = await axios.get(`${API_URL}/purchase-orders/${po.id}`);
+    const fetchedPo = getPoRes.data;
+    console.log('   Fetched PO status:', fetchedPo.status);
+    if (fetchedPo.status !== 'PARTIAL') {
+      console.error('   Expected status PARTIAL, but got:', fetchedPo.status);
+    } else {
+      console.log('   Status verified successfully.');
+    }
+
+    console.log('6. Verifying PO Items via GET endpoint...');
+    const getItemsRes = await axios.get(
+      `${API_URL}/purchase-orders/${po.id}/items`,
+    );
+    console.log('   Fetched PO items count:', getItemsRes.data.length);
+  } catch (error: any) {
+    console.error('Error Status:', error.response?.status);
+    console.error('Error Data:', error.response?.data);
+    console.error('Error Message:', error.message);
+  }
 }
 
 run();

--- a/apps/core-web/src/api/generated/openapi.ts
+++ b/apps/core-web/src/api/generated/openapi.ts
@@ -267,7 +267,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: operations["PurchaseController_getItems"];
         put?: never;
         post: operations["PurchaseController_addItems"];
         delete?: never;
@@ -283,7 +283,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        get: operations["PurchaseController_getItem"];
         put?: never;
         post?: never;
         delete: operations["PurchaseController_deleteItem"];
@@ -2979,6 +2979,27 @@ export interface operations {
             };
         };
     };
+    PurchaseController_getItems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
     PurchaseController_addItems: {
         parameters: {
             query?: never;
@@ -2995,6 +3016,28 @@ export interface operations {
         };
         responses: {
             201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    PurchaseController_getItem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                itemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
- Added `GET /purchase-orders/:id/items` and `GET /purchase-orders/:id/items/:itemId` endpoints in `PurchaseController`.
- Updated `findOne` in `PurchaseService` to throw `NotFoundException` when a purchase order is not found, and included nested `brand` relations under `catalog_item` per the memory specifications.
- Implemented `getPurchaseOrderItems` and `getPurchaseOrderItem` methods in `PurchaseService` mapping to the controller.
- Updated `verify_po_check.ts` test script to perform a GET request verification for the purchase order and its items via `axios.get` instead of skipping it.

---
*PR created automatically by Jules for task [12000084838685767933](https://jules.google.com/task/12000084838685767933) started by @vandean25*