### PR TITLE
🔒 fix(core-api): prevent credentials leak on parse error

### DIFF
--- a/apps/core-api/src/common/services/cloud-tasks.service.ts
+++ b/apps/core-api/src/common/services/cloud-tasks.service.ts
@@ -49,12 +49,9 @@ export class CloudTasksService {
           'Cloud Tasks client initialized with GCP_CREDENTIALS from env',
         );
         return;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        const stack = error instanceof Error ? error.stack : undefined;
+      } catch {
         this.logger.error(
-          `Failed to parse GCP_CREDENTIALS for Cloud Tasks client; falling back to default credentials: ${message}`,
-          stack,
+          'Failed to parse GCP_CREDENTIALS for Cloud Tasks client; falling back to default credentials',
         );
       }
     }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an information exposure where failing to parse a malformed `GCP_CREDENTIALS` string could log the error message and stack trace.

⚠️ **Risk:** If the JSON parsing fails, the error message might include part of the sensitive credentials string (e.g. `Unexpected token '...' in JSON at position ...`), exposing it in the application logs and allowing attackers to steal the service account credentials.

🛡️ **Solution:** Updated the catch block to ignore the detailed error object and instead log a generic, safe error message without the stack trace.

---
*PR created automatically by Jules for task [11814321495745974569](https://jules.google.com/task/11814321495745974569) started by @vandean25*